### PR TITLE
Fix the chunk flickering bug.

### DIFF
--- a/assets/cubyz/shaders/easyLighting/chunk_vertex.vs
+++ b/assets/cubyz/shaders/easyLighting/chunk_vertex.vs
@@ -30,12 +30,18 @@ void main()
 	int x = (positionAndNormals) & 1023;
 	int y = (positionAndNormals >> 10) & 1023;
 	int z = (positionAndNormals >> 20) & 1023;
+
+	// Only draw faces that are inside the bounds:
 	vec3 globalPosition = vec3(x, y, z) + modelPosition;
+	globalPosition -= normals[normal]*0.5; // Prevent showing faces that are outside this chunkpiece.
 	if(globalPosition.x < lowerBounds.x || globalPosition.x > upperBounds.x
 			|| globalPosition.y < lowerBounds.y || globalPosition.y > upperBounds.y
 			|| globalPosition.z < lowerBounds.z || globalPosition.z > upperBounds.z) {
 		globalPosition = vec3(0.0/0.0);
+	} else {
+		globalPosition = vec3(x, y, z) + modelPosition;
 	}
+	
 	vec4 mvPos = viewMatrix*vec4(globalPosition, 1);
 	gl_Position = projectionMatrix*mvPos;
 	outColor = vec3(((color >> 8) & 15)/15.0, ((color >> 4) & 15)/15.0, ((color >> 0) & 15)/15.0)*ambientLight;

--- a/assets/cubyz/shaders/easyLighting/chunk_vertex.vs
+++ b/assets/cubyz/shaders/easyLighting/chunk_vertex.vs
@@ -12,6 +12,8 @@ uniform mat4 projectionMatrix;
 uniform vec3 ambientLight;
 uniform mat4 viewMatrix;
 uniform vec3 modelPosition;
+uniform vec3 lowerBounds;
+uniform vec3 upperBounds;
 
 const vec3[6] normals = vec3[6](
 	vec3(-1, 0, 0),
@@ -28,7 +30,13 @@ void main()
 	int x = (positionAndNormals) & 1023;
 	int y = (positionAndNormals >> 10) & 1023;
 	int z = (positionAndNormals >> 20) & 1023;
-	vec4 mvPos = viewMatrix*vec4(vec3(x, y, z) + modelPosition, 1);
+	vec3 globalPosition = vec3(x, y, z) + modelPosition;
+	if(globalPosition.x < lowerBounds.x || globalPosition.x > upperBounds.x
+			|| globalPosition.y < lowerBounds.y || globalPosition.y > upperBounds.y
+			|| globalPosition.z < lowerBounds.z || globalPosition.z > upperBounds.z) {
+		globalPosition = vec3(0.0/0.0);
+	}
+	vec4 mvPos = viewMatrix*vec4(globalPosition, 1);
 	gl_Position = projectionMatrix*mvPos;
 	outColor = vec3(((color >> 8) & 15)/15.0, ((color >> 4) & 15)/15.0, ((color >> 0) & 15)/15.0)*ambientLight;
 	outNormal = normals[normal];

--- a/src/cubyz/client/ChunkMesh.java
+++ b/src/cubyz/client/ChunkMesh.java
@@ -2,11 +2,13 @@ package cubyz.client;
 
 import cubyz.world.Chunk;
 
-public abstract class ChunkMesh {
+public abstract class ChunkMesh implements Comparable<ChunkMesh> {
 
 	public final int wx, wy, wz, size;
 
 	protected final ReducedChunkMesh replacement;
+
+	protected float priority = 0;
 
 	public ChunkMesh(ReducedChunkMesh replacement, int wx, int wy, int wz, int size) {
 		this.replacement = replacement;
@@ -16,9 +18,17 @@ public abstract class ChunkMesh {
 		this.size = size;
 	}
 
-	public abstract boolean needsUpdate();
+	public void updatePriority(float priority) {
+		this.priority = priority;
+	}
+
 	public abstract void cleanUp();
 	public abstract void regenerateMesh();
 	public abstract void render();
 	public abstract Chunk getChunk();
+
+	@Override
+	public int compareTo(ChunkMesh arg0) {
+		return (int)Math.signum(priority - arg0.priority);
+	}
 }

--- a/src/cubyz/client/ChunkMesh.java
+++ b/src/cubyz/client/ChunkMesh.java
@@ -10,6 +10,8 @@ public abstract class ChunkMesh implements Comparable<ChunkMesh> {
 
 	protected float priority = 0;
 
+	protected boolean generated = false;
+
 	public ChunkMesh(ReducedChunkMesh replacement, int wx, int wy, int wz, int size) {
 		this.replacement = replacement;
 		this.wx = wx;

--- a/src/cubyz/client/ChunkMesh.java
+++ b/src/cubyz/client/ChunkMesh.java
@@ -1,0 +1,24 @@
+package cubyz.client;
+
+import cubyz.world.Chunk;
+
+public abstract class ChunkMesh {
+
+	public final int wx, wy, wz, size;
+
+	protected final ReducedChunkMesh replacement;
+
+	public ChunkMesh(ReducedChunkMesh replacement, int wx, int wy, int wz, int size) {
+		this.replacement = replacement;
+		this.wx = wx;
+		this.wy = wy;
+		this.wz = wz;
+		this.size = size;
+	}
+
+	public abstract boolean needsUpdate();
+	public abstract void cleanUp();
+	public abstract void regenerateMesh();
+	public abstract void render();
+	public abstract Chunk getChunk();
+}

--- a/src/cubyz/client/ChunkMesh.java
+++ b/src/cubyz/client/ChunkMesh.java
@@ -2,6 +2,10 @@ package cubyz.client;
 
 import cubyz.world.Chunk;
 
+/**
+ * A chunk mesh contains all rendering data of a single chunk.
+ */
+
 public abstract class ChunkMesh implements Comparable<ChunkMesh> {
 
 	public final int wx, wy, wz, size;
@@ -24,9 +28,23 @@ public abstract class ChunkMesh implements Comparable<ChunkMesh> {
 		this.priority = priority;
 	}
 
+	/**
+	 * Removes all data from the GPU.
+	 * MUST BE CALLED BEFORE GETTING RID OF THE OBJECT!
+	 */
 	public abstract void cleanUp();
+	
+	/**
+	 * Updates the Mesh based on changes of the chunk.
+	 */
 	public abstract void regenerateMesh();
+
 	public abstract void render();
+
+	/**
+	 * Returns the chunk associated with the mesh.
+	 * @return chunk. Can be null!
+	 */
 	public abstract Chunk getChunk();
 
 	@Override

--- a/src/cubyz/client/ClientOnly.java
+++ b/src/cubyz/client/ClientOnly.java
@@ -3,7 +3,6 @@ package cubyz.client;
 import java.util.function.Consumer;
 
 import cubyz.api.ClientConnection;
-import cubyz.world.Chunk;
 import cubyz.world.blocks.Block;
 import cubyz.world.entity.EntityType;
 
@@ -16,7 +15,6 @@ public class ClientOnly {
 	public static Consumer<Block[]> generateTextureAtlas;
 	public static Consumer<Block> createBlockMesh;
 	public static Consumer<EntityType> createEntityMesh;
-	public static Consumer<Chunk> deleteChunkMesh;
 	
 	// I didn't know where else to put it.
 	public static ClientConnection client;

--- a/src/cubyz/client/Meshes.java
+++ b/src/cubyz/client/Meshes.java
@@ -38,7 +38,7 @@ public class Meshes {
 	
 	public static final Registry<Model> models = new Registry<>();
 	
-	public static final ArrayList<Object> removableMeshes = new ArrayList<>();
+	public static final ArrayList<ChunkMesh> removableMeshes = new ArrayList<>();
 	
 	/**
 	 * Cleans all meshes scheduled for removal.
@@ -46,16 +46,17 @@ public class Meshes {
 	 */
 	public static void cleanUp() {
 		synchronized(removableMeshes) {
-			for(Object mesh : removableMeshes) {
-				if(mesh instanceof ReducedChunkMesh) {
-					((ReducedChunkMesh) mesh).cleanUp();
-				} else if(mesh instanceof NormalChunkMesh) {
-					((NormalChunkMesh) mesh).cleanUp();
-				} else if(mesh instanceof Mesh) {
-					((Mesh) mesh).cleanUp();
-				}
+			for(ChunkMesh mesh : removableMeshes) {
+				mesh.cleanUp();
 			}
 			removableMeshes.clear();
+		}
+	}
+
+	public static void deleteMesh(ChunkMesh mesh) {
+		if(mesh == null) return;
+		synchronized(removableMeshes) {
+			removableMeshes.add(mesh);
 		}
 	}
 	
@@ -143,12 +144,6 @@ public class Meshes {
 			mesh.setMaterial(material);
 			
 			Meshes.entityMeshes.put(type, mesh);
-		};
-		
-		ClientOnly.deleteChunkMesh = (chunk) -> {
-			synchronized(removableMeshes) {
-				removableMeshes.add(chunk.getChunkMesh());
-			}
 		};
 	}
 }

--- a/src/cubyz/client/Meshes.java
+++ b/src/cubyz/client/Meshes.java
@@ -39,8 +39,10 @@ public class Meshes {
 	
 	public static final Registry<Model> models = new Registry<>();
 	
+	/** List of meshes that need to be cleaned. */
 	public static final ArrayList<ChunkMesh> removableMeshes = new ArrayList<>();
 
+	/** List of meshes that need to be (re-)generated. */
 	private static final BinaryMaxHeap<ChunkMesh> updateQueue = new BinaryMaxHeap<ChunkMesh>(new ChunkMesh[16]);
 	
 	/**
@@ -56,6 +58,10 @@ public class Meshes {
 		}
 	}
 
+	/**
+	 * Schedules a mesh to be cleaned in the near future.
+	 * @param mesh
+	 */
 	public static void deleteMesh(ChunkMesh mesh) {
 		if(mesh == null) return;
 		synchronized(removableMeshes) {
@@ -63,6 +69,10 @@ public class Meshes {
 		}
 	}
 
+	/**
+	 * Schedules a mesh to be regenerated in the near future.
+	 * @param mesh
+	 */
 	public static void queueMesh(ChunkMesh mesh) {
 		// Calculate the priority, which is determined by distance and resolution/size.
 		float dx = Cubyz.player.getPosition().x - mesh.wx;

--- a/src/cubyz/client/NormalChunkMesh.java
+++ b/src/cubyz/client/NormalChunkMesh.java
@@ -178,6 +178,8 @@ public class NormalChunkMesh extends ChunkMesh implements Runnable {
 		if(faces.size == 0) {
 			return -1;
 		}
+		generated = true;
+		
 		FloatBuffer posBuffer = null;
 		FloatBuffer textureBuffer = null;
 		FloatBuffer normalBuffer = null;
@@ -287,7 +289,7 @@ public class NormalChunkMesh extends ChunkMesh implements Runnable {
 
 	@Override
 	public void render() {
-		if(chunk == null || needsUpdate) {
+		if(chunk == null || !generated) {
 			ReducedChunkMesh.shader.bind();
 			glUniform3f(ReducedChunkMesh.loc_lowerBounds, wx, wy, wz);
 			glUniform3f(ReducedChunkMesh.loc_upperBounds, wx+size, wy+size, wz+size);

--- a/src/cubyz/client/NormalChunkMesh.java
+++ b/src/cubyz/client/NormalChunkMesh.java
@@ -287,9 +287,15 @@ public class NormalChunkMesh extends ChunkMesh implements Runnable {
 
 	@Override
 	public void render() {
-		if(needsUpdate || chunk == null) {
+		if(chunk == null || needsUpdate) {
 			ReducedChunkMesh.shader.bind();
-			replacement.render();
+			glUniform3f(ReducedChunkMesh.loc_lowerBounds, wx, wy, wz);
+			glUniform3f(ReducedChunkMesh.loc_upperBounds, wx+size, wy+size, wz+size);
+			if(replacement != null) {
+				replacement.renderReplacement();
+			}
+			glUniform3f(ReducedChunkMesh.loc_lowerBounds, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY);
+			glUniform3f(ReducedChunkMesh.loc_upperBounds, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY);
 			shader.bind();
 			return;
 		}

--- a/src/cubyz/client/NormalChunkMesh.java
+++ b/src/cubyz/client/NormalChunkMesh.java
@@ -87,6 +87,11 @@ public class NormalChunkMesh extends ChunkMesh implements Runnable {
 				NormalChunkMesh.class);
 	}
 
+	/**
+	 * Also updates the uniforms.
+	 * @param ambient
+	 * @param directional
+	 */
 	public static void bindShader(Vector3f ambient, Vector3f directional) {
 		shader.bind();
 
@@ -179,7 +184,7 @@ public class NormalChunkMesh extends ChunkMesh implements Runnable {
 			return -1;
 		}
 		generated = true;
-		
+
 		FloatBuffer posBuffer = null;
 		FloatBuffer textureBuffer = null;
 		FloatBuffer normalBuffer = null;
@@ -189,6 +194,12 @@ public class NormalChunkMesh extends ChunkMesh implements Runnable {
 		try {
 			int vaoId = glGenVertexArrays();
 			glBindVertexArray(vaoId);
+			// Enable vertex arrays once.
+			glEnableVertexAttribArray(0);
+			glEnableVertexAttribArray(1);
+			glEnableVertexAttribArray(2);
+			glEnableVertexAttribArray(3);
+			glEnableVertexAttribArray(4);
 
 			// Position VBO
 			int vboId = glGenBuffers();
@@ -294,7 +305,7 @@ public class NormalChunkMesh extends ChunkMesh implements Runnable {
 			glUniform3f(ReducedChunkMesh.loc_lowerBounds, wx, wy, wz);
 			glUniform3f(ReducedChunkMesh.loc_upperBounds, wx+size, wy+size, wz+size);
 			if(replacement != null) {
-				replacement.renderReplacement();
+				replacement.render();
 			}
 			glUniform3f(ReducedChunkMesh.loc_lowerBounds, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY);
 			glUniform3f(ReducedChunkMesh.loc_upperBounds, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY);
@@ -303,43 +314,18 @@ public class NormalChunkMesh extends ChunkMesh implements Runnable {
 		}
 		if(vaoId == -1) return;
 		glUniform3f(loc_modelPosition, wx, wy, wz);
-		// Init
+
 		glBindVertexArray(vaoId);
-		glEnableVertexAttribArray(0);
-		glEnableVertexAttribArray(1);
-		glEnableVertexAttribArray(2);
-		glEnableVertexAttribArray(3);
-		glEnableVertexAttribArray(4);
-		// Draw
 		glDrawElements(GL_TRIANGLES, vertexCount, GL_UNSIGNED_INT, 0);
-		// Restore state
-		glDisableVertexAttribArray(0);
-		glDisableVertexAttribArray(1);
-		glDisableVertexAttribArray(2);
-		glDisableVertexAttribArray(3);
-		glDisableVertexAttribArray(4);
-		glBindVertexArray(0);
 	}
 
 	public void renderTransparent() {
 		if(transparentVaoId == -1) return;
+
 		glUniform3f(loc_modelPosition, wx, wy, wz);
-		// Init
+
 		glBindVertexArray(transparentVaoId);
-		glEnableVertexAttribArray(0);
-		glEnableVertexAttribArray(1);
-		glEnableVertexAttribArray(2);
-		glEnableVertexAttribArray(3);
-		glEnableVertexAttribArray(4);
-		// Draw
 		glDrawElements(GL_TRIANGLES, transparentVertexCount, GL_UNSIGNED_INT, 0);
-		// Restore state
-		glDisableVertexAttribArray(0);
-		glDisableVertexAttribArray(1);
-		glDisableVertexAttribArray(2);
-		glDisableVertexAttribArray(3);
-		glDisableVertexAttribArray(4);
-		glBindVertexArray(0);
 	}
 
 	@Override

--- a/src/cubyz/client/ReducedChunkMesh.java
+++ b/src/cubyz/client/ReducedChunkMesh.java
@@ -114,6 +114,8 @@ public class ReducedChunkMesh extends ChunkMesh implements Runnable {
 			if(chunk == null)
 				return;
 		}
+		generated = true;
+		
 		IntFastList vertices = localVertices.get();
 		IntFastList faces = localFaces.get();
 		IntFastList colorsAndNormals = localColorsAndNormals.get();
@@ -216,7 +218,7 @@ public class ReducedChunkMesh extends ChunkMesh implements Runnable {
 
 	@Override
 	public void render() {
-		if(chunk == null || !chunk.generated || needsUpdate) {
+		if(chunk == null || !generated) {
 			glUniform3f(loc_lowerBounds, wx, wy, wz);
 			glUniform3f(loc_upperBounds, wx+size, wy+size, wz+size);
 			if(replacement != null) {

--- a/src/cubyz/client/ReducedChunkMesh.java
+++ b/src/cubyz/client/ReducedChunkMesh.java
@@ -64,6 +64,11 @@ public class ReducedChunkMesh extends ChunkMesh implements Runnable {
 				ReducedChunkMesh.class);
 	}
 
+	/**
+	 * Also updates the uniforms.
+	 * @param ambient
+	 * @param directional
+	 */
 	public static void bindShader(Vector3f ambient, Vector3f directional) {
 		shader.bind();
 
@@ -115,7 +120,7 @@ public class ReducedChunkMesh extends ChunkMesh implements Runnable {
 				return;
 		}
 		generated = true;
-		
+
 		IntFastList vertices = localVertices.get();
 		IntFastList faces = localFaces.get();
 		IntFastList colorsAndNormals = localColorsAndNormals.get();
@@ -135,6 +140,9 @@ public class ReducedChunkMesh extends ChunkMesh implements Runnable {
 
 			vaoId = glGenVertexArrays();
 			glBindVertexArray(vaoId);
+			// Enable vertex arrays once.
+			glEnableVertexAttribArray(0);
+			glEnableVertexAttribArray(1);
 
 			// Position and normal VBO
 			int vboId = glGenBuffers();
@@ -195,34 +203,13 @@ public class ReducedChunkMesh extends ChunkMesh implements Runnable {
 		return chunk;
 	}
 
-	public void renderReplacement() {
-		if(chunk == null || !chunk.generated || needsUpdate) {
-			if(replacement != null) {
-				replacement.renderReplacement();
-			}
-			return;
-		}
-		if(vaoId == -1) return;
-		glUniform3f(loc_modelPosition, wx, wy, wz);
-		// Init
-		glBindVertexArray(vaoId);
-		glEnableVertexAttribArray(0);
-		glEnableVertexAttribArray(1);
-		// Draw
-		glDrawElements(GL_TRIANGLES, vertexCount, GL_UNSIGNED_INT, 0);
-		// Restore state
-		glDisableVertexAttribArray(0);
-		glDisableVertexAttribArray(1);
-		glBindVertexArray(0);
-	}
-
 	@Override
 	public void render() {
 		if(chunk == null || !generated) {
 			glUniform3f(loc_lowerBounds, wx, wy, wz);
 			glUniform3f(loc_upperBounds, wx+size, wy+size, wz+size);
 			if(replacement != null) {
-				replacement.renderReplacement();
+				replacement.render();
 			}
 			glUniform3f(loc_lowerBounds, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY);
 			glUniform3f(loc_upperBounds, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY);
@@ -230,16 +217,9 @@ public class ReducedChunkMesh extends ChunkMesh implements Runnable {
 		}
 		if(vaoId == -1) return;
 		glUniform3f(loc_modelPosition, wx, wy, wz);
-		// Init
+		
 		glBindVertexArray(vaoId);
-		glEnableVertexAttribArray(0);
-		glEnableVertexAttribArray(1);
-		// Draw
 		glDrawElements(GL_TRIANGLES, vertexCount, GL_UNSIGNED_INT, 0);
-		// Restore state
-		glDisableVertexAttribArray(0);
-		glDisableVertexAttribArray(1);
-		glBindVertexArray(0);
 	}
 
 	@Override

--- a/src/cubyz/rendering/BlockPreview.java
+++ b/src/cubyz/rendering/BlockPreview.java
@@ -41,7 +41,6 @@ public abstract class BlockPreview {
 	}
 
 	public static void unloadShader() throws Exception {
-		shader.unbind();
 		shader.cleanup();
 		shader = null;
 		System.gc();

--- a/src/cubyz/rendering/MainRenderer.java
+++ b/src/cubyz/rendering/MainRenderer.java
@@ -25,7 +25,6 @@ import cubyz.gui.input.Mouse;
 import cubyz.utils.Utils;
 import cubyz.utils.datastructures.FastList;
 import cubyz.world.NormalChunk;
-import cubyz.world.ReducedChunk;
 import cubyz.world.blocks.Block;
 import cubyz.world.blocks.BlockInstance;
 import cubyz.world.entity.ChunkEntityManager;
@@ -318,6 +317,13 @@ public class MainRenderer {
 			float x0 = playerPosition.x;
 			float y0 = playerPosition.y;
 			float z0 = playerPosition.z;
+			// Update meshes:
+			while(System.currentTimeMillis() - startTime <= maximumMeshTime) {
+				ChunkMesh mesh = Meshes.getNextQueuedMesh();
+				if(mesh == null) break;
+				mesh.regenerateMesh();
+			}
+
 			FastList<NormalChunkMesh> visibleChunks = new FastList<NormalChunkMesh>(NormalChunkMesh.class);
 			FastList<ReducedChunkMesh> visibleReduced = new FastList<ReducedChunkMesh>(ReducedChunkMesh.class);
 			for (ChunkMesh mesh : Cubyz.chunkTree.getRenderChunks(frustumInt, x0, z0)) {
@@ -328,14 +334,6 @@ public class MainRenderer {
 						NormalChunkMesh.shader.setUniform(NormalChunkMesh.loc_selectedIndex, selected.renderIndex);
 					} else {
 						NormalChunkMesh.shader.setUniform(NormalChunkMesh.loc_selectedIndex, -1);
-					}
-					
-					if(mesh.needsUpdate()) {
-						if(System.currentTimeMillis() - startTime > maximumMeshTime) {
-							// Stop meshing if the frame is taking to long.
-						} else {
-							mesh.regenerateMesh();
-						}
 					}
 					mesh.render();
 				} else if(mesh instanceof ReducedChunkMesh) {
@@ -348,15 +346,6 @@ public class MainRenderer {
 			
 			for(int i = 0; i < visibleReduced.size; i++) {
 				ReducedChunkMesh mesh = visibleReduced.array[i];
-				if(mesh.needsUpdate()) {
-					if(((ReducedChunk)mesh.getChunk()).generated) {
-						if(System.currentTimeMillis() - startTime > maximumMeshTime) {
-							// Stop meshing if the frame is taking to long.
-						} else {
-							mesh.regenerateMesh();
-						}
-					}
-				}
 				mesh.render();
 			}
 			

--- a/src/cubyz/rendering/MainRenderer.java
+++ b/src/cubyz/rendering/MainRenderer.java
@@ -292,6 +292,7 @@ public class MainRenderer {
 			playerPosition = localPlayer.getPosition(); // Use a constant copy of the player position for the whole rendering to prevent graphics bugs on player movement.
 		}
 		if(playerPosition != null) {
+			ReducedChunkMesh.bindShader(ambientLight, directionalLight.getDirection()); // Update the uniforms. The uniforms are needed to render the replacement meshes.
 			
 			NormalChunkMesh.bindShader(ambientLight, directionalLight.getDirection());
 			

--- a/src/cubyz/rendering/MainRenderer.java
+++ b/src/cubyz/rendering/MainRenderer.java
@@ -13,6 +13,7 @@ import org.joml.Vector4f;
 
 import cubyz.Logger;
 import cubyz.api.CubyzRegistries;
+import cubyz.client.ChunkMesh;
 import cubyz.client.ClientSettings;
 import cubyz.client.Cubyz;
 import cubyz.client.GameLauncher;
@@ -23,7 +24,6 @@ import cubyz.gui.input.Keyboard;
 import cubyz.gui.input.Mouse;
 import cubyz.utils.Utils;
 import cubyz.utils.datastructures.FastList;
-import cubyz.world.Chunk;
 import cubyz.world.NormalChunk;
 import cubyz.world.ReducedChunk;
 import cubyz.world.blocks.Block;
@@ -42,31 +42,6 @@ import cubyz.world.items.ItemBlock;
  */
 
 public class MainRenderer {
-	
-	public static final class ChunkUniforms {
-		public static int loc_projectionMatrix;
-		public static int loc_viewMatrix;
-		public static int loc_modelPosition;
-		public static int loc_ambientLight;
-		public static int loc_directionalLight;
-		public static int loc_fog_activ;
-		public static int loc_fog_color;
-		public static int loc_fog_density;
-	}
-	public static final class BlockUniforms {
-		public static int loc_projectionMatrix;
-		public static int loc_viewMatrix;
-		public static int loc_texture_sampler;
-		public static int loc_break_sampler;
-		public static int loc_ambientLight;
-		public static int loc_directionalLight;
-		public static int loc_modelPosition;
-		public static int loc_selectedIndex;
-		public static int loc_atlasSize;
-		public static int loc_fog_activ;
-		public static int loc_fog_color;
-		public static int loc_fog_density;
-	}
 	public static class EntityUniforms {
 		public static int loc_projectionMatrix;
 		public static int loc_viewMatrix;
@@ -79,11 +54,8 @@ public class MainRenderer {
 	}
 	
 	/**The number of milliseconds after which no more chunk meshes are created. This allows the game to run smoother on movement.*/
-	private static int maximumMeshTime = 12;
+	private static int maximumMeshTime = 1;
 
-	/**A simple shader for low resolution chunks*/
-	private ShaderProgram chunkShader;
-	private ShaderProgram blockShader;
 	private ShaderProgram entityShader; // Entities are sometimes small and sometimes big. Therefor it would mean a lot of work to still use smooth lighting. Therefor the non-smooth shader is used for those.
 
 	private static final float Z_NEAR = 0.01f;
@@ -123,10 +95,6 @@ public class MainRenderer {
 	}
 
 	public void unloadShaders() throws Exception {
-		blockShader.unbind();
-		blockShader.cleanup();
-		blockShader = null;
-		entityShader.unbind();
 		entityShader.cleanup();
 		entityShader = null;
 		System.gc();
@@ -137,14 +105,6 @@ public class MainRenderer {
 	}
 
 	public void loadShaders() throws Exception {
-		chunkShader = new ShaderProgram(Utils.loadResource(shaders + "/chunk_vertex.vs"),
-				Utils.loadResource(shaders + "/chunk_fragment.fs"),
-				ChunkUniforms.class);
-
-		blockShader = new ShaderProgram(Utils.loadResource(shaders + "/block_vertex.vs"),
-				Utils.loadResource(shaders + "/block_fragment.fs"),
-				BlockUniforms.class);
-
 		entityShader = new ShaderProgram(Utils.loadResource(shaders + "/entity_vertex.vs"),
 				Utils.loadResource(shaders + "/entity_fragment.fs"),
 				EntityUniforms.class);
@@ -157,6 +117,8 @@ public class MainRenderer {
 		Window.setProjectionMatrix(transformation.getProjectionMatrix((float) Math.toRadians(70.0f), Window.getWidth(),
 				Window.getHeight(), Z_NEAR, Z_FAR));
 		loadShaders();
+		ReducedChunkMesh.init(shaders);
+		NormalChunkMesh.init(shaders);
 
 		inited = true;
 	}
@@ -172,12 +134,12 @@ public class MainRenderer {
 	 * @param playerZ
 	 * @return sorted chunk array
 	 */
-	public NormalChunk[] sortChunks(NormalChunk[] toSort, float playerX, float playerY, float playerZ) {
-		NormalChunk[] output = new NormalChunk[toSort.length];
+	public NormalChunkMesh[] sortChunks(NormalChunkMesh[] toSort, float playerX, float playerY, float playerZ) {
+		NormalChunkMesh[] output = new NormalChunkMesh[toSort.length];
 		float[] distances = new float[toSort.length];
 		System.arraycopy(toSort, 0, output, 0, toSort.length);
 		for(int i = 0; i < output.length; i++) {
-			distances[i] = (playerX - output[i].getX())*(playerX - output[i].getX()) + (playerY - output[i].getY())*(playerY - output[i].getY()) + (playerZ - output[i].getZ())*(playerZ - output[i].getZ());
+			distances[i] = (playerX - output[i].wx)*(playerX - output[i].wx) + (playerY - output[i].wy)*(playerY - output[i].wy) + (playerZ - output[i].wz)*(playerZ - output[i].wz);
 		}
 		// Insert sort them:
 		for(int i = 1; i < output.length; i++) {
@@ -187,7 +149,7 @@ public class MainRenderer {
 					distances[j] += distances[j+1];
 					distances[j+1] = distances[j] - distances[j+1];
 					distances[j] -= distances[j+1];
-					NormalChunk local = output[j+1];
+					NormalChunkMesh local = output[j+1];
 					output[j+1] = output[j];
 					output[j] = local;
 				} else {
@@ -332,20 +294,7 @@ public class MainRenderer {
 		}
 		if(playerPosition != null) {
 			
-			blockShader.bind();
-
-			blockShader.setUniform(BlockUniforms.loc_fog_activ, Cubyz.fog.isActive());
-			blockShader.setUniform(BlockUniforms.loc_fog_color, Cubyz.fog.getColor());
-			blockShader.setUniform(BlockUniforms.loc_fog_density, Cubyz.fog.getDensity());
-			blockShader.setUniform(BlockUniforms.loc_projectionMatrix, Window.getProjectionMatrix());
-			blockShader.setUniform(BlockUniforms.loc_texture_sampler, 0);
-			blockShader.setUniform(BlockUniforms.loc_break_sampler, 2);
-			blockShader.setUniform(BlockUniforms.loc_viewMatrix, Cubyz.camera.getViewMatrix());
-
-			blockShader.setUniform(BlockUniforms.loc_ambientLight, ambientLight);
-			blockShader.setUniform(BlockUniforms.loc_directionalLight, directionalLight.getDirection());
-			
-			blockShader.setUniform(BlockUniforms.loc_atlasSize, Meshes.atlasSize);
+			NormalChunkMesh.bindShader(ambientLight, directionalLight.getDirection());
 			
 			// Activate first texture bank
 			glActiveTexture(GL_TEXTURE0);
@@ -369,71 +318,47 @@ public class MainRenderer {
 			float x0 = playerPosition.x;
 			float y0 = playerPosition.y;
 			float z0 = playerPosition.z;
-			FastList<NormalChunk> visibleChunks = new FastList<NormalChunk>(NormalChunk.class);
-			FastList<ReducedChunk> visibleReduced = new FastList<ReducedChunk>(ReducedChunk.class);
-			for (Chunk ch : Cubyz.chunkTree.getRenderChunks(frustumInt, x0, z0)) {
-				if(ch instanceof NormalChunk) {
-					NormalChunk chunk = (NormalChunk)ch;
-					if(!chunk.isLoaded()) continue;
-					visibleChunks.add(chunk);
-					blockShader.setUniform(BlockUniforms.loc_modelPosition, chunk.getMin());
+			FastList<NormalChunkMesh> visibleChunks = new FastList<NormalChunkMesh>(NormalChunkMesh.class);
+			FastList<ReducedChunkMesh> visibleReduced = new FastList<ReducedChunkMesh>(ReducedChunkMesh.class);
+			for (ChunkMesh mesh : Cubyz.chunkTree.getRenderChunks(frustumInt, x0, z0)) {
+				if(mesh instanceof NormalChunkMesh) {
+					visibleChunks.add((NormalChunkMesh)mesh);
 					
-					if(selected != null && selected.source == ch) {
-						blockShader.setUniform(BlockUniforms.loc_selectedIndex, selected.renderIndex);
+					if(selected != null && selected.source == mesh.getChunk()) {
+						NormalChunkMesh.shader.setUniform(NormalChunkMesh.loc_selectedIndex, selected.renderIndex);
 					} else {
-						blockShader.setUniform(BlockUniforms.loc_selectedIndex, -1);
+						NormalChunkMesh.shader.setUniform(NormalChunkMesh.loc_selectedIndex, -1);
 					}
 					
-					Object mesh = chunk.getChunkMesh();
-					if(chunk.wasUpdated() || mesh == null || !(mesh instanceof NormalChunkMesh)) {
+					if(mesh.needsUpdate()) {
 						if(System.currentTimeMillis() - startTime > maximumMeshTime) {
 							// Stop meshing if the frame is taking to long.
-							if(!(mesh instanceof NormalChunkMesh)) continue;
 						} else {
-							mesh = new NormalChunkMesh(chunk);
-							chunk.setChunkMesh(mesh);
+							mesh.regenerateMesh();
 						}
 					}
-					((NormalChunkMesh)mesh).render();
-				} else if(ch instanceof ReducedChunk) {
-					visibleReduced.add((ReducedChunk)ch);
+					mesh.render();
+				} else if(mesh instanceof ReducedChunkMesh) {
+					visibleReduced.add((ReducedChunkMesh)mesh);
 				}
 			}
-			blockShader.unbind();
 			
 			// Render the far away ReducedChunks:
-			chunkShader.bind();
-
-			chunkShader.setUniform(ChunkUniforms.loc_fog_activ, Cubyz.fog.isActive());
-			chunkShader.setUniform(ChunkUniforms.loc_fog_color, Cubyz.fog.getColor());
-			chunkShader.setUniform(ChunkUniforms.loc_fog_density, Cubyz.fog.getDensity());
-			chunkShader.setUniform(ChunkUniforms.loc_projectionMatrix, Window.getProjectionMatrix());
-			
-			chunkShader.setUniform(ChunkUniforms.loc_viewMatrix, Cubyz.camera.getViewMatrix());
-
-			chunkShader.setUniform(ChunkUniforms.loc_ambientLight, ambientLight);
-			chunkShader.setUniform(ChunkUniforms.loc_directionalLight, directionalLight.getDirection());
+			ReducedChunkMesh.bindShader(ambientLight, directionalLight.getDirection());
 			
 			for(int i = 0; i < visibleReduced.size; i++) {
-				ReducedChunk chunk = visibleReduced.array[i];
-				if(chunk != null && chunk.generated) {
-					if (!frustumInt.testAab(chunk.getMin(), chunk.getMax()))
-						continue;
-					Object mesh = chunk.getChunkMesh();
-					chunkShader.setUniform(ChunkUniforms.loc_modelPosition, chunk.getMin());
-					if(mesh == null || !(mesh instanceof ReducedChunkMesh)) {
+				ReducedChunkMesh mesh = visibleReduced.array[i];
+				if(mesh.needsUpdate()) {
+					if(((ReducedChunk)mesh.getChunk()).generated) {
 						if(System.currentTimeMillis() - startTime > maximumMeshTime) {
 							// Stop meshing if the frame is taking to long.
-							if(!(mesh instanceof ReducedChunkMesh)) continue;
 						} else {
-							chunk.setChunkMesh(mesh = new ReducedChunkMesh(chunk));
+							mesh.regenerateMesh();
 						}
 					}
-					((ReducedChunkMesh)mesh).render();
 				}
+				mesh.render();
 			}
-			
-			chunkShader.unbind();
 			
 			// Render entities:
 			
@@ -515,8 +440,8 @@ public class MainRenderer {
 				}
 			}
 			
-			
-			blockShader.setUniform(BlockUniforms.loc_fog_activ, 0); // manually disable the fog
+			NormalChunkMesh.shader.bind();
+			NormalChunkMesh.shader.setUniform(NormalChunkMesh.loc_fog_activ, 0); // manually disable the fog
 			for (int i = 0; i < spatials.length; i++) {
 				Spatial spatial = spatials[i];
 				Mesh mesh = spatial.getMesh();
@@ -530,23 +455,8 @@ public class MainRenderer {
 				});
 			}
 			
-			entityShader.unbind();
-			
 			// Render transparent chunk meshes:
-			blockShader.bind();
-
-			blockShader.setUniform(BlockUniforms.loc_fog_activ, Cubyz.fog.isActive());
-			blockShader.setUniform(BlockUniforms.loc_fog_color, Cubyz.fog.getColor());
-			blockShader.setUniform(BlockUniforms.loc_fog_density, Cubyz.fog.getDensity());
-			blockShader.setUniform(BlockUniforms.loc_projectionMatrix, Window.getProjectionMatrix());
-			blockShader.setUniform(BlockUniforms.loc_texture_sampler, 0);
-			blockShader.setUniform(BlockUniforms.loc_break_sampler, 2);
-			blockShader.setUniform(BlockUniforms.loc_viewMatrix, Cubyz.camera.getViewMatrix());
-
-			blockShader.setUniform(BlockUniforms.loc_ambientLight, ambientLight);
-			blockShader.setUniform(BlockUniforms.loc_directionalLight, directionalLight.getDirection());
-			
-			blockShader.setUniform(BlockUniforms.loc_atlasSize, Meshes.atlasSize);
+			NormalChunkMesh.bindShader(ambientLight, directionalLight.getDirection());
 			
 			// Activate first texture bank
 			glActiveTexture(GL_TEXTURE0);
@@ -566,38 +476,22 @@ public class MainRenderer {
 				glBindTexture(GL_TEXTURE_2D, GameLauncher.logic.breakAnimations[0].getId());
 			}
 
-			NormalChunk[] chunks = sortChunks(visibleChunks.toArray(), x0/NormalChunk.chunkSize - 0.5f, y0/NormalChunk.chunkSize - 0.5f, z0/NormalChunk.chunkSize - 0.5f);
-			for (NormalChunk ch : chunks) {
-				blockShader.setUniform(BlockUniforms.loc_modelPosition, ch.getMin());
+			NormalChunkMesh[] meshes = sortChunks(visibleChunks.toArray(), x0/NormalChunk.chunkSize - 0.5f, y0/NormalChunk.chunkSize - 0.5f, z0/NormalChunk.chunkSize - 0.5f);
+			for (NormalChunkMesh mesh : meshes) {
 				
-				if(selected != null && selected.source == ch) {
-					blockShader.setUniform(BlockUniforms.loc_selectedIndex, selected.renderIndex);
+				if(selected != null && selected.source == mesh.getChunk()) {
+					NormalChunkMesh.shader.setUniform(NormalChunkMesh.loc_selectedIndex, selected.renderIndex);
 				} else {
-					blockShader.setUniform(BlockUniforms.loc_selectedIndex, -1);
+					NormalChunkMesh.shader.setUniform(NormalChunkMesh.loc_selectedIndex, -1);
 				}
 				
-				Object mesh = ch.getChunkMesh();
-				if(ch.wasUpdated() || mesh == null || !(mesh instanceof NormalChunkMesh)) {
-					if(System.currentTimeMillis() - startTime > maximumMeshTime) {
-						// Stop meshing if the frame is taking to long.
-						if(!(mesh instanceof NormalChunkMesh)) continue;
-					} else {
-						mesh = new NormalChunkMesh(ch);
-						ch.setChunkMesh(mesh);
-					}
-				}
-				((NormalChunkMesh)mesh).renderTransparent();		
+				mesh.renderTransparent();		
 			}
-			blockShader.unbind();
 		}
 		Cubyz.gameUI.render();
 	}
 
 	public void cleanup() {
-		if (blockShader != null) {
-			blockShader.cleanup();
-			blockShader = null;
-		}
 		if (entityShader != null) {
 			entityShader.cleanup();
 			entityShader = null;

--- a/src/cubyz/rendering/RenderOctTree.java
+++ b/src/cubyz/rendering/RenderOctTree.java
@@ -48,10 +48,10 @@ public class RenderOctTree {
 					if(dx2*dx2 + dy2*dy2 + dz2*dz2 > nearRenderDistance*nearRenderDistance) return;
 				}
 				
+				double dist = dx*dx + dy*dy + dz*dz;
 				// Check if this chunk has reached the smallest possible size:
 				if(size == NormalChunk.chunkSize) {
 					// Check if this is a normal or a reduced chunk:
-					double dist = dx*dx + dy*dy + dz*dz;
 					if(dist < renderDistance*renderDistance) {
 						if(mesh.getChunk() == null) {
 							((NormalChunkMesh)mesh).updateChunk(Cubyz.surface.getChunk(x >> NormalChunk.chunkShift, y >> NormalChunk.chunkShift, z >> NormalChunk.chunkShift));
@@ -99,9 +99,16 @@ public class RenderOctTree {
 						nextNodes = null;
 					}
 				}
-				if(mesh.getChunk() == null) {
-					((ReducedChunkMesh)mesh).updateChunk(new ReducedChunk(x, y, z, CubyzMath.binaryLog(size) - NormalChunk.chunkShift, CubyzMath.binaryLog(size)));
-					Cubyz.surface.queueChunk(mesh.getChunk());
+				if(dist < maxRD*maxRD) {
+					if(mesh.getChunk() == null) {
+						((ReducedChunkMesh)mesh).updateChunk(new ReducedChunk(x, y, z, CubyzMath.binaryLog(size) - NormalChunk.chunkShift, CubyzMath.binaryLog(size)));
+						Cubyz.surface.queueChunk(mesh.getChunk());
+					}
+				} else {
+					if(mesh.getChunk() != null) {
+						Cubyz.surface.unQueueChunk(mesh.getChunk());
+						((ReducedChunkMesh)mesh).updateChunk(null);
+					}
 				}
 			}
 		}

--- a/src/cubyz/rendering/RenderOctTree.java
+++ b/src/cubyz/rendering/RenderOctTree.java
@@ -25,7 +25,6 @@ public class RenderOctTree {
 		//public Chunk chunk;
 		public ChunkMesh mesh;
 		public OctTreeNode(ReducedChunkMesh replacement, int x, int y, int z, int size) {
-			System.out.println(replacement);
 			this.x = x;
 			this.y = y;
 			this.z = z;

--- a/src/cubyz/rendering/ShaderProgram.java
+++ b/src/cubyz/rendering/ShaderProgram.java
@@ -145,7 +145,6 @@ public class ShaderProgram {
 	}
 
 	public void cleanup() {
-		unbind();
 		if (programId != 0) {
 			glDeleteProgram(programId);
 		}

--- a/src/cubyz/utils/datastructures/BinaryMaxHeap.java
+++ b/src/cubyz/utils/datastructures/BinaryMaxHeap.java
@@ -1,0 +1,103 @@
+package cubyz.utils.datastructures;
+
+import java.util.Arrays;
+
+/**
+ * A simple binary heap.
+ * Thread safe.
+ *
+ * @param <T>  extends Comparable<T>
+ */
+
+public class BinaryMaxHeap<T extends Comparable<T>> {
+	private int size;
+	private T[] array;
+	/**
+	 * @param initialCapacity
+	 */
+	public BinaryMaxHeap(T[] initialCapacity) {
+		array = initialCapacity;
+	}
+	
+	/**
+	 * Moves an element from a given index down the heap, such that all children are always smaller than their parents.
+	 * @param i
+	 */
+	private void siftDown(int i) {
+		while(i*2 + 2 < size) {
+			int biggest = array[i*2 + 1].compareTo(array[i*2 + 2]) > 0 ? i*2 + 1 : i*2 + 2;
+			biggest = array[biggest].compareTo(array[i]) > 0 ? biggest : i;
+			// Break if all childs are smaller.
+			if(biggest == i) return;
+			// Swap it:
+			T local = array[biggest];
+			array[biggest] = array[i];
+			array[i] = local;
+			// goto the next node:
+			i = biggest;
+		}
+	}
+	
+	/**
+	 * Moves an element from a given index up the heap, such that all children are always smaller than their parents.
+	 * @param i
+	 */
+	private void siftUp(int i) {
+		int parentIndex = (i-1)/2;
+		// Go through the parents, until the child is smaller and swap.
+		while(array[parentIndex].compareTo(array[i]) < 0 && i > 0) {
+			T local = array[parentIndex];
+			array[parentIndex] = array[i];
+			array[i] = local;
+			i = parentIndex;
+			parentIndex = (i-1)/2;
+		}
+	}
+	
+	/**
+	 * Adds a new element to the heap.
+	 * @param element
+	 */
+	public void add(T element) {
+		synchronized(this) {
+			if(size == array.length) {
+				increaseCapacity(size*2);
+			}
+			array[size] = element;
+			siftUp(size);
+			size++;
+		}
+	}
+	
+	/**
+	 * Returns the biggest element and removes it from the heap.
+	 * @return max or null if empty.
+	 */
+	public T extractMax() {
+		synchronized(this) {
+			if(size == 0) return null;
+			T ret = array[0];
+			array[0] = array[--size];
+			array[size] = null;
+			siftDown(0);
+			return ret;
+		}
+	}
+	/**
+	 * Removes all elements inside. Also fills them with nulls.
+	 */
+	public void clear() {
+		synchronized(this) {
+			while(--size >= 0) {
+				array[size] = null;
+			}
+			size = 0;
+		}
+	}
+	
+	private void increaseCapacity(int newCapacity) {
+		array = Arrays.copyOf(array, newCapacity);
+	}
+}
+
+

--- a/src/cubyz/world/Chunk.java
+++ b/src/cubyz/world/Chunk.java
@@ -4,6 +4,15 @@ import cubyz.world.blocks.Block;
 import cubyz.world.generator.SurfaceGenerator;
 
 public abstract class Chunk {
+	protected Runnable meshListener;
+
+	/**
+	 * The mesh listener will be notified every time the mesh should change.
+	 * @param listener
+	 */
+	public void setMeshListener(Runnable listener) {
+		meshListener = listener;
+	}
 	/**
 	 * This is useful to convert for loops to work for reduced resolution:<br>
 	 * Instead of using<br>

--- a/src/cubyz/world/Chunk.java
+++ b/src/cubyz/world/Chunk.java
@@ -1,12 +1,9 @@
 package cubyz.world;
 
-import cubyz.client.ClientOnly;
 import cubyz.world.blocks.Block;
 import cubyz.world.generator.SurfaceGenerator;
 
 public abstract class Chunk {
-	private Object chunkMesh = null;
-	
 	/**
 	 * This is useful to convert for loops to work for reduced resolution:<br>
 	 * Instead of using<br>
@@ -94,22 +91,4 @@ public abstract class Chunk {
 	 * @return this chunks width.
 	 */
 	public abstract int getWidth();
-	
-	/**
-	 * Store a chunk mesh in this chunk.
-	 * @param mesh
-	 */
-	public void setChunkMesh(Object mesh) {
-		if(chunkMesh != null)
-			ClientOnly.deleteChunkMesh.accept(this);
-		chunkMesh = mesh;
-	}
-	
-	/**
-	 * Returns the currently stored chunk mesh.
-	 * @return mesh
-	 */
-	public Object getChunkMesh() {
-		return chunkMesh;
-	}
 }

--- a/src/cubyz/world/LocalSurface.java
+++ b/src/cubyz/world/LocalSurface.java
@@ -626,11 +626,6 @@ public class LocalSurface extends Surface {
 				thread.join();
 			}
 			generatorThreads = new ArrayList<>();
-
-			// Clean up additional GPU data:
-			for(MetaChunk chunk : metaChunks.values()) {
-				chunk.cleanup();
-			}
 			
 			metaChunks = null;
 		} catch (Exception e) {

--- a/src/cubyz/world/MetaChunk.java
+++ b/src/cubyz/world/MetaChunk.java
@@ -3,7 +3,6 @@ package cubyz.world;
 import java.util.ArrayList;
 
 import cubyz.Logger;
-import cubyz.client.ClientOnly;
 import cubyz.world.blocks.Block;
 import cubyz.world.blocks.BlockEntity;
 import cubyz.world.blocks.Updateable;
@@ -113,13 +112,6 @@ public class MetaChunk {
 		}
 	}
 	
-	public void cleanup() {
-		for (NormalChunk chunk : chunks) {
-			if(chunk == null) continue;
-			ClientOnly.deleteChunkMesh.accept(chunk);
-		}
-	}
-	
 	public void updatePlayer(int x, int y, int z, int renderDistance, int entityDistance, ArrayList<NormalChunk> chunksList, ArrayList<ChunkEntityManager> managers) {
 		// Shift the player position, so chunks are loaded once the center comes into render distance:
 		x -= NormalChunk.chunkSize/2;
@@ -145,7 +137,6 @@ public class MetaChunk {
 								chunk.map.mapIO.saveChunk(chunk); // Only needs to be stored if it was ever generated.
 							else
 								surface.unQueueChunk(chunk);
-							ClientOnly.deleteChunkMesh.accept(chunk);
 							chunks[index] = null;
 						}
 					} else if(chunk == null) {

--- a/src/cubyz/world/NormalChunk.java
+++ b/src/cubyz/world/NormalChunk.java
@@ -743,6 +743,10 @@ public class NormalChunk extends Chunk {
 		updated = true;
 	}
 	
+	public void setUpdated(boolean updated) {
+		this.updated = updated;
+	}
+	
 	public int startIndex(int start) {
 		return start;
 	}
@@ -772,12 +776,6 @@ public class NormalChunk extends Chunk {
 	@Override
 	public void updateBlock(int x, int y, int z, Block newBlock) {
 		updateBlock(x, y, z, newBlock, newBlock == null ? 0 : newBlock.mode.getNaturalStandard());
-	}
-	
-	@Override
-	public void setChunkMesh(Object mesh) {
-		updated = false;
-		super.setChunkMesh(mesh);
 	}
 
 	@Override

--- a/src/cubyz/world/NormalChunk.java
+++ b/src/cubyz/world/NormalChunk.java
@@ -735,16 +735,8 @@ public class NormalChunk extends Chunk {
 		return loaded;
 	}
 	
-	public boolean wasUpdated() {
-		return updated;
-	}
-	
 	public void setUpdated() {
-		updated = true;
-	}
-	
-	public void setUpdated(boolean updated) {
-		this.updated = updated;
+		if(meshListener != null) meshListener.run();
 	}
 	
 	public int startIndex(int start) {

--- a/src/cubyz/world/ReducedChunk.java
+++ b/src/cubyz/world/ReducedChunk.java
@@ -88,6 +88,7 @@ public class ReducedChunk extends Chunk {
 		gen.generate(this, Cubyz.surface);
 		applyBlockChanges();
 		generated = true;
+		if(meshListener != null) meshListener.run();
 	}
 
 	@Override

--- a/src/cubyz/world/terrain/ClimateMap.java
+++ b/src/cubyz/world/terrain/ClimateMap.java
@@ -38,7 +38,6 @@ public class ClimateMap {
 				}
 			}
 		}
-		System.out.println(cache.cacheMisses+"/"+cache.cacheRequests);
 		return map;
 	}
 	
@@ -60,7 +59,6 @@ public class ClimateMap {
 	public static ClimateMapFragment getOrGenerateFragment(long seed, int wx, int wz) {
 		int hash = ClimateMapFragment.hashCode(wx, wz) & CACHE_MASK;
 		ClimateMapFragment ret = cache.find(new ClimateMapFragmentComparator(wx, wz), hash);
-		System.out.println(wx+" "+wz+" "+ret);
 		if(ret != null) return ret;
 		synchronized(cache.cache[hash]) {
 			// Try again in case it was already generated in another thread:

--- a/src/cubyz/world/terrain/ClimateMapFragment.java
+++ b/src/cubyz/world/terrain/ClimateMapFragment.java
@@ -1,6 +1,5 @@
 package cubyz.world.terrain;
 
-import cubyz.utils.datastructures.Cache;
 import cubyz.world.cubyzgenerators.biomes.Biome;
 import cubyz.world.terrain.noise.FractalNoise;
 


### PR DESCRIPTION
When the player moves around too fast the LOD-borders start flickering.

The idea is to use replacement meshes(from the higher LOD-level) that will be shown when a given mesh hasn't been created yet.
This requires some rewriting, which gives me the opportunity to also fix some other problems.

- [x] Implement replacement meshes
- [x] Implement a mesh queue, for meshes to be generated by priority instead of when they are needed on screen(which is usually too late). This will allow the player to move around without seeing meshes generate at the edges of the screen.
- [x] Only draw a subregion of the replacement mesh to avoid overlap.
- [x] Fix the chunk borders, which cause cracks in the terrain.
- [x] Cleanup some code, add some comments.