### PR TITLE
Changes on block registry.

### DIFF
--- a/src/cubyz/api/CubyzRegistries.java
+++ b/src/cubyz/api/CubyzRegistries.java
@@ -20,7 +20,7 @@ import cubyz.world.terrain.worldgenerators.SurfaceGenerator;
 
 public class CubyzRegistries {
 
-	public static final Registry<DataOrientedRegistry>   BLOCK_REGISTRIES        = new Registry<DataOrientedRegistry>();
+	public static final Registry<RegistryElement>   BLOCK_REGISTRIES        = new Registry<RegistryElement>();
 	public static final NoIDRegistry<Ore>                ORE_REGISTRY            = new NoIDRegistry<Ore>();
 	public static final Registry<Item>                   ITEM_REGISTRY           = new Registry<Item>();
 	public static final NoIDRegistry<Recipe>             RECIPE_REGISTRY         = new NoIDRegistry<Recipe>();

--- a/src/cubyz/api/CurrentWorldRegistries.java
+++ b/src/cubyz/api/CurrentWorldRegistries.java
@@ -19,7 +19,7 @@ import cubyz.world.terrain.worldgenerators.SurfaceGenerator;
 
 public class CurrentWorldRegistries {
 
-	public final Registry<DataOrientedRegistry> blockRegistries = new Registry<DataOrientedRegistry>(CubyzRegistries.BLOCK_REGISTRIES);
+	public final Registry<RegistryElement> blockRegistries = new Registry<RegistryElement>(CubyzRegistries.BLOCK_REGISTRIES);
 	public final NoIDRegistry<Ore>              oreRegistry     = new NoIDRegistry<Ore>(CubyzRegistries.ORE_REGISTRY);
 	public final Registry<Item>                 itemRegistry    = new Registry<Item>(CubyzRegistries.ITEM_REGISTRY);
 	public final NoIDRegistry<Recipe>           recipeRegistry  = new NoIDRegistry<Recipe>(CubyzRegistries.RECIPE_REGISTRY);
@@ -38,8 +38,9 @@ public class CurrentWorldRegistries {
 		if (!assets.exists()) {
 			generateAssets(assets, world);
 		}
-		for(DataOrientedRegistry reg : blockRegistries.registered(new DataOrientedRegistry[0])) {
-			reg.reset(CubyzRegistries.blocksBeforeWorld);
+		for(RegistryElement reg : blockRegistries.registered(new RegistryElement[0])) {
+			if(reg instanceof DataOrientedRegistry)
+				((DataOrientedRegistry) reg).reset(CubyzRegistries.blocksBeforeWorld);
 		}
 		loadWorldAssets(assetPath);
 	}

--- a/src/cubyz/modding/base/AddonsMod.java
+++ b/src/cubyz/modding/base/AddonsMod.java
@@ -8,17 +8,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.function.BiConsumer;
 
+import cubyz.api.*;
 import cubyz.utils.Logger;
-import cubyz.api.CubyzRegistries;
-import cubyz.api.DataOrientedRegistry;
-import cubyz.api.EventHandler;
-import cubyz.api.LoadOrder;
-import cubyz.api.Mod;
-import cubyz.api.NoIDRegistry;
-import cubyz.api.Order;
-import cubyz.api.Proxy;
-import cubyz.api.Registry;
-import cubyz.api.Resource;
 import cubyz.utils.datastructures.IntFastList;
 import cubyz.utils.json.JsonObject;
 import cubyz.utils.json.JsonParser;
@@ -66,7 +57,7 @@ public class AddonsMod {
 	public void init() {
 		init(CubyzRegistries.ITEM_REGISTRY, CubyzRegistries.BLOCK_REGISTRIES, CubyzRegistries.RECIPE_REGISTRY);
 	}
-	public void init(Registry<Item> itemRegistry, Registry<DataOrientedRegistry> blockRegistries, NoIDRegistry<Recipe> recipeRegistry) {
+	public void init(Registry<Item> itemRegistry, Registry<RegistryElement> blockRegistries, NoIDRegistry<Recipe> recipeRegistry) {
 		proxy.init(this);
 		registerMissingStuff(itemRegistry, blockRegistries);
 		registerRecipes(recipeRegistry);
@@ -152,11 +143,12 @@ public class AddonsMod {
 		registerItems(registry, "assets/");
 	}
 	
-	public void registerBlocks(Registry<DataOrientedRegistry> registries, NoIDRegistry<Ore> oreRegistry) {
+	public void registerBlocks(Registry<RegistryElement> registries, NoIDRegistry<Ore> oreRegistry) {
 		readAllJsonObjects("blocks", (json, id) -> {
 			int block = 0;
-			for(DataOrientedRegistry reg : registries.registered(new DataOrientedRegistry[0])) {
-				block = reg.register(assetPath, id, json);
+			for(RegistryElement reg : registries.registered(new RegistryElement[0])) {
+				if(reg instanceof DataOrientedRegistry)
+					block = ((DataOrientedRegistry) reg).register(assetPath, id, json);
 			}
 
 			// Ores:
@@ -207,7 +199,7 @@ public class AddonsMod {
 		});
 	}
 	@EventHandler(type = "register:block")
-	public void registerBlocks(Registry<DataOrientedRegistry> registries) {
+	public void registerBlocks(Registry<RegistryElement> registries) {
 		registerBlocks(registries, CubyzRegistries.ORE_REGISTRY);
 	}
 	@EventHandler(type = "register:biome")
@@ -221,7 +213,7 @@ public class AddonsMod {
 	/**
 	 * Takes care of all missing references.
 	 */
-	public void registerMissingStuff(Registry<Item> itemRegistry, Registry<DataOrientedRegistry> blockRegistry) {
+	public void registerMissingStuff(Registry<Item> itemRegistry, Registry<RegistryElement> blockRegistry) {
 		for(int i = 0; i < missingDropsBlock.size; i++) {
 			Blocks.addBlockDrop(missingDropsBlock.array[i], new BlockDrop(itemRegistry.getByID(missingDropsItem.get(i)), missingDropsAmount.get(i)));
 		}


### PR DESCRIPTION
## Problem:

- While trying to register a block thru an event, the game crashed while opening the world. The crash was related to the fact that my registered block was being registered with the code **below** and the game was only expecting `DataOrientedRegistry` blocks.

```java
@EventHandler(type = "register:block")
public void registerBlocks(Registry<RegistryElement> registries) {
    registries.register(new Block(MOD_ID.concat(":example"), .5f, .5f, Block.BlockClass.STONE));
}
```

## The solution:

- Changed the `CubzyRegistries.BLOCK_REGISTRY` to accept `RegistryElement` and when registering blocks with **.json** files, the game will check first if the object is an instance of `DataOrientedRegistry`. 

![example](https://cdn.discordapp.com/attachments/713470714501398549/920334550540898304/unknown.png)