### PR TITLE
Log Viewer or ConsoleLogGUI

### DIFF
--- a/src/cubyz/gui/ConsoleLog.java
+++ b/src/cubyz/gui/ConsoleLog.java
@@ -69,7 +69,7 @@ public class ConsoleLog extends MenuGUI {
                 for (String line : Files.readAllLines(Paths.get(currentLogPath))) {
                     if (line.contains("| warning |")) {
                         lastLogLevel = WARN;
-                    } else if (line.contains("| error |")) {
+                    } else if (line.contains("| error |") || line.contains("| crash |")) {
                         lastLogLevel = ERROR;
                     } else if (line.contains("| info |") || line.contains("| debug |")) {
                         lastLogLevel = DEBUG;
@@ -103,7 +103,7 @@ public class ConsoleLog extends MenuGUI {
         @Override
         public void render(int x, int y) {
             Graphics.setColor(color);
-            Graphics.setFont(Fonts.PIXEL_FONT, 16f);
+            Graphics.setFont(Fonts.PIXEL_FONT, 16f * GUI_SCALE);
             Graphics.drawText(x, y, rawText);
         }
     }

--- a/src/cubyz/gui/ConsoleLog.java
+++ b/src/cubyz/gui/ConsoleLog.java
@@ -14,7 +14,6 @@ import static cubyz.client.ClientSettings.GUI_SCALE;
 
 public class ConsoleLog extends MenuGUI {
 
-    public static String currentLogPath = null;
     private final ScrollingContainer container = new ScrollingContainer();
 
     private final int DEBUG = 0xffffff;
@@ -63,31 +62,25 @@ public class ConsoleLog extends MenuGUI {
     }
 
     private void read() {
-        if (currentLogPath != null) {
-            try {
-                int lastLogLevel = DEBUG;
-                for (String line : Files.readAllLines(Paths.get(currentLogPath))) {
-                    if (line.contains("| warning |")) {
-                        lastLogLevel = WARN;
-                    } else if (line.contains("| error |") || line.contains("| crash |")) {
-                        lastLogLevel = ERROR;
-                    } else if (line.contains("| info |") || line.contains("| debug |")) {
-                        lastLogLevel = DEBUG;
-                    }
-                    log(line, lastLogLevel);
+        try {
+            int lastLogLevel = DEBUG;
+            for (String line : Files.readAllLines(Paths.get("./logs/latest.log"))) {
+                if (line.contains("| warning |")) {
+                    lastLogLevel = WARN;
+                } else if (line.contains("| error |") || line.contains("| crash |")) {
+                    lastLogLevel = ERROR;
+                } else if (line.contains("| info |") || line.contains("| debug |")) {
+                    lastLogLevel = DEBUG;
                 }
-            } catch (IOException e) {
-                e.printStackTrace();
+                log(line, lastLogLevel);
             }
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 
     private void log(String msg, int logLevel) {
         this.container.add(new LogLabel(msg, logLevel));
-    }
-
-    public static void setLogFile(String file) {
-        currentLogPath = file;
     }
 
     private static class LogLabel extends Component {

--- a/src/cubyz/gui/ConsoleLog.java
+++ b/src/cubyz/gui/ConsoleLog.java
@@ -1,0 +1,110 @@
+package cubyz.gui;
+
+import cubyz.gui.components.Component;
+import cubyz.gui.components.ScrollingContainer;
+import cubyz.rendering.Graphics;
+import cubyz.rendering.Window;
+import cubyz.rendering.text.Fonts;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static cubyz.client.ClientSettings.GUI_SCALE;
+
+public class ConsoleLog extends MenuGUI {
+
+    public static String currentLogPath = null;
+    private final ScrollingContainer container = new ScrollingContainer();
+
+    private final int DEBUG = 0xffffff;
+    private final int WARN = 0xffff00;
+    private final int ERROR = 0xff0000;
+
+    @Override
+    public void init() {
+        this.container.clear();
+        this.read();
+        this.updateGUIScale();
+        this.container.scrollToEnd();
+    }
+
+    @Override
+    public void updateGUIScale() {
+        int y = 10;
+        for (Component label : this.container.getChildren()) {
+            label.setBounds(20 * GUI_SCALE, (y + 4) * GUI_SCALE, 0, 24 * GUI_SCALE, Component.ALIGN_TOP_LEFT);
+            y += 10;
+        }
+        this.container.setBounds(0, 0, Window.getWidth(), Window.getHeight(), Component.ALIGN_TOP_LEFT);
+    }
+
+    @Override
+    public void render() {
+        Graphics.setColor(0x000000, 200);
+        Graphics.fillRect(0, 0, Window.getWidth(), Window.getHeight());
+        this.container.render();
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        this.container.clear();
+    }
+
+    @Override
+    public boolean doesPauseGame() {
+        return true;
+    }
+
+    @Override
+    public boolean ungrabsMouse() {
+        return true;
+    }
+
+    private void read() {
+        if (currentLogPath != null) {
+            try {
+                int lastLogLevel = DEBUG;
+                for (String line : Files.readAllLines(Paths.get(currentLogPath))) {
+                    if (line.contains("| warning |")) {
+                        lastLogLevel = WARN;
+                    } else if (line.contains("| error |")) {
+                        lastLogLevel = ERROR;
+                    } else if (line.contains("| info |") || line.contains("| debug |")) {
+                        lastLogLevel = DEBUG;
+                    }
+                    log(line, lastLogLevel);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void log(String msg, int logLevel) {
+        this.container.add(new LogLabel(msg, logLevel));
+    }
+
+    public static void setLogFile(String file) {
+        currentLogPath = file;
+    }
+
+    private static class LogLabel extends Component {
+
+        private final String rawText;
+        private final int color;
+
+        public LogLabel(String rawText, int color) {
+            this.rawText = rawText;
+            this.color = color;
+        }
+
+        @Override
+        public void render(int x, int y) {
+            Graphics.setColor(color);
+            Graphics.setFont(Fonts.PIXEL_FONT, 16f);
+            Graphics.drawText(x, y, rawText);
+        }
+    }
+}

--- a/src/cubyz/gui/UISystem.java
+++ b/src/cubyz/gui/UISystem.java
@@ -188,8 +188,8 @@ public class UISystem {
 				overlay.render();
 			}
 		}
-		if(!(Cubyz.gameUI.getMenuGUI() instanceof ConsoleGUI)){
-			if (Keyboard.isKeyReleased(GLFW.GLFW_KEY_L)) {
+		if (Keyboard.isKeyPressed(GLFW.GLFW_KEY_F3)) {
+			if(Keyboard.isKeyPressed(GLFW.GLFW_KEY_L)) {
 				if(getOverlays()[getOverlays().length-1] instanceof ConsoleLog)
 					Cubyz.gameUI.removeOverlay(consoleLog);
 				else Cubyz.gameUI.addOverlay(consoleLog);

--- a/src/cubyz/gui/UISystem.java
+++ b/src/cubyz/gui/UISystem.java
@@ -15,6 +15,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 
 import cubyz.client.Cubyz;
+import cubyz.gui.game.ConsoleGUI;
 import org.lwjgl.glfw.GLFW;
 
 import cubyz.client.ClientSettings;
@@ -187,10 +188,12 @@ public class UISystem {
 				overlay.render();
 			}
 		}
-		if (Keyboard.isKeyReleased(GLFW.GLFW_KEY_L)) {
-			if(getOverlays()[getOverlays().length-1] instanceof ConsoleLog)
-				Cubyz.gameUI.removeOverlay(consoleLog);
-			else Cubyz.gameUI.addOverlay(consoleLog);
+		if(!(Cubyz.gameUI.getMenuGUI() instanceof ConsoleGUI)){
+			if (Keyboard.isKeyReleased(GLFW.GLFW_KEY_L)) {
+				if(getOverlays()[getOverlays().length-1] instanceof ConsoleLog)
+					Cubyz.gameUI.removeOverlay(consoleLog);
+				else Cubyz.gameUI.addOverlay(consoleLog);
+			}
 		}
 		Window.restoreState();
 	}

--- a/src/cubyz/gui/UISystem.java
+++ b/src/cubyz/gui/UISystem.java
@@ -14,6 +14,7 @@ import static org.lwjgl.opengl.GL13.glActiveTexture;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 
+import cubyz.client.Cubyz;
 import org.lwjgl.glfw.GLFW;
 
 import cubyz.client.ClientSettings;
@@ -33,6 +34,8 @@ public class UISystem {
 	private MenuGUI oldGui;
 	private ArrayList<MenuGUI> overlays = new ArrayList<>();
 	private ArrayDeque<MenuGUI> menuQueue = new ArrayDeque<>();
+
+	private final ConsoleLog consoleLog = new ConsoleLog();
 	
 	private Transition curTransition;
 	private long lastAnimTime = System.currentTimeMillis();
@@ -183,6 +186,11 @@ public class UISystem {
 			for(MenuGUI overlay : getOverlays()) {
 				overlay.render();
 			}
+		}
+		if (Keyboard.isKeyReleased(GLFW.GLFW_KEY_L)) {
+			if(getOverlays()[getOverlays().length-1] instanceof ConsoleLog)
+				Cubyz.gameUI.removeOverlay(consoleLog);
+			else Cubyz.gameUI.addOverlay(consoleLog);
 		}
 		Window.restoreState();
 	}

--- a/src/cubyz/gui/components/Container.java
+++ b/src/cubyz/gui/components/Container.java
@@ -1,6 +1,7 @@
 package cubyz.gui.components;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.joml.Vector4i;
 
@@ -44,5 +45,8 @@ public abstract class Container extends Component {
 		}
 		Graphics.restoreClip(oldClip);
 	}
-	
+
+	public List<Component> getChildren() {
+		return children;
+	}
 }

--- a/src/cubyz/gui/components/ScrollingContainer.java
+++ b/src/cubyz/gui/components/ScrollingContainer.java
@@ -51,5 +51,8 @@ public class ScrollingContainer extends Container {
 		scrollY = Math.min(maxY, scrollY);
 		Graphics.restoreClip(oldClip);
 	}
-	
+
+    public void scrollToEnd(){
+        scrollY = height;
+    }
 }

--- a/src/cubyz/utils/Logger.java
+++ b/src/cubyz/utils/Logger.java
@@ -1,5 +1,7 @@
 package cubyz.utils;
 
+import cubyz.gui.ConsoleLog;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -31,7 +33,9 @@ public class Logger {
 			}
 			
 			latestLogOutput = new FileOutputStream("logs/latest.log");
-			currentLogOutput = new FileOutputStream("logs/" + logFileFormat.format(Calendar.getInstance().getTime()) + ".log");
+			String currentLogName = "logs/" + logFileFormat.format(Calendar.getInstance().getTime()) + ".log";
+			currentLogOutput = new FileOutputStream(currentLogName);
+			ConsoleLog.setLogFile(currentLogName);
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();
 		}

--- a/src/cubyz/utils/Logger.java
+++ b/src/cubyz/utils/Logger.java
@@ -1,7 +1,5 @@
 package cubyz.utils;
 
-import cubyz.gui.ConsoleLog;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -33,9 +31,7 @@ public class Logger {
 			}
 			
 			latestLogOutput = new FileOutputStream("logs/latest.log");
-			String currentLogName = "logs/" + logFileFormat.format(Calendar.getInstance().getTime()) + ".log";
-			currentLogOutput = new FileOutputStream(currentLogName);
-			ConsoleLog.setLogFile(currentLogName);
+			currentLogOutput = new FileOutputStream("logs/" + logFileFormat.format(Calendar.getInstance().getTime()) + ".log");
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
### Done:

Checking the console output while developing the game is very handy right? With this in mind, I implemented the ability to check the current log output by pressing the `L` key. 

### Notes:

- The `ConsoleLog` can be open from every GUI since it's added as an overlay.
- Currently, you use `L` to show and hide the `ConsoleLog` GUI.
- The ScrollContainer is automatically set to the end. 
- Log levels are available on ### DEBUG, WARN, and ERROR with the respective colors being **white, yellow, and red**.

### Maybe in the future:

- Add a command output to run the in-game commands, or show dev-only features.

### Result: 
![image](https://user-images.githubusercontent.com/52864251/146558909-299a77b4-6af3-4caa-aab6-6f6b499c03da.png)
![image](https://user-images.githubusercontent.com/52864251/146559154-dc899f24-0747-43fa-bd69-18d0e74aed06.png)
