### PR TITLE
Fix: Custom ore .lang file.

### DIFF
--- a/src/cubyz/api/CurrentWorldRegistries.java
+++ b/src/cubyz/api/CurrentWorldRegistries.java
@@ -53,11 +53,20 @@ public class CurrentWorldRegistries {
 		assets.mkdirs();
 		new File(assets, "blocks/textures").mkdirs();
 		new File(assets, "items/textures").mkdirs();
+		new File(assets, "lang").mkdirs();
+		Properties oreLang = new Properties();
 		Random rand = new Random(world.getSeed());
 		int randomAmount = 9 + rand.nextInt(3); // TODO
 		int i = 0;
 		for(i = 0; i < randomAmount; i++) {
-			CustomOre.random(rand, assets, "cubyz");
+			CustomOre.random(rand, assets, "cubyz", oreLang);
+		}
+		try {
+			FileOutputStream oreLangFile = new FileOutputStream(new File(assets, "lang/en_ore.lang"));
+			oreLang.store(oreLangFile, "Contains all the translated names for the generated ores.");
+			oreLangFile.close();
+		} catch (IOException e) {
+			Logger.error(e.getMessage());
 		}
 	}
 }

--- a/src/cubyz/api/CurrentWorldRegistries.java
+++ b/src/cubyz/api/CurrentWorldRegistries.java
@@ -1,9 +1,15 @@
 package cubyz.api;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
 import java.util.Random;
 
 import cubyz.modding.base.AddonsMod;
+import cubyz.utils.Logger;
+import cubyz.utils.translate.Language;
+import cubyz.utils.translate.LanguageLoader;
 import cubyz.world.World;
 import cubyz.world.blocks.CustomOre;
 import cubyz.world.blocks.Ore;
@@ -24,6 +30,8 @@ public class CurrentWorldRegistries {
 	public final NoIDRegistry<Recipe>           recipeRegistry  = new NoIDRegistry<Recipe>(CubyzRegistries.RECIPE_REGISTRY);
 	public final Registry<EntityType>           entityRegistry  = new Registry<EntityType>(CubyzRegistries.ENTITY_REGISTRY);
 	public final BiomeRegistry                  biomeRegistry   = new BiomeRegistry(CubyzRegistries.BIOME_REGISTRY);
+
+	public static Language oreLang;
 
 	/**
 	 * Loads the world specific assets, such as procedural ores.
@@ -46,6 +54,7 @@ public class CurrentWorldRegistries {
 		AddonsMod.instance.registerItems(itemRegistry, assetPath);
 		AddonsMod.instance.registerBiomes(biomeRegistry);
 		AddonsMod.instance.init(itemRegistry, blockRegistries, recipeRegistry);
+		oreLang = LanguageLoader.loadOreLang(assetPath);
 	}
 
 	public void generateAssets(File assets, World world) {

--- a/src/cubyz/api/CurrentWorldRegistries.java
+++ b/src/cubyz/api/CurrentWorldRegistries.java
@@ -31,7 +31,7 @@ public class CurrentWorldRegistries {
 	public final Registry<EntityType>           entityRegistry  = new Registry<EntityType>(CubyzRegistries.ENTITY_REGISTRY);
 	public final BiomeRegistry                  biomeRegistry   = new BiomeRegistry(CubyzRegistries.BIOME_REGISTRY);
 
-	public static Language oreLang;
+	public static Language fallbackLang;
 
 	/**
 	 * Loads the world specific assets, such as procedural ores.
@@ -49,12 +49,12 @@ public class CurrentWorldRegistries {
 	}
 
 	public void loadWorldAssets(String assetPath) {
+		fallbackLang = LanguageLoader.loadFallbackLang(assetPath);
 		AddonsMod.instance.preInit(assetPath);
 		AddonsMod.instance.registerBlocks(blockRegistries, oreRegistry);
 		AddonsMod.instance.registerItems(itemRegistry, assetPath);
 		AddonsMod.instance.registerBiomes(biomeRegistry);
 		AddonsMod.instance.init(itemRegistry, blockRegistries, recipeRegistry);
-		oreLang = LanguageLoader.loadOreLang(assetPath);
 	}
 
 	public void generateAssets(File assets, World world) {
@@ -63,17 +63,17 @@ public class CurrentWorldRegistries {
 		new File(assets, "blocks/textures").mkdirs();
 		new File(assets, "items/textures").mkdirs();
 		new File(assets, "lang").mkdirs();
-		Properties oreLang = new Properties();
+		Properties fallbackLang = new Properties();
 		Random rand = new Random(world.getSeed());
 		int randomAmount = 9 + rand.nextInt(3); // TODO
 		int i = 0;
 		for(i = 0; i < randomAmount; i++) {
-			CustomOre.random(rand, assets, "cubyz", oreLang);
+			CustomOre.random(rand, assets, "cubyz", fallbackLang);
 		}
 		try {
-			FileOutputStream oreLangFile = new FileOutputStream(new File(assets, "lang/en_ore.lang"));
-			oreLang.store(oreLangFile, "Contains all the translated names for the generated ores.");
-			oreLangFile.close();
+			FileOutputStream fallbackLangFile = new FileOutputStream(new File(assets, "lang/fallback.lang"));
+			fallbackLang.store(fallbackLangFile, "Contains all the translated names for the generated ores.");
+			fallbackLangFile.close();
 		} catch (IOException e) {
 			Logger.error(e.getMessage());
 		}

--- a/src/cubyz/utils/translate/Language.java
+++ b/src/cubyz/utils/translate/Language.java
@@ -2,6 +2,7 @@ package cubyz.utils.translate;
 
 import java.util.HashMap;
 
+import cubyz.api.CurrentWorldRegistries;
 import cubyz.utils.Logger;
 
 /**
@@ -32,6 +33,10 @@ public class Language {
 	public void translate(TextKey key) {
 		if (keyValues.containsKey(key.getTranslateKey())) {
 			key.translation = keyValues.get(key.getTranslateKey());
+			return;
+		}
+		if(CurrentWorldRegistries.oreLang != null && CurrentWorldRegistries.oreLang.keyValues.containsKey(key.getTranslateKey())) {
+			key.translation = CurrentWorldRegistries.oreLang.get(key.getTranslateKey());
 			return;
 		}
 		if (key.getTranslateKey().contains("."))

--- a/src/cubyz/utils/translate/Language.java
+++ b/src/cubyz/utils/translate/Language.java
@@ -35,8 +35,8 @@ public class Language {
 			key.translation = keyValues.get(key.getTranslateKey());
 			return;
 		}
-		if(CurrentWorldRegistries.oreLang != null && CurrentWorldRegistries.oreLang.keyValues.containsKey(key.getTranslateKey())) {
-			key.translation = CurrentWorldRegistries.oreLang.get(key.getTranslateKey());
+		if(CurrentWorldRegistries.fallbackLang != null && CurrentWorldRegistries.fallbackLang.keyValues.containsKey(key.getTranslateKey())) {
+			key.translation = CurrentWorldRegistries.fallbackLang.get(key.getTranslateKey());
 			return;
 		}
 		if (key.getTranslateKey().contains("."))

--- a/src/cubyz/utils/translate/LanguageLoader.java
+++ b/src/cubyz/utils/translate/LanguageLoader.java
@@ -27,9 +27,9 @@ public class LanguageLoader {
 		return lang;
 	}
 
-	public static Language loadOreLang(String worldAssetPath) {
-		Language lang = new Language("en_ore");
-		loadLangFile(new File(worldAssetPath), lang, new File(worldAssetPath + "cubyz/lang/en_ore.lang"));
+	public static Language loadFallbackLang(String worldAssetPath) {
+		Language lang = new Language("fallback");
+		loadLangFile(new File(worldAssetPath), lang, new File(worldAssetPath + "cubyz/lang/fallback.lang"));
 		return lang;
 	}
 

--- a/src/cubyz/utils/translate/LanguageLoader.java
+++ b/src/cubyz/utils/translate/LanguageLoader.java
@@ -22,24 +22,33 @@ public class LanguageLoader {
 		Language lang = new Language(locale);
 		for (File assetFolder : assetsFolders) {
 			File langFile = ResourceManager.lookup(assetFolder.getName() + "/lang/" + locale + ".lang");
-			if (langFile != null) {
-				Properties props = new Properties();
-				try {
-					FileReader reader = new FileReader(langFile, StandardCharsets.UTF_8);
-					props.load(reader);
-					for (Object key : props.keySet()) {
-						lang.add(key.toString(), props.getProperty(key.toString()));
-					}
-					reader.close();
-				} catch (IOException e) {
-					Logger.error("Could not open language file " + locale + " for mod " + assetFolder.getName());
-					Logger.error(e);
-				}
-			} else if (assetFolder.getName().equals("cubyz")) {
-				Logger.warning("Language \"" + locale + "\" not found");
-			}
+			loadLangFile(assetFolder, lang, langFile);
 		}
 		return lang;
 	}
-	
+
+	public static Language loadOreLang(String worldAssetPath) {
+		Language lang = new Language("en_ore");
+		loadLangFile(new File(worldAssetPath), lang, new File(worldAssetPath + "cubyz/lang/en_ore.lang"));
+		return lang;
+	}
+
+	private static void loadLangFile(File assetFolder, Language lang, File langFile) {
+		if (langFile != null) {
+			Properties props = new Properties();
+			try {
+				FileReader reader = new FileReader(langFile, StandardCharsets.UTF_8);
+				props.load(reader);
+				for (Object key : props.keySet()) {
+					lang.add(key.toString(), props.getProperty(key.toString()));
+				}
+				reader.close();
+			} catch (IOException e) {
+				Logger.error("Could not open language file " + lang.getLocale() + " for mod " + assetFolder.getName());
+				Logger.error(e);
+			}
+		} else if (assetFolder.getName().equals("cubyz")) {
+			Logger.warning("Language \"" + lang.getLocale() + "\" not found");
+		}
+	}
 }

--- a/src/cubyz/world/blocks/CustomOre.java
+++ b/src/cubyz/world/blocks/CustomOre.java
@@ -6,6 +6,7 @@ import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Properties;
 import java.util.Random;
 
 import javax.imageio.ImageIO;
@@ -144,7 +145,7 @@ public class CustomOre {
 			return sb.toString();
 	}
 	
-	public static void random(Random rand, File assets, String mod) {
+	public static void random(Random rand, File assets, String mod, Properties oreLang) {
 		JsonObject json = new JsonObject();
 		json.put("class", "stone");
 
@@ -247,6 +248,8 @@ public class CustomOre {
 		} catch(Exception e) {
 			Logger.warning(e);
 		}
+
+		oreLang.put("block.cubyz." + name.replace(" ", "_") + "_ore.name", name + " Ore");
 	}
 	
 	/*public static CustomOre fromNDT(NDTContainer ndt) {

--- a/src/cubyz/world/blocks/CustomOre.java
+++ b/src/cubyz/world/blocks/CustomOre.java
@@ -145,7 +145,7 @@ public class CustomOre {
 			return sb.toString();
 	}
 	
-	public static void random(Random rand, File assets, String mod, Properties oreLang) {
+	public static void random(Random rand, File assets, String mod, Properties fallbackLang) {
 		JsonObject json = new JsonObject();
 		json.put("class", "stone");
 
@@ -249,7 +249,7 @@ public class CustomOre {
 			Logger.warning(e);
 		}
 
-		oreLang.put("block.cubyz." + name.replace(" ", "_") + "_ore.name", name + " Ore");
+		fallbackLang.put("block.cubyz." + name.replace(" ", "_") + "_ore.name", name + " Ore");
 	}
 	
 	/*public static CustomOre fromNDT(NDTContainer ndt) {


### PR DESCRIPTION
### Done:

- Implementation of the Discord idea on the translation of custom ores.
![image](https://user-images.githubusercontent.com/52864251/148891155-1120118c-213d-4e82-a891-4b7a8f879b4c.png)

### How it works:

- When the world is created a language file is created with all the world custom ore translations. This file is then used as a fallback when the translation key isn't found in the main language in use. 

#### Example:
```properties
#Contains all the translated names for the generated ores.
block.cubyz.Wyartite_ore.name=Wyartite Ore
block.cubyz.Ekanksite_ore.name=Ekanksite Ore
block.cubyz.Vivinella_ore.name=Vivinella Ore
block.cubyz.Derssulan_ore.name=Derssulan Ore
block.cubyz.Yeliotil_ore.name=Yeliotil Ore
block.cubyz.Evesuvite_ore.name=Evesuvite Ore
block.cubyz.Kamackiter_ore.name=Kamackiter Ore
block.cubyz.Geridymium_ore.name=Geridymium Ore
```