### PR TITLE
Exit crash

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -759,9 +759,7 @@ pub fn main() !void {
 		}
 	}
 
-	// I think that another way to fix this is to not deinit anything and let OS clear everything up
-	// I think that would also improve close times
-	// Otherwise just need to make sure threadPool is done before freeing any data
+	// Make sure that threadPool is done before freeing any data
 	threadPool.clear();
 
 	if(game.world) |world| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -758,6 +758,12 @@ pub fn main() !void {
 			gui.windowlist.gpu_performance_measuring.stopQuery();
 		}
 	}
+
+	// I think that another way to fix this is to not deinit anything and let OS clear everything up
+	// I think that would also improve close times
+	// Otherwise just need to make sure threadPool is done before freeing any data
+	threadPool.clear();
+
 	if(game.world) |world| {
 		world.deinit();
 		game.world = null;


### PR DESCRIPTION
The issue seemed to be that that the thread pool was accessing freed memory because memory was freed before all the threads were done doing stuff, my fix is to make sure that the thread pool is all cleared up before freeing anything.

I think that another way to fix this is to not deinit anything and let OS clear everything up which could improve close times.

Should fix #127