### PR TITLE
WIP: Chat opens with T. GameMenu closes if there is no need for it from a guiwindow. 

### DIFF
--- a/src/gui/GuiWindow.zig
+++ b/src/gui/GuiWindow.zig
@@ -46,6 +46,7 @@ const RelativePosition = union(enum) {
 
 const snapDistance = 3;
 
+gameMenuNeed:bool = false,
 pos: Vec2f = undefined,
 size: Vec2f = undefined,
 contentSize: Vec2f,

--- a/src/gui/components/TextInput.zig
+++ b/src/gui/components/TextInput.zig
@@ -134,6 +134,15 @@ pub fn mainButtonReleased(self: *TextInput, mousePosition: Vec2f) void {
 	}
 }
 
+pub fn select(self: *TextInput) void {
+	gui.setSelectedTextInput(self);
+	self.pressed = false;
+	self.selectionStart = null;
+	if(self.cursor == null)
+		self.cursor = @intCast(self.currentString.items.len);
+		
+}
+
 pub fn deselect(self: *TextInput) void {
 	self.cursor = null;
 	self.selectionStart = null;

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -322,6 +322,7 @@ pub fn toggleWindow(id: []const u8) void {
 			for(openWindows.items, 0..) |_openWindow, i| {
 				if(_openWindow == window) {
 					_ = openWindows.swapRemove(i);
+					window.onCloseFn();
 					selectedWindow = null;
 					return;
 				}

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -543,27 +543,39 @@ pub fn updateAndRenderGui() void {
 
 pub fn toggleGameMenu() void {
 	main.Window.setMouseGrabbed(!main.Window.grabbed);
-	if(main.Window.grabbed) { // Take of the currently held item stack and close some windows
-		if(inventory.carriedItemStack.item) |item| {
-			inventory.carriedItemStack.amount = main.game.Player.inventory__SEND_CHANGES_TO_SERVER.addItem(item, inventory.carriedItemStack.amount);
-			main.network.Protocols.genericUpdate.sendInventory_full(main.game.world.?.conn, main.game.Player.inventory__SEND_CHANGES_TO_SERVER); // TODO(post-java): Add better options to the protocol.
-			if(inventory.carriedItemStack.amount != 0) {
-				main.network.Protocols.genericUpdate.itemStackDrop(main.game.world.?.conn, inventory.carriedItemStack, @floatCast(main.game.Player.getPosBlocking()), main.game.camera.direction, 20);
-			}
-			inventory.carriedItemStack.clear();
+	if(!main.Window.grabbed)  // Take of the currently held item stack and close some windows
+		return;
+	if(inventory.carriedItemStack.item) |item| {
+		inventory.carriedItemStack.amount = main.game.Player.inventory__SEND_CHANGES_TO_SERVER.addItem(item, inventory.carriedItemStack.amount);
+		main.network.Protocols.genericUpdate.sendInventory_full(main.game.world.?.conn, main.game.Player.inventory__SEND_CHANGES_TO_SERVER); // TODO(post-java): Add better options to the protocol.
+		if(inventory.carriedItemStack.amount != 0) {
+			main.network.Protocols.genericUpdate.itemStackDrop(main.game.world.?.conn, inventory.carriedItemStack, @floatCast(main.game.Player.getPosBlocking()), main.game.camera.direction, 20);
 		}
-		hoveredItemSlot = null;
-		var i: usize = 0;
-		while(i < openWindows.items.len) {
-			const window = openWindows.items[i];
-			if(window.closeIfMouseIsGrabbed) {
-				_ = openWindows.swapRemove(i);
-				window.onCloseFn();
-			} else {
-				i += 1;
-			}
+		inventory.carriedItemStack.clear();
+	}
+	selectedTextInput = null;
+	selectedWindow    = null;
+	hoveredItemSlot   = null;
+	var i: usize = 0;
+	while(i < openWindows.items.len) {
+		const window = openWindows.items[i];
+		if(window.closeIfMouseIsGrabbed) {
+			_ = openWindows.swapRemove(i);
+			window.onCloseFn();
+		} else {
+			i += 1;
 		}
 	}
+}
+pub fn closeGameMenuIfNoNeed() void {
+	if(main.Window.grabbed)
+		return;
+	for(openWindows.items) |_openWindow| {
+		if(_openWindow.gameMenuNeed) {			
+			return;
+		}
+	}
+	toggleGameMenu();
 }
 
 pub const inventory = struct {

--- a/src/gui/windows/chat.zig
+++ b/src/gui/windows/chat.zig
@@ -34,7 +34,7 @@ var history: main.List(*Label) = undefined;
 var expirationTime: main.List(i32) = undefined;
 var historyStart: u32 = 0;
 var fadeOutEnd: u32 = 0;
-var input: *TextInput = undefined;
+pub var input: *TextInput = undefined;
 var hideInput: bool = true;
 
 fn refresh() void {

--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -14,6 +14,7 @@ const VerticalList = GuiComponent.VerticalList;
 const ItemSlot = GuiComponent.ItemSlot;
 
 pub var window = GuiWindow {
+	.gameMenuNeed = true,
 	.relativePosition = .{
 		.{ .attachedToFrame = .{.selfAttachmentPoint = .lower, .otherAttachmentPoint = .lower} },
 		.{ .attachedToFrame = .{.selfAttachmentPoint = .middle, .otherAttachmentPoint = .middle} },

--- a/src/gui/windows/inventory.zig
+++ b/src/gui/windows/inventory.zig
@@ -17,6 +17,7 @@ const ItemSlot = GuiComponent.ItemSlot;
 const hotbar = @import("hotbar.zig");
 
 pub var window = GuiWindow {
+	.gameMenuNeed = true,
 	.relativePosition = .{
 		.{ .attachedToWindow = .{.reference = &hotbar.window, .selfAttachmentPoint = .middle, .otherAttachmentPoint = .middle} },
 		.{ .attachedToWindow = .{.reference = &hotbar.window, .selfAttachmentPoint = .upper, .otherAttachmentPoint = .lower} },

--- a/src/gui/windows/workbench.zig
+++ b/src/gui/windows/workbench.zig
@@ -23,6 +23,7 @@ const inventory = @import("inventory.zig");
 const inventory_crafting = @import("inventory_crafting.zig");
 
 pub var window = GuiWindow {
+	.gameMenuNeed = true,
 	.relativePosition = .{
 		.{ .attachedToWindow = .{.reference = &inventory.window, .selfAttachmentPoint = .middle, .otherAttachmentPoint = .middle} },
 		.{ .attachedToWindow = .{.reference = &inventory.window, .selfAttachmentPoint = .upper, .otherAttachmentPoint = .lower} },

--- a/src/main.zig
+++ b/src/main.zig
@@ -247,21 +247,36 @@ fn ungrabMouse() void {
 		gui.toggleGameMenu();
 	}
 }
+
+fn switchGrabOpenWindow(name:[]const u8) void{
+	if(Window.grabbed){
+		gui.toggleGameMenu();
+		gui.openWindow(name);
+	}else {
+		gui.toggleWindow(name);
+		gui.closeGameMenuIfNoNeed();
+	}
+}
 fn openInventory() void {
 	if(game.world == null) return;
-	gui.toggleGameMenu();
-	gui.openWindow("inventory");
+	switchGrabOpenWindow("inventory");
+	
 }
 fn openWorkbench() void {
 	if(game.world == null) return;
-	gui.toggleGameMenu();
-	gui.openWindow("workbench");
+	switchGrabOpenWindow("workbench");
+
 }
 fn openCreativeInventory() void {
 	if(game.world == null) return;
-	gui.toggleGameMenu();
-	gui.openWindow("creative_inventory");
+	switchGrabOpenWindow("creative_inventory");
 }
+fn openChat() void {
+	if(game.world == null) return;
+	ungrabMouse();
+	gui.windowlist.chat.input.select();
+}
+
 fn takeBackgroundImageFn() void {
 	if(game.world == null) return;
 	renderer.MenuBackGround.takeBackgroundImage();
@@ -301,6 +316,7 @@ pub const KeyBoard = struct {
 
 		// Gui:
 		.{.name = "escape", .key = c.GLFW_KEY_ESCAPE, .releaseAction = &escape},
+		.{.name = "openChat", .key = c.GLFW_KEY_T, .releaseAction = &openChat},
 		.{.name = "openInventory", .key = c.GLFW_KEY_E, .releaseAction = &openInventory},
 		.{.name = "openWorkbench", .key = c.GLFW_KEY_R, .releaseAction = &openWorkbench}, // TODO: Remove
 		.{.name = "openCreativeInventory(aka cheat inventory)", .key = c.GLFW_KEY_C, .releaseAction = &openCreativeInventory},


### PR DESCRIPTION
"T" opens chat.
Gui also works as it used to be, with the added feature, that once all "important" windows are closed, it closes the game menu, i.e.
grabs the mouse, thus satisfying my and Quantums wishes. 
This means, that by double pressing 'c' your return from the create inventory to the game. (if no other window was opened)

fixes #401