### PR TITLE
Change stalagmites to simple structures

### DIFF
--- a/assets/cubyz/biomes/cave/cave.json
+++ b/assets/cubyz/biomes/cave/cave.json
@@ -2,6 +2,8 @@
 	"isCave" : true,
 	"maxHeight" : 0,
 
+	"fogDensity" : 2,
+
 	"music" : "cubyz:heart-of-the-beast",
 
 
@@ -16,6 +18,13 @@
 			"depth" : 3,
 			"smoothness" : 0.1
 		}
+		{
+			"id" : "cubyz:stalagmite",
+			"block" : "cubyz:stone",
+			"chance" : 0.003,
+			"size" : 3,
+			"size_variation" : 6
+		},	
 		{
 			"id" : "cubyz:boulder",
 			"chance" : 0.001,

--- a/assets/cubyz/biomes/cave/marble_cave.json
+++ b/assets/cubyz/biomes/cave/marble_cave.json
@@ -1,14 +1,19 @@
 {
 	"isCave" : true,
 	"maxHeight" : -64,
-	"chance" : 0.2
+	"chance" : 0.2,
 
-	"stalagmites" : 160,
-	"stalagmiteBlock" : "cubyz:marble",
 	"fogDensity" : 10,
 
 	"stoneBlock" : "cubyz:marble",
 	"structures" : [
+	{
+		"id" : "cubyz:stalagmite",
+		"block" : "cubyz:marble",
+		"chance" : 0.007,
+		"size" : 4,
+		"size_variation" : 10
+	},	
 	{
 		"id" : "cubyz:ground_patch",
 		"block" : "cubyz:water",

--- a/assets/cubyz/biomes/cave/stalagmite_cave.json
+++ b/assets/cubyz/biomes/cave/stalagmite_cave.json
@@ -1,13 +1,38 @@
 {
 	"isCave" : true,
-	"maxHeight" : -512,
-
+	"maxHeight" : -256,
 	"chance" : 0.2,
 
+	"fogDensity" : 10,
+	"fogColor" : 0x57575e,
+
 	"caves" : -0.1,
-	"stalagmites" : 160,
 
 	"music" : "cubyz:heart-of-the-beast",
 
-	"stoneBlock" : "cubyz:stone"
+	"structures" : [
+		{
+			"id" : "cubyz:stalagmite",
+			"block" : "cubyz:limestone",
+			"chance" : 0.03,
+			"size" : 4,
+			"size_variation" : 6
+		},	
+		{
+			"id" : "cubyz:stalagmite",
+			"block" : "cubyz:limestone",
+			"chance" : 0.005,
+			"size" : 8,
+			"size_variation" : 12
+		},	
+		{
+			"id" : "cubyz:ground_patch",
+			"block" : "cubyz:limestone",
+			"chance" : 0.003,
+			"width" : 5,
+			"variation" : 6,
+			"depth" : 3,
+			"smoothness" : 1
+		}
+	]
 }


### PR DESCRIPTION
Resolves #562

Also some small unrelated changes:
- Normal caves are slightly foggier
- Normal caves have small stalagmites (rarely)
- Stalagmite caves have limestone ground_patches to emulate flowstone, and to distribute the limestone more evenly throughout the biome (instead of it being only on stalagmites)
- Stalagmite caves max_height raised to -256
- Stalagmite caves have fog