### PR TITLE
Fix some text, add default_background

### DIFF
--- a/src/gui/windows/pause.zig
+++ b/src/gui/windows/pause.zig
@@ -32,7 +32,7 @@ pub fn onOpen() void {
 	}
 	list.add(Button.initText(.{0, 0}, 128, "Settings", gui.openWindowCallback("settings")));
 	list.add(Button.initText(.{0, 0}, 128, "Reorder HUD", .{.callback = &reorderHudCallbackFunction}));
-	list.add(Button.initText(.{0, 0}, 128, "Exit to Menu TODO", .{
+	list.add(Button.initText(.{0, 0}, 128, "Exit World", .{
 		.callback = &exitMenuCallbackFunction,
 	}));
 	list.finish(.center);

--- a/src/gui/windows/save_selection.zig
+++ b/src/gui/windows/save_selection.zig
@@ -137,8 +137,8 @@ pub fn update() void {
 pub fn onOpen() void {
 	buttonNameArena = main.utils.NeverFailingArenaAllocator.init(main.globalAllocator);
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 8);
-	list.add(Button.initText(.{0, 0}, 128, "Create World", gui.openWindowCallback("save_creation")));
-
+	list.add(Label.init(.{0, 0}, width, "**Select World**", .center));
+	list.add(Button.initText(.{0, 0}, 128, "Create New World", gui.openWindowCallback("save_creation")));
 	readingSaves: {
 		var dir = std.fs.cwd().makeOpenPath("saves", .{.iterate = true}) catch |err| {
 			list.add(Label.init(.{0, 0}, 128, "Encountered error while trying to open saves folder:", .center));
@@ -159,7 +159,7 @@ pub fn onOpen() void {
 				const decodedName = parseEscapedFolderName(main.stackAllocator, entry.name);
 				defer main.stackAllocator.free(decodedName);
 				const name = buttonNameArena.allocator().dupeZ(u8, entry.name); // Null terminate, so we can later recover the string from just the pointer.
-				const buttonName = std.fmt.allocPrint(buttonNameArena.allocator().allocator, "Play {s}", .{decodedName}) catch unreachable;
+				const buttonName = std.fmt.allocPrint(buttonNameArena.allocator().allocator, "{s}", .{decodedName}) catch unreachable;
 				
 				row.add(Button.initText(.{0, 0}, 128, buttonName, .{.callback = &openWorldWrap, .arg = @intFromPtr(name.ptr)}));
 				row.add(Button.initIcon(.{8, 0}, .{16, 16}, fileExplorerIcon, false, .{.callback = &openFolder, .arg = @intFromPtr(name.ptr)}));
@@ -169,7 +169,7 @@ pub fn onOpen() void {
 			}
 		}
 	}
-
+	
 	list.finish(.center);
 	window.rootComponent = list.toComponent();
 	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));


### PR DESCRIPTION
When a player boots up Cubyz for the first time, it will look like this:
![image](https://github.com/user-attachments/assets/e830cd41-6293-4dc4-bb94-26e1edf5c5c5)
Which isn't the best first impression. 
Now, with default_background, the player will have a background when playing for the first time.
![image](https://github.com/user-attachments/assets/ece28afb-66b9-49b0-9593-2a51386633a1)
We can change the image itself whenever.

Also removes the "Play" before the world name
![image](https://github.com/user-attachments/assets/6196d936-13c2-4e0a-a3fe-dd12d53e5b9d)
Also removes the "TODO" from the exit button (because... it has been done!)
![image](https://github.com/user-attachments/assets/c71370e2-5b5e-48b0-b4c9-738daee326c6)
