### PR TITLE
Fix overwriteing held item when copying block

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -384,9 +384,10 @@ pub const Player = struct { // MARK: Player
 			for (0..items.itemListSize) |idx|{
 				if (items.itemList[idx].block == block.typ){
 					const item = items.Item {.baseItem = &items.itemList[idx]};
-					if (inventory__SEND_CHANGES_TO_SERVER.items[selectedSlot].item != null) {
+					const slotItem = inventory__SEND_CHANGES_TO_SERVER.items[selectedSlot];
+					if (slotItem.empty() or !std.meta.eql(slotItem.item, item)) {
 						for (0..12) |slotIdx| {
-							if (inventory__SEND_CHANGES_TO_SERVER.items[slotIdx].item == null) {
+							if (inventory__SEND_CHANGES_TO_SERVER.items[slotIdx].empty()) {
 								inventory__SEND_CHANGES_TO_SERVER.items[slotIdx] = items.ItemStack {.item = item, .amount = items.itemList[idx].stackSize};
 								selectedSlot = @intCast(slotIdx);
 								return;

--- a/src/game.zig
+++ b/src/game.zig
@@ -378,13 +378,23 @@ pub const Player = struct { // MARK: Player
 		main.renderer.MeshSelection.breakBlock(&inventory__SEND_CHANGES_TO_SERVER.items[selectedSlot]);
 	}
 
-	pub fn acquireSelectedBlock() void { 
+	pub fn acquireSelectedBlock() void {
 		if (main.renderer.MeshSelection.selectedBlockPos) |selectedPos| {
 			const block = main.renderer.mesh_storage.getBlock(selectedPos[0], selectedPos[1], selectedPos[2]) orelse return;
 			for (0..items.itemListSize) |idx|{
 				if (items.itemList[idx].block == block.typ){
 					const item = items.Item {.baseItem = &items.itemList[idx]};
+					if (inventory__SEND_CHANGES_TO_SERVER.items[selectedSlot].item != null) {
+						for (0..12) |slotIdx| {
+							if (inventory__SEND_CHANGES_TO_SERVER.items[slotIdx].item == null) {
+								inventory__SEND_CHANGES_TO_SERVER.items[slotIdx] = items.ItemStack {.item = item, .amount = items.itemList[idx].stackSize};
+								selectedSlot = @intCast(slotIdx);
+								return;
+							}
+						}
+					}
 					inventory__SEND_CHANGES_TO_SERVER.items[selectedSlot] = items.ItemStack {.item = item, .amount = items.itemList[idx].stackSize};
+					return;
 				}
 			}
 		}

--- a/src/game.zig
+++ b/src/game.zig
@@ -378,7 +378,7 @@ pub const Player = struct { // MARK: Player
 		main.renderer.MeshSelection.breakBlock(&inventory__SEND_CHANGES_TO_SERVER.items[selectedSlot]);
 	}
 
-pub fn acquireSelectedBlock() void {
+	pub fn acquireSelectedBlock() void {
 		if (main.renderer.MeshSelection.selectedBlockPos) |selectedPos| {
 			const block = main.renderer.mesh_storage.getBlock(selectedPos[0], selectedPos[1], selectedPos[2]) orelse return;
 			for (0..items.itemListSize) |idx|{

--- a/src/game.zig
+++ b/src/game.zig
@@ -384,34 +384,35 @@ pub const Player = struct { // MARK: Player
 			for (0..items.itemListSize) |idx|{
 				if (items.itemList[idx].block == block.typ){
 					const item = items.Item {.baseItem = &items.itemList[idx]};
-					const slotItem = inventory__SEND_CHANGES_TO_SERVER.items[selectedSlot];
-					if (slotItem.empty() or !std.meta.eql(slotItem.item, item)) {
-						var isDone = false;
-
-						// First check if there is already a slot with that type of item
-						for (0..12) |slotIdx| {
-							if (std.meta.eql(inventory__SEND_CHANGES_TO_SERVER.items[slotIdx].item, item)) {
-								inventory__SEND_CHANGES_TO_SERVER.items[slotIdx] = items.ItemStack {.item = item, .amount = items.itemList[idx].stackSize};
-								selectedSlot = @intCast(slotIdx);
-								isDone = true;
-								break;
-							}
+					var isDone = false;
+					
+					// Check if there is already a slot with that item type
+					for (0..12) |slotIdx| {
+						if (std.meta.eql(inventory__SEND_CHANGES_TO_SERVER.items[slotIdx].item, item)) {
+							inventory__SEND_CHANGES_TO_SERVER.items[slotIdx] = items.ItemStack {.item = item, .amount = items.itemList[idx].stackSize};
+							selectedSlot = @intCast(slotIdx);
+							isDone = true;
+							break;
 						}
-						if (isDone) break;
-
-						// And if there was no item with the same type, look for an empty slot
-						for (0..12) |slotIdx| {
-							if (inventory__SEND_CHANGES_TO_SERVER.items[slotIdx].empty()) {
-								inventory__SEND_CHANGES_TO_SERVER.items[slotIdx] = items.ItemStack {.item = item, .amount = items.itemList[idx].stackSize};
-								selectedSlot = @intCast(slotIdx);
-								isDone = true;
-								break;
-							}
-						}
-						if (isDone) break;
-
-						// And if none of that worked, just replace the current slot
 					}
+					if (isDone) break;
+
+					if (inventory__SEND_CHANGES_TO_SERVER.items[selectedSlot].empty()) {
+						inventory__SEND_CHANGES_TO_SERVER.items[selectedSlot] = items.ItemStack {.item = item, .amount = items.itemList[idx].stackSize};
+						break;
+					}
+					
+					// Look for an empty slot
+					for (0..12) |slotIdx| {
+						if (inventory__SEND_CHANGES_TO_SERVER.items[slotIdx].empty()) {
+							inventory__SEND_CHANGES_TO_SERVER.items[slotIdx] = items.ItemStack {.item = item, .amount = items.itemList[idx].stackSize};
+							selectedSlot = @intCast(slotIdx);
+							isDone = true;
+							break;
+						}
+					}
+					if (isDone) break;
+
 					inventory__SEND_CHANGES_TO_SERVER.items[selectedSlot] = items.ItemStack {.item = item, .amount = items.itemList[idx].stackSize};
 					break;
 				}


### PR DESCRIPTION
When you middle click a block and your selected slot has an item. Instead of overwriting it the block will get added to the first empty slot in the hotbar and it will move the selected slot to the slot, and if you have no open slots in your hotbar it will just overwrite the selected slot.