### PR TITLE
Fix issues with check_format.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ sudo apt install libgl-dev libasound2-dev libx11-dev libxcursor-dev libxrandr-de
 
 # Contributing
 ### Code
-Try to follow the style of the existing code. The `check_format.py` file can be used to find violations of indentation and line endings. `// TODO: Add a full style guide` <br>
+Try to follow the style of the existing code. The `format_check.py` file can be used to find violations of indentation and line endings. `// TODO: Add a full style guide` <br>
 If you have any more questions, you can ask them over on [Discord](https://discord.gg/XtqCRRG).
 ### Textures
 If you want to add new textures, make sure they fit the style of the game. It's recommended that you have baseline skills in pixel art before attempting to make textures. A great collection of tutorials can be found [here](https://lospec.com/pixel-art-tutorials)

--- a/format_check.py
+++ b/format_check.py
@@ -10,11 +10,11 @@ for subdir, dirs, files in os.walk("."):
 	for file in files:
 		#print os.path.join(subdir, file)
 		filepath = subdir + os.sep + file
-		if filepath.startswith("./compiler"): continue
-		if filepath.startswith("./saves"): continue
-		if filepath.startswith("./serverAssets"): continue
-		if filepath.startswith("./zig-cache"): continue
-		if filepath.startswith("./.zig-cache"): continue
+		if filepath.startswith(f".{os.sep}compiler"): continue
+		if filepath.startswith(f".{os.sep}saves"): continue
+		if filepath.startswith(f".{os.sep}serverAssets"): continue
+		if filepath.startswith(f".{os.sep}zig-cache"): continue
+		if filepath.startswith(f".{os.sep}.zig-cache"): continue
 
 		if filepath.endswith(".json") or filepath.endswith(".zig") or filepath.endswith(".py") or filepath.endswith(".zon") or filepath.endswith(".vs") or filepath.endswith(".fs") or filepath.endswith(".glsl"):
 			with open(filepath, "r", newline = '') as f:

--- a/format_check.py
+++ b/format_check.py
@@ -17,7 +17,7 @@ for subdir, dirs, files in os.walk("."):
 		if filepath.startswith(f".{os.sep}.zig-cache"): continue
 
 		if filepath.endswith(".json") or filepath.endswith(".zig") or filepath.endswith(".py") or filepath.endswith(".zon") or filepath.endswith(".vs") or filepath.endswith(".fs") or filepath.endswith(".glsl"):
-			with open(filepath, "r", newline = '') as f:
+			with open(filepath, "r", newline = '', encoding="utf-8") as f:
 				string = f.read()
 				line = 1
 				lineStart = True


### PR DESCRIPTION
Fixes the following issues:
- os.walk uses os.sep in their filepaths, so on windows no folders were ignored.
- Some files like Boulder.zig use non-ascii symbols in their comments. The default open encoding on windows is your locale's ANSI codepage, and therefore caused an exception.
- The project readme incorrectly referred to the file as check_format.py. I renamed the documentation rather than the file in case somebody is using it in their workflow. 