### PR TITLE
Reset fadeOutEnd when chat lists are created.

### DIFF
--- a/src/gui/windows/chat.zig
+++ b/src/gui/windows/chat.zig
@@ -73,6 +73,7 @@ pub fn onOpen() void {
 	expirationTime = main.List(i32).init(main.globalAllocator);
 	messageQueue = main.List([]const u8).init(main.globalAllocator);
 	historyStart = 0;
+	fadeOutEnd = 0;
 	input = TextInput.init(.{0, 0}, 256, 32, "", .{.callback = &sendMessage});
 	refresh();
 }


### PR DESCRIPTION
Fixes crash when reentering world in singleplayer after a chat message has faded out. Fixes error mentioned in https://github.com/PixelGuys/Cubyz/issues/649#issuecomment-2327506297, but does not affect #649