### PR TITLE
Fixed radius of peak and slope6 being too large.

### DIFF
--- a/assets/cubyz/biomes/tall_mountain/peak.json
+++ b/assets/cubyz/biomes/tall_mountain/peak.json
@@ -2,7 +2,7 @@
 	"properties" : [
 		"mountain"
 	],
-	"radius" : 60,
+	"radius" : 40,
 	"minHeight" : 864,
 	"maxHeight" : 864,
 

--- a/assets/cubyz/biomes/tall_mountain/slope6.json
+++ b/assets/cubyz/biomes/tall_mountain/slope6.json
@@ -2,7 +2,7 @@
 	"properties" : [
 		"mountain"
 	],
-	"radius" : 90,
+	"radius" : 80,
 	"minHeight" : 768,
 	"maxHeight" : 768,
 


### PR DESCRIPTION
Log kept getting spammed by these two lines during generation:
```
[warning]: SubBiome cubyz:tall_mountain/slope5 of cubyz:tall_mountain/slope4 is too big
[warning]: SubBiome cubyz:tall_mountain/peak of cubyz:tall_mountain/slope6 is too big
```