### PR TITLE
Don't convert dotfiles to ZON, which may include editor configurations.

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -435,7 +435,7 @@ pub fn convertJsonToZon(jsonPath: []const u8) void { // TODO: Remove after #480
 	var zonString = List(u8).init(stackAllocator);
 	defer zonString.deinit();
 	std.log.debug("{s}", .{jsonString});
-
+	
 	var i: usize = 0;
 	while(i < jsonString.len) : (i += 1) {
 		switch(jsonString[i]) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -407,17 +407,13 @@ fn isHiddenOrParentHiddenPosix(path: []const u8) bool {
 		std.log.err("Cannot iterate on path {s}: {s}!", .{path, @errorName(err)});
 		return false;
 	};
-	var componentMaybe = iter.next();
-	while (componentMaybe != null) {
-		if (componentMaybe) |component| {
-			if (std.mem.eql(u8, component.name, ".") or std.mem.eql(u8, component.name, "..")) {
-				continue;
-			}
-			if (component.name.len > 0 and component.name[0] == '.') {
-				return true;
-			}
+	while (iter.next()) |component| {
+		if (std.mem.eql(u8, component.name, ".") or std.mem.eql(u8, component.name, "..")) {
+			continue;
 		}
-		componentMaybe = iter.next();
+		if (component.name.len > 0 and component.name[0] == '.') {
+			return true;
+		}
 	}
 	return false;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -402,6 +402,7 @@ fn isValidIdentifierName(str: []const u8) bool { // TODO: Remove after #480
 	}
 	return true;
 }
+
 fn isHiddenOrParentHiddenPosix(path: []const u8) bool {
 	var iter = std.fs.path.componentIterator(path) catch |err| {
 		std.log.err("Cannot iterate on path {s}: {s}!", .{path, @errorName(err)});


### PR DESCRIPTION
This means that configurations specific to this workspace in editors don't get overwritten, which prevents accidental formatting errors whenever the game is tested.
This was affecting me when working on my PR, as I tend to run the start scripts to make sure the game compiles, and that my changes worked.