### PR TITLE
Make creative menu 10 slots wide

### DIFF
--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -55,7 +55,7 @@ pub fn onOpen() void {
 	var i: u32 = 0;
 	while(i < items.items.len) {
 		const row = HorizontalList.init();
-		for(0..8) |_| {
+		for(0..10) |_| {
 			if(i >= items.items.len) break;
 			row.add(ItemSlot.init(.{0, 0}, inventory, i, .default, .takeOnly));
 			i += 1;


### PR DESCRIPTION
In lieu of proper creative menu UX. 
Makes it the same width as the inventory, and cuts down on the amount of scrolling to do.
![image](https://github.com/user-attachments/assets/22f1ad22-7d14-49f4-b16b-f7a1df9bd1b4)
