### PR TITLE
Increase FOV when moving fast (Issue#716)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -332,6 +332,7 @@ pub const Player = struct { // MARK: Player
 	pub var eyeVel: Vec3d = .{0, 0, 0};
 	pub var eyeCoyote: f64 = 0;
 	pub var eyeStep: @Vector(3, bool) = .{false, false, false};
+	pub var fovMod: f32 = 0;
 	pub var id: u32 = 0;
 	pub var gamemode: Atomic(Gamemode) = .init(.creative);
 	pub var isFlying: Atomic(bool) = .init(false);
@@ -399,6 +400,12 @@ pub const Player = struct { // MARK: Player
 		mutex.lock();
 		defer mutex.unlock();
 		return eyeCoyote;
+	}
+
+	pub fn getFovModifierBlocking() f32 {
+		mutex.lock();
+		defer mutex.unlock();
+		return fovMod;
 	}
 
 	pub fn setGamemode(newGamemode: Gamemode) void {
@@ -703,6 +710,9 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 		// At equillibrium we want to have dv/dt = a - λv = 0 → a = λ*v
 		const fricMul = speedMultiplier*baseFrictionCoefficient;
 
+		const MaxSpeedWalking: f64 = 4;
+		const MaxSpeedRunning: f64 = 8;
+
 		const forward = vec.rotateZ(Vec3d{0, 1, 0}, -camera.rotation[2]);
 		const right = Vec3d{-forward[1], forward[0], 0};
 		var movementDir: Vec3d = .{0, 0, 0};
@@ -717,25 +727,25 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 						movementSpeed = @max(movementSpeed, 32)*KeyBoard.key("forward").value;
 						movementDir += forward*@as(Vec3d, @splat(32*KeyBoard.key("forward").value));
 					} else {
-						movementSpeed = @max(movementSpeed, 8)*KeyBoard.key("forward").value;
-						movementDir += forward*@as(Vec3d, @splat(8*KeyBoard.key("forward").value));
+						movementSpeed = @max(movementSpeed, MaxSpeedRunning)*KeyBoard.key("forward").value;
+						movementDir += forward*@as(Vec3d, @splat(MaxSpeedRunning*KeyBoard.key("forward").value));
 					}
 				} else {
-					movementSpeed = @max(movementSpeed, 4)*KeyBoard.key("forward").value;
-					movementDir += forward*@as(Vec3d, @splat(4*KeyBoard.key("forward").value));
+					movementSpeed = @max(movementSpeed, MaxSpeedWalking)*KeyBoard.key("forward").value;
+					movementDir += forward*@as(Vec3d, @splat(MaxSpeedWalking*KeyBoard.key("forward").value));
 				}
 			}
 			if(KeyBoard.key("backward").value > 0.0) {
-				movementSpeed = @max(movementSpeed, 4)*KeyBoard.key("backward").value;
-				movementDir += forward*@as(Vec3d, @splat(-4*KeyBoard.key("backward").value));
+				movementSpeed = @max(movementSpeed, MaxSpeedWalking)*KeyBoard.key("backward").value;
+				movementDir += forward*@as(Vec3d, @splat(-MaxSpeedWalking*KeyBoard.key("backward").value));
 			}
 			if(KeyBoard.key("left").value > 0.0) {
-				movementSpeed = @max(movementSpeed, 4*KeyBoard.key("left").value);
-				movementDir += right*@as(Vec3d, @splat(4*KeyBoard.key("left").value));
+				movementSpeed = @max(movementSpeed, MaxSpeedWalking*KeyBoard.key("left").value);
+				movementDir += right*@as(Vec3d, @splat(MaxSpeedWalking*KeyBoard.key("left").value));
 			}
 			if(KeyBoard.key("right").value > 0.0) {
-				movementSpeed = @max(movementSpeed, 4*KeyBoard.key("right").value);
-				movementDir += right*@as(Vec3d, @splat(-4*KeyBoard.key("right").value));
+				movementSpeed = @max(movementSpeed, MaxSpeedWalking*KeyBoard.key("right").value);
+				movementDir += right*@as(Vec3d, @splat(-MaxSpeedWalking*KeyBoard.key("right").value));
 			}
 			if(KeyBoard.key("jump").pressed) {
 				if(Player.isFlying.load(.monotonic)) {
@@ -894,6 +904,25 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 			Player.eyeVel[i] = firstTerm.mul(c_3.negate().subScalar(frictionCoefficient).mulScalar(0.5)).add(secondTerm.mul((c_3.subScalar(frictionCoefficient)).mulScalar(0.5))).val[0];
 			Player.eyePos[i] += firstTerm.add(secondTerm).addScalar(a/k).val[0];
 		}
+
+		// Calculate our FOV modifier based on our current speed.
+		{
+			const fovModStartSpeed: f32 = @as(f32, @floatCast(MaxSpeedWalking));
+			const fovModEndSpeed: f32 = @as(f32, @floatCast(MaxSpeedRunning));
+
+			// Clamped between 0-1. We'll let the renderer decide what the acual FOV values are
+			const fovModGoal : f32 =  std.math.clamp((@as(f32, @floatCast(movementSpeed)) - fovModStartSpeed) / (fovModEndSpeed - fovModStartSpeed), 0, 1);
+			const fovModDir: f32 = if(Player.fovMod < fovModGoal) 1 else -1;
+			const fovModNext: f32 = Player.fovMod + (fovModDir * @as(f32, @floatCast(deltaTime)) * 5.0);
+
+			if((Player.fovMod < fovModGoal and fovModNext < fovModGoal) or (Player.fovMod > fovModGoal and fovModNext > fovModGoal)) {
+				Player.fovMod = fovModNext;
+			} else {
+				Player.fovMod = fovModGoal;	
+			}
+			
+			main.renderer.updateFovModifier(Player.fovMod);
+		} 
 	}
 
 	const time = std.time.milliTimestamp();


### PR DESCRIPTION
Picked up this issue: https://github.com/PixelGuys/Cubyz/issues/716

I added a smooth FOV transition when the player goes from walking to sprinting, and vice-versa., 

This is a draft PR, because I am unsure if: 
- The player should directly tell the renderer to change fov (as it does now), or
- The renderer polls with the player what the current FOV modifier is (probably better?)

I think it should probably be the second, especially because the FOV vs FOVExtra in the renderer file is a little awkward. 