### PR TITLE
[WIP] Revamp the procedural crafting system.

### DIFF
--- a/src/gui/windows/workbench.zig
+++ b/src/gui/windows/workbench.zig
@@ -41,6 +41,10 @@ var seed: u32 = undefined;
 
 var itemSlots: [25]*ItemSlot = undefined;
 
+fn toggleTool(_: usize) void {
+
+}
+
 pub fn onOpen() void {
 	seed = @truncate(@as(u128, @bitCast(std.time.nanoTimestamp())));
 	inv = Inventory.init(main.globalAllocator, 26, .workbench, .other);
@@ -61,8 +65,17 @@ pub fn onOpen() void {
 		grid.finish(.center);
 		list.add(grid);
 	}
-	list.add(Icon.init(.{8, 0}, .{32, 32}, inventory_crafting.arrowTexture, false));
-	list.add(ItemSlot.init(.{8, 0}, inv, 25, .craftingResult, .takeOnly));
+	const verticalThing = VerticalList.init(.{0, 0}, 300, padding);
+	verticalThing.add(Button.initText(.{8, 0}, 104, "Test", .{.callback = &toggleTool}));
+	const buttonHeight = verticalThing.size[1];
+	const craftingResultList = HorizontalList.init();
+	craftingResultList.add(Icon.init(.{0, 0}, .{32, 32}, inventory_crafting.arrowTexture, false));
+	craftingResultList.add(ItemSlot.init(.{8, 0}, inv, 25, .craftingResult, .takeOnly));
+	craftingResultList.finish(.{padding, padding}, .center);
+	verticalThing.add(craftingResultList);
+	verticalThing.size[1] += buttonHeight + 2*padding; // Centering the thing
+	verticalThing.finish(.center);
+	list.add(verticalThing);
 	list.finish(.{padding, padding + 16}, .center);
 	window.rootComponent = list.toComponent();
 	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));


### PR DESCRIPTION
- [x] Add a button (WOOOOO! Progress!)
- [ ] Load a list of tool types from the assets
- [ ] Use the button to toggle between the available tool types
- [ ] Store the selected tool type in the inventory and sync it with the server (make sure the button displays the right thing)
  - [ ] How should it be sent to the server? By numerical id with a palette, or directly as a string?
  - [ ] What should happen if the player clicks the button while something is in the crafting grid? Should it just reject it so we don't have to deal with the problems?
- [ ] Support adding properties to each slot (source property of material, destination property of the tool and factor), which get added together to form the tool stats
- [ ] Support disabling slots(can't place items there), or making them mandatory(can't craft if empty).
- [ ] Support selecting which blocks it can mine.
- [ ] Add the base tools (axe, pickaxe, shovel)
- [ ] Support for tool textures to allow more control over the procedural generation (these should allow the artist to say which pixel corresponds to which slot using a color coding theme)
- [ ] cleanup

fixes #594
fixes #238
fixes #947 
progress towards #89
progress towards #625 