### PR TITLE
Raise default stackSize to 120

### DIFF
--- a/src/items.zig
+++ b/src/items.zig
@@ -94,7 +94,7 @@ pub const BaseItem = struct { // MARK: BaseItem
 			};
 		}
 		self.name = allocator.dupe(u8, zon.get([]const u8, "name", id));
-		self.stackSize = zon.get(u16, "stackSize", 64);
+		self.stackSize = zon.get(u16, "stackSize", 120);
 		const material = zon.getChild("material");
 		if(material == .object) {
 			self.material = Material{};


### PR DESCRIPTION
I saw Quantum suggest this number a few weeks ago. 
Obviously, a larger stack size lets you carry more stuff. It also leads to less slots of the same item (ex. 4 slots of stone -> 2 slots of stone)

I tried it in survival for a little while and it felt nice. I was able to keep my torches in one slot, for example.
![image](https://github.com/user-attachments/assets/aa0edfda-20a8-412f-aa1d-93af2034d136)
