### PR TITLE
Add block touch detection

### DIFF
--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -380,7 +380,7 @@ pub const Block = packed struct { // MARK: Block
 	pub fn canBeChangedInto(self: Block, newBlock: Block, item: main.items.ItemStack, shouldDropSourceBlockOnSuccess: *bool) main.rotation.RotationMode.CanBeChangedInto {
 		return newBlock.mode().canBeChangedInto(self, newBlock, item, shouldDropSourceBlockOnSuccess);
 	}
-	
+
 	pub fn onTouchedBy(self: Block, entity: main.server.Entity, position: Vec3i, neighbor: Neighbor) void {
 		_ = self;
 		_ = entity;

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -13,6 +13,7 @@ const items = @import("items.zig");
 const models = @import("models.zig");
 const rotation = @import("rotation.zig");
 const RotationMode = rotation.RotationMode;
+const Vec3i = @import("vec.zig").Vec3i;
 
 pub const BlockTag = enum(u32) {
 	air = 0,

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -379,6 +379,13 @@ pub const Block = packed struct { // MARK: Block
 	pub fn canBeChangedInto(self: Block, newBlock: Block, item: main.items.ItemStack, shouldDropSourceBlockOnSuccess: *bool) main.rotation.RotationMode.CanBeChangedInto {
 		return newBlock.mode().canBeChangedInto(self, newBlock, item, shouldDropSourceBlockOnSuccess);
 	}
+	
+	pub fn onTouchedBy(self: Block, entity: main.server.Entity, position: Vec3i, neighbor: Neighbor) void {
+		_ = self;
+		_ = entity;
+		_ = position;
+		_ = neighbor;
+	}
 };
 
 

--- a/src/game.zig
+++ b/src/game.zig
@@ -782,9 +782,9 @@ fn touchBlocksFromDirection(entity: main.server.Entity, hitBox: collision.Box, u
 		while (rel[1] != relMax[1]) {
 			rel[1] = @min(rel[1] + 1.0, relMax[1]);
 			var blockPos: Vec3i = undefined;
-			blockPos[swizzle[0]] = @intFromFloat(entity.pos[swizzle[0]] + rel[0]);
-			blockPos[swizzle[1]] = @intFromFloat(entity.pos[swizzle[1]] + rel[1]);
-			blockPos[swizzle[2]] = @intFromFloat(entity.pos[swizzle[2]] + uniformZ);
+			blockPos[swizzle[0]] = @intFromFloat(@floor(entity.pos[swizzle[0]] + rel[0]));
+			blockPos[swizzle[1]] = @intFromFloat(@floor(entity.pos[swizzle[1]] + rel[1]));
+			blockPos[swizzle[2]] = @intFromFloat(@floor(entity.pos[swizzle[2]] + uniformZ));
 			var isUnique: bool = true;
 			for (blockPosList.items) |blockPosElement| {
 				if (std.meta.eql(blockPos, blockPosElement)) {

--- a/src/game.zig
+++ b/src/game.zig
@@ -20,11 +20,14 @@ const Vec3f = vec.Vec3f;
 const Vec4f = vec.Vec4f;
 const Vec3d = vec.Vec3d;
 const Mat4f = vec.Mat4f;
+const Vec3i = vec.Vec3i;
 const graphics = @import("graphics.zig");
 const models = main.models;
 const Fog = graphics.Fog;
 const renderer = @import("renderer.zig");
 const settings = @import("settings.zig");
+const List = @import("utils/list.zig").List;
+const Block = @import("blocks.zig").Block;
 
 pub const camera = struct { // MARK: camera
 	pub var rotation: Vec3f = Vec3f{0, 0, 0};
@@ -803,13 +806,13 @@ fn touchBlocksFromDirection(entity: main.server.Entity, hitBox: collision.Box, u
 	blockPosList.deinit();
 }
 
-fn touchBlocks(entity: main.server.Entity, hitBox: collision.Box) {
-	touchBlocksFromDirection(entity, hitBox, hitBox.max[2] + touchOffset, {0, 1, 2}, chunk.Neighbor.dirUp);
-	touchBlocksFromDirection(entity, hitBox, hitBox.min[2] - touchOffset, {0, 1, 2}, chunk.Neighbor.dirDown);
-	touchBlocksFromDirection(entity, hitBox, hitBox.max[0] + touchOffset, {1, 2, 0}, chunk.Neighbor.dirPosX);
-	touchBlocksFromDirection(entity, hitBox, hitBox.min[0] - touchOffset, {1, 2, 0}, chunk.Neighbor.dirNegX);
-	touchBlocksFromDirection(entity, hitBox, hitBox.max[1] + touchOffset, {0, 2, 1}, chunk.Neighbor.dirPosY);
-	touchBlocksFromDirection(entity, hitBox, hitBox.min[1] - touchOffset, {0, 2, 1}, chunk.Neighbor.dirNegY);
+fn touchBlocks(entity: main.server.Entity, hitBox: collision.Box) void {
+	touchBlocksFromDirection(entity, hitBox, hitBox.max[2] + touchOffset, Vec3i {0, 1, 2}, chunk.Neighbor.dirUp);
+	touchBlocksFromDirection(entity, hitBox, hitBox.min[2] - touchOffset, Vec3i {0, 1, 2}, chunk.Neighbor.dirDown);
+	touchBlocksFromDirection(entity, hitBox, hitBox.max[0] + touchOffset, Vec3i {1, 2, 0}, chunk.Neighbor.dirPosX);
+	touchBlocksFromDirection(entity, hitBox, hitBox.min[0] - touchOffset, Vec3i {1, 2, 0}, chunk.Neighbor.dirNegX);
+	touchBlocksFromDirection(entity, hitBox, hitBox.max[1] + touchOffset, Vec3i {0, 2, 1}, chunk.Neighbor.dirPosY);
+	touchBlocksFromDirection(entity, hitBox, hitBox.min[1] - touchOffset, Vec3i {0, 2, 1}, chunk.Neighbor.dirNegY);
 }
 
 pub fn update(deltaTime: f64) void { // MARK: update()


### PR DESCRIPTION
I have added a function in `blocks.zig` that runs every time a block is touched. This is one step towards making cacti prickly and lava hot as requested by ikabod in Issue #1081. Note that this system does not support incomplete blocks yet.