### PR TITLE
Remove unused `readAllFilesInAddons` function from `assets.zig`

### DIFF
--- a/src/assets.zig
+++ b/src/assets.zig
@@ -158,34 +158,6 @@ pub fn readAllZonFilesInAddons(
 		}
 	}
 }
-/// Reads text files recursively from all subfolders.
-pub fn readAllFilesInAddons(externalAllocator: NeverFailingAllocator, addons: main.List(std.fs.Dir), subPath: []const u8, output: *main.List([]const u8)) void {
-	for(addons.items) |addon| {
-		var dir = addon.openDir(subPath, .{.iterate = true}) catch |err| {
-			if(err != error.FileNotFound) {
-				std.log.err("Could not open addon directory {s}: {s}", .{subPath, @errorName(err)});
-			}
-			continue;
-		};
-		defer dir.close();
-
-		var walker = dir.walk(main.stackAllocator.allocator) catch unreachable;
-		defer walker.deinit();
-
-		while(walker.next() catch |err| blk: {
-			std.log.err("Got error while iterating addon directory {s}: {s}", .{subPath, @errorName(err)});
-			break :blk null;
-		}) |entry| {
-			if(entry.kind == .file) {
-				const string = dir.readFileAlloc(externalAllocator.allocator, entry.path, std.math.maxInt(usize)) catch |err| {
-					std.log.err("Could not open {s}/{s}: {s}", .{subPath, entry.path, @errorName(err)});
-					continue;
-				};
-				output.append(string);
-			}
-		}
-	}
-}
 
 /// Reads obj files recursively from all subfolders.
 pub fn readAllObjFilesInAddonsHashmap(


### PR DESCRIPTION
This could probably have a conflict with #1125, just in case it should be merged after if at all.

I would wait for #1125 myself, but I am worried I will eventually forget to create this PR, so I am making it now.