### PR TITLE
Add biome migrations to mitigate damage after biome renames

### DIFF
--- a/src/assets.zig
+++ b/src/assets.zig
@@ -11,11 +11,11 @@ const NeverFailingAllocator = main.utils.NeverFailingAllocator;
 var arena: main.utils.NeverFailingArenaAllocator = undefined;
 var arenaAllocator: NeverFailingAllocator = undefined;
 var commonBlocks: std.StringHashMap(ZonElement) = undefined;
-var commonBlocksMigrations: std.StringHashMap(ZonElement) = undefined;
+var commonBlockMigrations: std.StringHashMap(ZonElement) = undefined;
 var commonItems: std.StringHashMap(ZonElement) = undefined;
 var commonTools: std.StringHashMap(ZonElement) = undefined;
 var commonBiomes: std.StringHashMap(ZonElement) = undefined;
-var commonBiomesMigrations: std.StringHashMap(ZonElement) = undefined;
+var commonBiomeMigrations: std.StringHashMap(ZonElement) = undefined;
 var commonRecipes: std.StringHashMap(ZonElement) = undefined;
 var commonModels: std.StringHashMap([]const u8) = undefined;
 
@@ -26,11 +26,11 @@ pub fn init() void {
 	arena = .init(main.globalAllocator);
 	arenaAllocator = arena.allocator();
 	commonBlocks = .init(arenaAllocator.allocator);
-	commonBlocksMigrations = .init(arenaAllocator.allocator);
+	commonBlockMigrations = .init(arenaAllocator.allocator);
 	commonItems = .init(arenaAllocator.allocator);
 	commonTools = .init(arenaAllocator.allocator);
 	commonBiomes = .init(arenaAllocator.allocator);
-	commonBiomesMigrations = .init(arenaAllocator.allocator);
+	commonBiomeMigrations = .init(arenaAllocator.allocator);
 	commonRecipes = .init(arenaAllocator.allocator);
 	commonModels = .init(arenaAllocator.allocator);
 
@@ -38,18 +38,18 @@ pub fn init() void {
 		arenaAllocator,
 		"assets/",
 		&commonBlocks,
-		&commonBlocksMigrations,
+		&commonBlockMigrations,
 		&commonItems,
 		&commonTools,
 		&commonBiomes,
-		&commonBlocksMigrations,
+		&commonBlockMigrations,
 		&commonRecipes,
 		&commonModels,
 	);
 
 	std.log.info(
 		"Finished assets init with {} blocks ({} migrations), {} items, {} tools. {} biomes ({} migrations), {} recipes",
-		.{commonBlocks.count(), commonBlocksMigrations.count(), commonItems.count(), commonTools.count(), commonBiomes.count(), commonBiomesMigrations.count(), commonRecipes.count()},
+		.{commonBlocks.count(), commonBlockMigrations.count(), commonItems.count(), commonTools.count(), commonBiomes.count(), commonBiomeMigrations.count(), commonRecipes.count()},
 	);
 }
 
@@ -214,11 +214,11 @@ pub fn readAssets(
 	externalAllocator: NeverFailingAllocator,
 	assetPath: []const u8,
 	blocks: *std.StringHashMap(ZonElement),
-	blocksMigrations: *std.StringHashMap(ZonElement),
+	blockMigrations: *std.StringHashMap(ZonElement),
 	items: *std.StringHashMap(ZonElement),
 	tools: *std.StringHashMap(ZonElement),
 	biomes: *std.StringHashMap(ZonElement),
-	biomesMigrations: *std.StringHashMap(ZonElement),
+	biomeMigrations: *std.StringHashMap(ZonElement),
 	recipes: *std.StringHashMap(ZonElement),
 	models: *std.StringHashMap([]const u8),
 ) void {
@@ -252,10 +252,10 @@ pub fn readAssets(
 		main.stackAllocator.free(addonName);
 	};
 
-	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "blocks", true, blocks, blocksMigrations);
+	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "blocks", true, blocks, blockMigrations);
 	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "items", true, items, null);
 	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "tools", true, tools, null);
-	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "biomes", true, biomes, biomesMigrations);
+	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "biomes", true, biomes, biomeMigrations);
 	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "recipes", false, recipes, null);
 	readAllObjFilesInAddonsHashmap(externalAllocator, addons, addonNames, "models", models);
 }
@@ -361,16 +361,16 @@ pub fn loadWorldAssets(assetFolder: []const u8, blockPalette: *Palette, biomePal
 
 	var blocks = commonBlocks.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
 	defer blocks.clearAndFree();
-	var blocksMigrations = commonBlocksMigrations.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
-	defer blocksMigrations.clearAndFree();
+	var blockMigrations = commonBlockMigrations.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
+	defer blockMigrations.clearAndFree();
 	var items = commonItems.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
 	defer items.clearAndFree();
 	var tools = commonTools.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
 	defer tools.clearAndFree();
 	var biomes = commonBiomes.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
 	defer biomes.clearAndFree();
-	var biomesMigrations = commonBiomesMigrations.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
-	defer biomesMigrations.clearAndFree();
+	var biomeMigrations = commonBiomeMigrations.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
+	defer biomeMigrations.clearAndFree();
 	var recipes = commonRecipes.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
 	defer recipes.clearAndFree();
 	var models = commonModels.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
@@ -380,20 +380,20 @@ pub fn loadWorldAssets(assetFolder: []const u8, blockPalette: *Palette, biomePal
 		arenaAllocator,
 		assetFolder,
 		&blocks,
-		&blocksMigrations,
+		&blockMigrations,
 		&items,
 		&tools,
 		&biomes,
-		&biomesMigrations,
+		&biomeMigrations,
 		&recipes,
 		&models,
 	);
 	errdefer unloadAssets();
 
-	migrations_zig.registerBlockMigrations(&blocksMigrations);
+	migrations_zig.registerBlockMigrations(&blockMigrations);
 	migrations_zig.applyBlockPaletteMigrations(blockPalette);
 
-	migrations_zig.registerBiomeMigrations(&biomesMigrations);
+	migrations_zig.registerBiomeMigrations(&biomeMigrations);
 	migrations_zig.applyBiomePaletteMigrations(biomePalette);
 
 	// models:
@@ -486,7 +486,7 @@ pub fn loadWorldAssets(assetFolder: []const u8, blockPalette: *Palette, biomePal
 
 	std.log.info(
 		"Finished registering assets with {} blocks ({} migrations), {} items {} tools. {} biomes ({} migrations), {} recipes and {} models",
-		.{blocks.count(), blocksMigrations.count(), items.count(), tools.count(), biomes.count(), biomesMigrations.count(), recipes.count(), models.count()},
+		.{blocks.count(), blockMigrations.count(), items.count(), tools.count(), biomes.count(), biomeMigrations.count(), recipes.count(), models.count()},
 	);
 }
 

--- a/src/assets.zig
+++ b/src/assets.zig
@@ -394,7 +394,7 @@ pub fn loadWorldAssets(assetFolder: []const u8, blockPalette: *Palette, biomePal
 	migrations_zig.applyBlockPaletteMigrations(blockPalette);
 
 	migrations_zig.registerBiomeMigrations(&biomesMigrations);
-	migrations_zig.applyBiomePaletteMigrations(blockPalette);
+	migrations_zig.applyBiomePaletteMigrations(biomePalette);
 
 	// models:
 	var modelIterator = models.iterator();

--- a/src/assets.zig
+++ b/src/assets.zig
@@ -12,9 +12,10 @@ var arena: main.utils.NeverFailingArenaAllocator = undefined;
 var arenaAllocator: NeverFailingAllocator = undefined;
 var commonBlocks: std.StringHashMap(ZonElement) = undefined;
 var commonBlocksMigrations: std.StringHashMap(ZonElement) = undefined;
-var commonBiomes: std.StringHashMap(ZonElement) = undefined;
 var commonItems: std.StringHashMap(ZonElement) = undefined;
 var commonTools: std.StringHashMap(ZonElement) = undefined;
+var commonBiomes: std.StringHashMap(ZonElement) = undefined;
+var commonBiomesMigrations: std.StringHashMap(ZonElement) = undefined;
 var commonRecipes: std.StringHashMap(ZonElement) = undefined;
 var commonModels: std.StringHashMap([]const u8) = undefined;
 
@@ -29,6 +30,7 @@ pub fn init() void {
 	commonItems = .init(arenaAllocator.allocator);
 	commonTools = .init(arenaAllocator.allocator);
 	commonBiomes = .init(arenaAllocator.allocator);
+	commonBiomesMigrations = .init(arenaAllocator.allocator);
 	commonRecipes = .init(arenaAllocator.allocator);
 	commonModels = .init(arenaAllocator.allocator);
 
@@ -40,13 +42,14 @@ pub fn init() void {
 		&commonItems,
 		&commonTools,
 		&commonBiomes,
+		&commonBlocksMigrations,
 		&commonRecipes,
 		&commonModels,
 	);
 
 	std.log.info(
-		"Finished assets init with {} blocks ({} migrations), {} items, {} tools. {} biomes, {} recipes",
-		.{commonBlocks.count(), commonBlocksMigrations.count(), commonItems.count(), commonTools.count(), commonBiomes.count(), commonRecipes.count()},
+		"Finished assets init with {} blocks ({} migrations), {} items, {} tools. {} biomes ({} migrations), {} recipes",
+		.{commonBlocks.count(), commonBlocksMigrations.count(), commonItems.count(), commonTools.count(), commonBiomes.count(), commonBiomesMigrations.count(), commonRecipes.count()},
 	);
 }
 
@@ -207,7 +210,18 @@ pub fn readAllObjFilesInAddonsHashmap(
 	}
 }
 
-pub fn readAssets(externalAllocator: NeverFailingAllocator, assetPath: []const u8, blocks: *std.StringHashMap(ZonElement), blocksMigrations: *std.StringHashMap(ZonElement), items: *std.StringHashMap(ZonElement), tools: *std.StringHashMap(ZonElement), biomes: *std.StringHashMap(ZonElement), recipes: *std.StringHashMap(ZonElement), models: *std.StringHashMap([]const u8)) void {
+pub fn readAssets(
+	externalAllocator: NeverFailingAllocator,
+	assetPath: []const u8,
+	blocks: *std.StringHashMap(ZonElement),
+	blocksMigrations: *std.StringHashMap(ZonElement),
+	items: *std.StringHashMap(ZonElement),
+	tools: *std.StringHashMap(ZonElement),
+	biomes: *std.StringHashMap(ZonElement),
+	biomesMigrations: *std.StringHashMap(ZonElement),
+	recipes: *std.StringHashMap(ZonElement),
+	models: *std.StringHashMap([]const u8),
+) void {
 	var addons = main.List(std.fs.Dir).init(main.stackAllocator);
 	defer addons.deinit();
 	var addonNames = main.List([]const u8).init(main.stackAllocator);
@@ -241,7 +255,7 @@ pub fn readAssets(externalAllocator: NeverFailingAllocator, assetPath: []const u
 	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "blocks", true, blocks, blocksMigrations);
 	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "items", true, items, null);
 	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "tools", true, tools, null);
-	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "biomes", true, biomes, null);
+	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "biomes", true, biomes, biomesMigrations);
 	readAllZonFilesInAddons(externalAllocator, addons, addonNames, "recipes", false, recipes, null);
 	readAllObjFilesInAddonsHashmap(externalAllocator, addons, addonNames, "models", models);
 }
@@ -355,6 +369,8 @@ pub fn loadWorldAssets(assetFolder: []const u8, blockPalette: *Palette, biomePal
 	defer tools.clearAndFree();
 	var biomes = commonBiomes.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
 	defer biomes.clearAndFree();
+	var biomesMigrations = commonBiomesMigrations.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
+	defer biomesMigrations.clearAndFree();
 	var recipes = commonRecipes.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
 	defer recipes.clearAndFree();
 	var models = commonModels.cloneWithAllocator(main.stackAllocator.allocator) catch unreachable;
@@ -368,13 +384,17 @@ pub fn loadWorldAssets(assetFolder: []const u8, blockPalette: *Palette, biomePal
 		&items,
 		&tools,
 		&biomes,
+		&biomesMigrations,
 		&recipes,
 		&models,
 	);
 	errdefer unloadAssets();
 
-	migrations_zig.registerBlockMigrations(&commonBlocksMigrations);
+	migrations_zig.registerBlockMigrations(&blocksMigrations);
 	migrations_zig.applyBlockPaletteMigrations(blockPalette);
+
+	migrations_zig.registerBiomeMigrations(&biomesMigrations);
+	migrations_zig.applyBiomePaletteMigrations(blockPalette);
 
 	// models:
 	var modelIterator = models.iterator();
@@ -465,8 +485,8 @@ pub fn loadWorldAssets(assetFolder: []const u8, blockPalette: *Palette, biomePal
 	}
 
 	std.log.info(
-		"Finished registering assets with {} blocks ({} migrations), {} items {} tools. {} biomes, {} recipes and {} models",
-		.{blocks.count(), blocksMigrations.count(), items.count(), tools.count(), biomes.count(), recipes.count(), models.count()},
+		"Finished registering assets with {} blocks ({} migrations), {} items {} tools. {} biomes ({} migrations), {} recipes and {} models",
+		.{blocks.count(), blocksMigrations.count(), items.count(), tools.count(), biomes.count(), biomesMigrations.count(), recipes.count(), models.count()},
 	);
 }
 

--- a/src/assets.zig
+++ b/src/assets.zig
@@ -390,11 +390,11 @@ pub fn loadWorldAssets(assetFolder: []const u8, blockPalette: *Palette, biomePal
 	);
 	errdefer unloadAssets();
 
-	migrations_zig.registerBlockMigrations(&blockMigrations);
-	migrations_zig.applyBlockPaletteMigrations(blockPalette);
+	migrations_zig.registerAll(.block, &blockMigrations);
+	migrations_zig.apply(.block, blockPalette);
 
-	migrations_zig.registerBiomeMigrations(&biomeMigrations);
-	migrations_zig.applyBiomePaletteMigrations(biomePalette);
+	migrations_zig.registerAll(.biome, &biomeMigrations);
+	migrations_zig.apply(.biome, biomePalette);
 
 	// models:
 	var modelIterator = models.iterator();

--- a/src/migrations.zig
+++ b/src/migrations.zig
@@ -42,7 +42,7 @@ fn register(
 		return;
 	}
 	if(migrationZon.array.items.len == 0) {
-		std.log.info("Skipping empty {s} migration data structure from addon {s}", .{@tagName(typ), addonName});
+		std.log.warn("Skipping empty {s} migration data structure from addon {s}", .{@tagName(typ), addonName});
 		return;
 	}
 

--- a/src/migrations.zig
+++ b/src/migrations.zig
@@ -35,14 +35,14 @@ fn register(
 	migrationZon: ZonElement,
 ) void {
 	if(migrationZon != .array) {
-		if ((migrationZon == .object and migrationZon.object.count() == 0)) {
+		if(migrationZon == .object and migrationZon.object.count() == 0) {
 			std.log.info("Skipping empty {s} migration data structure from addon {s}", .{assetType, addonName});
 			return;
 		}
 		std.log.info("Skipping incorrect {s} migration data structure from addon {s}", .{assetType, addonName});
 		return;
 	}
-	if (migrationZon.array.items.len == 0) {
+	if(migrationZon.array.items.len == 0) {
 		std.log.info("Skipping empty {s} migration data structure from addon {s}", .{assetType, addonName});
 		return;
 	}

--- a/src/migrations.zig
+++ b/src/migrations.zig
@@ -34,8 +34,16 @@ fn register(
 	addonName: []const u8,
 	migrationZon: ZonElement,
 ) void {
-	if((migrationZon.toSlice().len == 0)) {
-		std.log.err("Skipping incorrect {s} migration data structure from addon {s}", .{assetType, addonName});
+	if(migrationZon != .array) {
+		if ((migrationZon == .object and migrationZon.object.count() == 0)) {
+			std.log.info("Skipping empty {s} migration data structure from addon {s}", .{assetType, addonName});
+			return;
+		}
+		std.log.info("Skipping incorrect {s} migration data structure from addon {s}", .{assetType, addonName});
+		return;
+	}
+	if (migrationZon.array.items.len == 0) {
+		std.log.info("Skipping empty {s} migration data structure from addon {s}", .{assetType, addonName});
 		return;
 	}
 

--- a/src/migrations.zig
+++ b/src/migrations.zig
@@ -16,7 +16,7 @@ const MigrationType = enum {
 };
 
 pub fn registerAll(comptime typ: MigrationType, migrations: *std.StringHashMap(ZonElement)) void {
-	std.log.info("Registering {} biome migrations", .{migrations.count()});
+	std.log.info("Registering {} {s} migrations", .{migrations.count(), @tagName(typ)});
 	const collection = switch(typ) {
 		.block => &blockMigrations,
 		.biome => &biomeMigrations,

--- a/src/migrations.zig
+++ b/src/migrations.zig
@@ -17,7 +17,7 @@ const MigrationType = enum {
 
 pub fn registerAll(comptime typ: MigrationType, migrations: *std.StringHashMap(ZonElement)) void {
 	std.log.info("Registering {} biome migrations", .{migrations.count()});
-	const collection = switch (typ) {
+	const collection = switch(typ) {
 		.block => &blockMigrations,
 		.biome => &biomeMigrations,
 	};
@@ -83,7 +83,7 @@ fn register(
 }
 
 pub fn apply(comptime typ: MigrationType, palette: *Palette) void {
-	const migrations = switch (typ) {
+	const migrations = switch(typ) {
 		.block => blockMigrations,
 		.biome => biomeMigrations,
 	};

--- a/src/migrations.zig
+++ b/src/migrations.zig
@@ -35,7 +35,7 @@ fn register(
 ) void {
 	if(migrationZon != .array) {
 		if(migrationZon == .object and migrationZon.object.count() == 0) {
-			std.log.info("Skipping empty {s} migration data structure from addon {s}", .{@tagName(typ), addonName});
+			std.log.warn("Skipping empty {s} migration data structure from addon {s}", .{@tagName(typ), addonName});
 			return;
 		}
 		std.log.err("Skipping incorrect {s} migration data structure from addon {s}", .{@tagName(typ), addonName});

--- a/src/migrations.zig
+++ b/src/migrations.zig
@@ -39,7 +39,7 @@ fn register(
 			std.log.info("Skipping empty {s} migration data structure from addon {s}", .{assetType, addonName});
 			return;
 		}
-		std.log.info("Skipping incorrect {s} migration data structure from addon {s}", .{assetType, addonName});
+		std.log.err("Skipping incorrect {s} migration data structure from addon {s}", .{assetType, addonName});
 		return;
 	}
 	if(migrationZon.array.items.len == 0) {


### PR DESCRIPTION
This PR continues the initiative from #1125 

Additionally it fixes few small issues in previous implementation:
- migration code would show an error when loading migration file with empty object/array
- when registering migrations `commonBlocksMigrations` was used instead of `blocksMigrations` so migrations from asset folder in world would be ignored