### PR TITLE
Reduce Cacti spawn rates

### DIFF
--- a/assets/cubyz/biomes/desert/base.zig.zon
+++ b/assets/cubyz/biomes/desert/base.zig.zon
@@ -19,7 +19,7 @@
 		.{
 			.id = "cubyz:simple_vegetation",
 			.block = "cubyz:cactus",
-			.chance = 0.16,
+			.chance = 0.01,
 			.height = 2,
 			.height_variation = 3,
 		},


### PR DESCRIPTION
This is my first contribution to Cubyz. There were too many cacti spawning in the desert. I adjusted the rates so they would appear more infrequently and make the desert look more natural.

*Before*
![Before](https://github.com/user-attachments/assets/07ff8bc0-9e5a-4642-9ebc-8b74ef0dfe87)

*After*
![After](https://github.com/user-attachments/assets/e413bddc-4107-4ea0-b08f-9113f390afa0)

