### PR TITLE
Refactor `ClientEntityManager.serverUpdate` to use `BinaryReader`

### DIFF
--- a/src/entity.zig
+++ b/src/entity.zig
@@ -227,19 +227,13 @@ pub const ClientEntityManager = struct {
 			}
 		}
 	}
-	pub fn serverUpdate(time: i16, data: []const u8) void {
-		_serverUpdate(time, data) catch |err| {
-			std.log.err("Corrupted entity update packet ({s})", .{@errorName(err)});
-		};
-	}
 
-	fn _serverUpdate(time: i16, data: []const u8) !void {
+	pub fn serverUpdate(time: i16, reader: *BinaryReader) !void {
 		mutex.lock();
 		defer mutex.unlock();
-		if(data.len%(4 + 24 + 12 + 24) != 0) return error.corrupted;
+		if(reader.remaining.len%(4 + 24 + 12 + 24) != 0) return error.corrupted;
 
 		timeDifference.addDataPoint(time);
-		var reader = BinaryReader.init(data, .big);
 
 		while(reader.remaining.len != 0) {
 			const id = try reader.readInt(u32);

--- a/src/entity.zig
+++ b/src/entity.zig
@@ -231,8 +231,6 @@ pub const ClientEntityManager = struct {
 	pub fn serverUpdate(time: i16, reader: *BinaryReader) !void {
 		mutex.lock();
 		defer mutex.unlock();
-		if(reader.remaining.len%(4 + 24 + 12 + 24) != 0) return error.corrupted;
-
 		timeDifference.addDataPoint(time);
 
 		while(reader.remaining.len != 0) {

--- a/src/entity.zig
+++ b/src/entity.zig
@@ -16,6 +16,8 @@ const Vec3f = vec.Vec3f;
 const Vec4f = vec.Vec4f;
 const NeverFailingAllocator = main.utils.NeverFailingAllocator;
 
+const BinaryReader = main.utils.BinaryReader;
+
 pub const ClientEntity = struct {
 	interpolatedValues: utils.GenericInterpolation(6) = undefined,
 	_interpolationPos: [6]f64 = undefined,
@@ -225,34 +227,38 @@ pub const ClientEntityManager = struct {
 			}
 		}
 	}
-
 	pub fn serverUpdate(time: i16, data: []const u8) void {
+		_serverUpdate(time, data) catch |err| {
+			std.log.err("Corrupted entity update packet ({s})", .{@errorName(err)});
+		};
+	}
+
+	fn _serverUpdate(time: i16, data: []const u8) !void {
 		mutex.lock();
 		defer mutex.unlock();
+		if(data.len%(4 + 24 + 12 + 24) != 0) return error.corrupted;
+
 		timeDifference.addDataPoint(time);
-		std.debug.assert(data.len%(4 + 24 + 12 + 24) == 0);
-		var remaining = data;
-		while(remaining.len != 0) {
-			const id = std.mem.readInt(u32, remaining[0..4], .big);
-			remaining = remaining[4..];
+		var reader = BinaryReader.init(data, .big);
+
+		while(reader.remaining.len != 0) {
+			const id = try reader.readInt(u32);
 			const pos = [_]f64{
-				@bitCast(std.mem.readInt(u64, remaining[0..8], .big)),
-				@bitCast(std.mem.readInt(u64, remaining[8..16], .big)),
-				@bitCast(std.mem.readInt(u64, remaining[16..24], .big)),
-				@floatCast(@as(f32, @bitCast(std.mem.readInt(u32, remaining[24..28], .big)))),
-				@floatCast(@as(f32, @bitCast(std.mem.readInt(u32, remaining[28..32], .big)))),
-				@floatCast(@as(f32, @bitCast(std.mem.readInt(u32, remaining[32..36], .big)))),
+				try reader.readFloat(f64),
+				try reader.readFloat(f64),
+				try reader.readFloat(f64),
+				@floatCast(try reader.readFloat(f32)),
+				@floatCast(try reader.readFloat(f32)),
+				@floatCast(try reader.readFloat(f32)),
 			};
-			remaining = remaining[36..];
 			const vel = [_]f64{
-				@bitCast(std.mem.readInt(u64, remaining[0..8], .big)),
-				@bitCast(std.mem.readInt(u64, remaining[8..16], .big)),
-				@bitCast(std.mem.readInt(u64, remaining[16..24], .big)),
+				try reader.readFloat(f64),
+				try reader.readFloat(f64),
+				try reader.readFloat(f64),
 				0,
 				0,
 				0,
 			};
-			remaining = remaining[24..];
 			for(entities.items()) |*ent| {
 				if(ent.id == id) {
 					ent.updatePosition(&pos, &vel, time);

--- a/src/network.zig
+++ b/src/network.zig
@@ -881,7 +881,7 @@ pub const Protocols = struct {
 				const typ = try reader.readInt(u8);
 				const time = try reader.readInt(i16);
 				if(typ == type_entity) {
-					main.entity.ClientEntityManager.serverUpdate(time, reader.remaining);
+					try main.entity.ClientEntityManager.serverUpdate(time, reader);
 				} else if(typ == type_item) {
 					world.itemDrops.readPosition(reader.remaining, time);
 				}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1924,7 +1924,11 @@ pub const BinaryReader = struct {
 		if(self.remaining.len < bufSize) return error.OutOfBounds;
 		defer self.remaining = self.remaining[bufSize..];
 
-		const intT = switch(T) { f32 => u32, f64 => u64, else => unreachable };
+		const intT = switch(T) {
+			f32 => u32,
+			f64 => u64,
+			else => unreachable,
+		};
 		const intValue = std.mem.readInt(intT, self.remaining[0..bufSize], self.endian);
 		return @as(T, @bitCast(intValue));
 	}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1919,6 +1919,16 @@ pub const BinaryReader = struct {
 		return std.mem.readInt(T, self.remaining[0..bufSize], self.endian);
 	}
 
+	pub fn readFloat(self: *BinaryReader, comptime T: type) error{OutOfBounds, IntOutOfBounds}!T {
+		const bufSize = @divExact(@typeInfo(T).float.bits, 8);
+		if(self.remaining.len < bufSize) return error.OutOfBounds;
+		defer self.remaining = self.remaining[bufSize..];
+
+		const intT = switch(T) { f32 => u32, f64 => u64, else => unreachable };
+		const intValue = std.mem.readInt(intT, self.remaining[0..bufSize], self.endian);
+		return @as(T, @bitCast(intValue));
+	}
+
 	pub fn readEnum(self: *BinaryReader, T: type) error{OutOfBounds, IntOutOfBounds, InvalidEnumTag}!T {
 		const int = try self.readInt(@typeInfo(T).@"enum".tag_type);
 		return std.meta.intToEnum(T, int);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1919,7 +1919,7 @@ pub const BinaryReader = struct {
 		return std.mem.readInt(T, self.remaining[0..bufSize], self.endian);
 	}
 
-	pub fn readFloat(self: *BinaryReader, comptime T: type) error{OutOfBounds, IntOutOfBounds}!T {
+	pub fn readFloat(self: *BinaryReader, T: type) error{OutOfBounds, IntOutOfBounds}!T {
 		const IntT = std.meta.Int(.unsigned, @typeInfo(T).float.bits);
 		return @as(T, @bitCast(try self.readInt(IntT)));
 	}
@@ -1968,7 +1968,7 @@ pub const BinaryWriter = struct {
 		std.mem.writeInt(T, self.data.addMany(bufSize)[0..bufSize], value, self.endian);
 	}
 
-	pub fn writeFloat(self: *BinaryWriter, comptime T: type, value: T) T {
+	pub fn writeFloat(self: *BinaryWriter, T: type, value: T) T {
 		const IntT = std.meta.Int(.unsigned, @typeInfo(T).float.bits);
 		self.writeInt(IntT, @bitCast(value));
 	}


### PR DESCRIPTION
This pull request:
- Replaces raw calls to `std.mem.readInt` with use of `BinaryReader`
- Changes treatment of corrupted/malicious payloads from crashing server to ignoring and reporting in log.