### PR TITLE
Fix page sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,7 @@ jobs:
           version: 0.14.0
       - run: sudo apt install libgl-dev libasound2-dev libx11-dev
       - run: wget -O /opt/hostedtoolcache/zig/0.14.0/x64/lib/std/zig/render.zig https://github.com/PixelGuys/Cubyz-std-lib/releases/download/0.14.0/render.zig
-      - run: zig build -Dtarget=x86_64-linux
-      - run: zig build -Dtarget=aarch64-linux
+      - run: zig build
       - run: zig build -Dtarget=x86_64-windows-gnu
       - run: zig build format --summary none
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
           version: 0.14.0
       - run: sudo apt install libgl-dev libasound2-dev libx11-dev
       - run: wget -O /opt/hostedtoolcache/zig/0.14.0/x64/lib/std/zig/render.zig https://github.com/PixelGuys/Cubyz-std-lib/releases/download/0.14.0/render.zig
-      - run: zig build
+      - run: zig build -Dtarget=x86_64-linux
+      - run: zig build -Dtarget=aarch64-linux
       - run: zig build -Dtarget=x86_64-windows-gnu
       - run: zig build format --summary none
       - run: |

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -476,7 +476,6 @@ fn releaseMemory(start: [*]align(page_size_min) u8, len: usize) void {
 /// A list that reserves a continuous region of virtual memory without actually committing its pages.
 /// This allows it to grow without ever invalidating pointers.
 pub fn VirtualList(T: type, maxSize: u32) type {
-	std.debug.assert(@sizeOf(T) <= page_size_max);
 	return struct {
 		mem: [*]align(page_size_min) T,
 		len: u32,
@@ -487,7 +486,6 @@ pub fn VirtualList(T: type, maxSize: u32) type {
 		}
 
 		pub fn init() @This() {
-			std.debug.assert(@sizeOf(T) <= pageSize());
 			return .{
 				.mem = @ptrCast(reserveMemory(maxSizeBytes())),
 				.len = 0,

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -433,9 +433,11 @@ pub fn ListUnmanaged(comptime T: type) type {
 	};
 }
 
-const pageSize = 4096;
+const page_size_min = std.heap.page_size_min;
+const page_size_max = std.heap.page_size_max;
+const pageSize = std.heap.pageSize;
 
-fn reserveMemory(len: usize) [*]align(pageSize) u8 {
+fn reserveMemory(len: usize) [*]align(page_size_min) u8 {
 	if(builtin.os.tag == .windows) {
 		return @ptrCast(@alignCast(std.os.windows.VirtualAlloc(null, len, std.os.windows.MEM_RESERVE, std.os.windows.PAGE_READWRITE) catch |err| {
 			std.log.err("Got error while reserving virtual memory of size {}: {s}", .{len, @errorName(err)});
@@ -449,7 +451,7 @@ fn reserveMemory(len: usize) [*]align(pageSize) u8 {
 	}
 }
 
-fn commitMemory(start: [*]align(pageSize) u8, len: usize) void {
+fn commitMemory(start: [*]align(page_size_min) u8, len: usize) void {
 	if(builtin.os.tag == .windows) {
 		_ = std.os.windows.VirtualAlloc(start, len, std.os.windows.MEM_COMMIT, std.os.windows.PAGE_READWRITE) catch |err| {
 			std.log.err("Got error while committing virtual memory of size {}: {s}.", .{len, @errorName(err)});
@@ -463,7 +465,7 @@ fn commitMemory(start: [*]align(pageSize) u8, len: usize) void {
 	}
 }
 
-fn releaseMemory(start: [*]align(pageSize) u8, len: usize) void {
+fn releaseMemory(start: [*]align(page_size_min) u8, len: usize) void {
 	if(builtin.os.tag == .windows) {
 		std.os.windows.VirtualFree(start, 0, std.os.windows.MEM_RELEASE);
 	} else {
@@ -474,10 +476,11 @@ fn releaseMemory(start: [*]align(pageSize) u8, len: usize) void {
 /// A list that reserves a continuous region of virtual memory without actually committing its pages.
 /// This allows it to grow without ever invalidating pointers.
 pub fn VirtualList(T: type, maxSize: u32) type {
-	const maxSizeBytes = std.mem.alignForward(usize, @as(usize, maxSize)*@sizeOf(T), pageSize);
-	std.debug.assert(@sizeOf(T) <= pageSize);
+	// TODO: is there a significant reason to align to page size?
+	const maxSizeBytes = std.mem.alignForward(usize, @as(usize, maxSize)*@sizeOf(T), pageSize());
+	std.debug.assert(@sizeOf(T) <= pageSize());
 	return struct {
-		mem: [*]align(pageSize) T,
+		mem: [*]align(page_size_min) T,
 		len: u32,
 		committedCapacity: u32,
 
@@ -503,10 +506,10 @@ pub fn VirtualList(T: type, maxSize: u32) type {
 
 		pub fn ensureCapacity(self: *@This(), newCapacity: usize) void {
 			if(newCapacity > self.committedCapacity) {
-				const alignedCapacity = std.mem.alignForward(usize, self.committedCapacity*@sizeOf(T), pageSize);
-				const newAlignedCapacity = std.mem.alignForward(usize, newCapacity*@sizeOf(T), pageSize);
+				const alignedCapacity = std.mem.alignForward(usize, self.committedCapacity*@sizeOf(T), pageSize());
+				const newAlignedCapacity = std.mem.alignForward(usize, newCapacity*@sizeOf(T), pageSize());
 
-				commitMemory(@alignCast(@as([*]align(pageSize) u8, @ptrCast(self.mem))[alignedCapacity..]), newAlignedCapacity - alignedCapacity);
+				commitMemory(@alignCast(@as([*]align(page_size_min) u8, @ptrCast(self.mem))[alignedCapacity..]), newAlignedCapacity - alignedCapacity);
 				self.committedCapacity = @intCast(newAlignedCapacity/@sizeOf(T));
 			}
 		}

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -476,7 +476,6 @@ fn releaseMemory(start: [*]align(page_size_min) u8, len: usize) void {
 /// A list that reserves a continuous region of virtual memory without actually committing its pages.
 /// This allows it to grow without ever invalidating pointers.
 pub fn VirtualList(T: type, maxSize: u32) type {
-	// TODO: is there a significant reason to align to page size?
 	const maxSizeBytes = std.mem.alignForward(usize, @as(usize, maxSize)*@sizeOf(T), pageSize());
 	std.debug.assert(@sizeOf(T) <= pageSize());
 	return struct {

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -476,8 +476,9 @@ fn releaseMemory(start: [*]align(page_size_min) u8, len: usize) void {
 /// A list that reserves a continuous region of virtual memory without actually committing its pages.
 /// This allows it to grow without ever invalidating pointers.
 pub fn VirtualList(T: type, maxSize: u32) type {
-	const maxSizeBytes = std.mem.alignForward(usize, @as(usize, maxSize)*@sizeOf(T), pageSize());
-	std.debug.assert(@sizeOf(T) <= pageSize());
+	const maxSizeBytes = std.mem.alignForward(usize, @as(usize, maxSize)*@sizeOf(T), page_size_max);
+	std.debug.assert(@sizeOf(T) <= page_size_max);
+	std.debug.assert(maxSize >= page_size_max);
 	return struct {
 		mem: [*]align(page_size_min) T,
 		len: u32,


### PR DESCRIPTION
Cubyz once switched to its own `pageSize`, but since then the standard library was upgraded to better represent hardware and software variation. This PR allows for running on ARM Linux and MacOS.