### PR TITLE
Double free reported in GUI code

### DIFF
--- a/src/gui/windows/delete_world_confirmation.zig
+++ b/src/gui/windows/delete_world_confirmation.zig
@@ -18,6 +18,10 @@ const padding: f32 = 8;
 
 var deleteWorldName: []const u8 = "";
 
+pub fn init() void {
+	deleteWorldName = main.globalAllocator.dupe(u8, "");
+}
+
 pub fn deinit() void {
 	main.globalAllocator.free(deleteWorldName);
 }

--- a/src/gui/windows/delete_world_confirmation.zig
+++ b/src/gui/windows/delete_world_confirmation.zig
@@ -19,7 +19,7 @@ const padding: f32 = 8;
 var deleteWorldName: []const u8 = "";
 
 pub fn init() void {
-	deleteWorldName = main.globalAllocator.dupe(u8, "");
+	deleteWorldName = "";
 }
 
 pub fn deinit() void {


### PR DESCRIPTION
This pull request resolves double free reported by zig at a cost of one extra allocation. Double free occurs when game is closed after entering and exiting the world because exiting the world invokes `gui.deinit();gui.init()` to clear UI and frees `deleteWorldName` string that is not realocated when `gui.init()` is called.

```
C:\Users\argma\dev\Cubyz7\compiler\zig\lib\std\mem\Allocator.zig:411:40: 0x7ff7c4313367 in dupe__anon_9435 (Cubyzig.exe.obj)
    const new_buf = try allocator.alloc(T, m.len);
                                       ^
C:\Users\argma\dev\Cubyz7\src\utils.zig:859:29: 0x7ff7c43bf950 in dupe__anon_31922 (Cubyzig.exe.obj)
  return self.allocator.dupe(T, m) catch unreachable;
                            ^
C:\Users\argma\dev\Cubyz7\src\gui\windows\delete_world_confirmation.zig:27:45: 0x7ff7c4497531 in setDeleteWorldName (Cubyzig.exe.obj)
 deleteWorldName = main.globalAllocator.dupe(u8, name);
                                            ^
C:\Users\argma\dev\Cubyz7\src\gui\windows\save_selection.zig:80:66: 0x7ff7c4404d6b in deleteWorld (Cubyzig.exe.obj)
 main.gui.windowlist.delete_world_confirmation.setDeleteWorldName(name);
                                                                 ^
C:\Users\argma\dev\Cubyz7\src\gui\gui.zig:113:12: 0x7ff7c44a11ac in run (Cubyzig.exe.obj)
   callback(self.arg);
           ^
C:\Users\argma\dev\Cubyz7\src\gui\components\Button.zig:128:21: 0x7ff7c452a717 in mainButtonReleased (Cubyzig.exe.obj)
   self.onAction.run();
                    ^

 First free:
C:\Users\argma\dev\Cubyz7\src\utils.zig:854:22: 0x7ff7c43cb666 in free__anon_34963 (Cubyzig.exe.obj)
  self.allocator.free(memory);
                     ^
C:\Users\argma\dev\Cubyz7\src\gui\windows\delete_world_confirmation.zig:22:27: 0x7ff7c43e7f03 in deinit (Cubyzig.exe.obj)
 main.globalAllocator.free(deleteWorldName);
                          ^
C:\Users\argma\dev\Cubyz7\src\gui\gui.zig:180:23: 0x7ff7c43a3917 in deinit (Cubyzig.exe.obj)
   WindowStruct.deinit();
                      ^
C:\Users\argma\dev\Cubyz7\src\game.zig:680:18: 0x7ff7c43a3653 in deinit (Cubyzig.exe.obj)
  main.gui.deinit();
                 ^
C:\Users\argma\dev\Cubyz7\src\main.zig:692:17: 0x7ff7c4395375 in main (Cubyzig.exe.obj)
    world.deinit();
                ^
C:\Users\argma\dev\Cubyz7\compiler\zig\lib\std\start.zig:631:28: 0x7ff7c439403a in main (Cubyzig.exe.obj)
    return callMainWithArgs(@as(usize, @intCast(c_argc)), @as([*][*:0]u8, @ptrCast(c_argv)), envp);
                           ^

 Second free:
C:\Users\argma\dev\Cubyz7\src\utils.zig:854:22: 0x7ff7c43cb666 in free__anon_34963 (Cubyzig.exe.obj)
  self.allocator.free(memory);
                     ^
C:\Users\argma\dev\Cubyz7\src\gui\windows\delete_world_confirmation.zig:22:27: 0x7ff7c43e7f03 in deinit (Cubyzig.exe.obj)
 main.globalAllocator.free(deleteWorldName);
                          ^
C:\Users\argma\dev\Cubyz7\src\gui\gui.zig:180:23: 0x7ff7c43a3917 in deinit (Cubyzig.exe.obj)
   WindowStruct.deinit();
                      ^
C:\Users\argma\dev\Cubyz7\src\main.zig:610:18: 0x7ff7c439539e in main (Cubyzig.exe.obj)
 defer gui.deinit();
                 ^
C:\Users\argma\dev\Cubyz7\compiler\zig\lib\std\start.zig:631:28: 0x7ff7c439403a in main (Cubyzig.exe.obj)
    return callMainWithArgs(@as(usize, @intCast(c_argc)), @as([*][*:0]u8, @ptrCast(c_argv)), envp);
                           ^
C:\Users\argma\dev\Cubyz5\compiler\zig\lib\libc\mingw\crt\crtexe.c:266:0: 0x7ff7c4abcc4b in __tmainCRTStartup (crt2.obj)
    mainret = _tmain (argc, argv, envp);
```