### PR TITLE
Move `hashInt` and `hashCombine` to utils

### DIFF
--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1527,3 +1527,17 @@ fn CastFunctionReturnToAnyopaqueType(Fn: type) type {
 pub fn castFunctionReturnToAnyopaque(function: anytype) *const CastFunctionReturnToAnyopaqueType(@TypeOf(function)) {
 	return @ptrCast(&function);
 }
+
+// https://stackoverflow.com/questions/5889238/why-is-xor-the-default-way-to-combine-hashes
+pub fn hashCombine(left: u64, right: u64) u64 {
+	return left ^ (right +% 0x517cc1b727220a95 +% (left << 6) +% (left >> 2));
+}
+
+// https://stackoverflow.com/questions/664014/what-integer-hash-function-are-good-that-accepts-an-integer-hash-key
+pub fn hashInt(input: u64) u64 {
+	var x = input;
+	x = (x ^ (x >> 30))*%0xbf58476d1ce4e5b9;
+	x = (x ^ (x >> 27))*%0x94d049bb133111eb;
+	x = x ^ (x >> 31);
+	return x;
+}


### PR DESCRIPTION
Those functions are good for hashing integers and combining hashes when implementing specialized hashes, eg. for generators and should be widely available, therefore they are moved to `utils.zig`. 

In particular they are used in #1227