### PR TITLE
Fix `rotateZ` after rotation move

### DIFF
--- a/src/rotation/branch.zig
+++ b/src/rotation/branch.zig
@@ -312,7 +312,7 @@ pub fn model(block: Block) ModelIndex {
 	return .{.index = blocks.meshes.modelIndexStart(block).index + (block.data & 63)};
 }
 
-fn rotateZ(data: u16, angle: Degrees) u16 {
+pub fn rotateZ(data: u16, angle: Degrees) u16 {
 	@setEvalBranchQuota(65_536);
 
 	comptime var rotationTable: [4][16]u8 = undefined;

--- a/src/rotation/carpet.zig
+++ b/src/rotation/carpet.zig
@@ -28,7 +28,7 @@ const CarpetData = packed struct(u6) {
 	posZ: bool,
 };
 
-fn rotateZ(data: u16, angle: Degrees) u16 {
+pub fn rotateZ(data: u16, angle: Degrees) u16 {
 	comptime var rotationTable: [4][64]u8 = undefined;
 	comptime for(0..64) |i| {
 		rotationTable[0][i] = @intCast(i);

--- a/src/rotation/fence.zig
+++ b/src/rotation/fence.zig
@@ -34,7 +34,7 @@ pub fn reset() void {
 	fenceModels.clearRetainingCapacity();
 }
 
-fn rotateZ(data: u16, angle: Degrees) u16 {
+pub fn rotateZ(data: u16, angle: Degrees) u16 {
 	comptime var rotationTable: [4][16]u8 = undefined;
 	comptime for(0..16) |i| {
 		rotationTable[0][i] = @intCast(i);

--- a/src/rotation/log.zig
+++ b/src/rotation/log.zig
@@ -47,7 +47,7 @@ pub fn model(block: Block) ModelIndex {
 	return .{.index = blocks.meshes.modelIndexStart(block).index + @min(block.data, 5)};
 }
 
-fn rotateZ(data: u16, angle: Degrees) u16 {
+pub fn rotateZ(data: u16, angle: Degrees) u16 {
 	comptime var rotationTable: [4][6]u8 = undefined;
 	comptime for(0..6) |i| {
 		rotationTable[0][i] = i;

--- a/src/rotation/planar.zig
+++ b/src/rotation/planar.zig
@@ -45,7 +45,7 @@ pub fn model(block: Block) ModelIndex {
 	return .{.index = blocks.meshes.modelIndexStart(block).index + @min(block.data, 3)};
 }
 
-fn rotateZ(data: u16, angle: Degrees) u16 {
+pub fn rotateZ(data: u16, angle: Degrees) u16 {
 	comptime var rotationTable: [4][4]u8 = undefined;
 	comptime for(0..4) |i| {
 		rotationTable[0][i] = i;

--- a/src/rotation/stairs.zig
+++ b/src/rotation/stairs.zig
@@ -25,7 +25,7 @@ fn hasSubBlock(stairData: u8, x: u1, y: u1, z: u1) bool {
 	return stairData & subBlockMask(x, y, z) == 0;
 }
 
-fn rotateZ(data: u16, angle: Degrees) u16 {
+pub fn rotateZ(data: u16, angle: Degrees) u16 {
 	@setEvalBranchQuota(65_536);
 
 	comptime var rotationTable: [4][256]u8 = undefined;

--- a/src/rotation/torch.zig
+++ b/src/rotation/torch.zig
@@ -97,7 +97,7 @@ pub fn model(block: Block) ModelIndex {
 	return .{.index = blocks.meshes.modelIndexStart(block).index + (@as(u5, @truncate(block.data)) -| 1)};
 }
 
-fn rotateZ(data: u16, angle: Degrees) u16 {
+pub fn rotateZ(data: u16, angle: Degrees) u16 {
 	comptime var rotationTable: [4][32]u8 = undefined;
 	comptime for(0..32) |i| {
 		rotationTable[0][i] = @intCast(i);


### PR DESCRIPTION
Rotations were moved to separate files, but their `rotateZ` were not marked `pub`. Because there is default implementation for that function (noop) it was not immediately visible that custom `rotateZ` are not detected.