### PR TITLE
Add tests for `BinaryReader` and `BinaryWriter`

### DIFF
--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1531,8 +1531,8 @@ pub const BinaryWriter = struct {
 };
 
 const ReadWriteTest = struct {
-	pub var testingAllocator = main.heap.ErrorHandlingAllocator.init(std.testing.allocator);
-	pub var allocator = testingAllocator.allocator();
+	var testingAllocator = main.heap.ErrorHandlingAllocator.init(std.testing.allocator);
+	var allocator = testingAllocator.allocator();
 
 	fn getWriter() BinaryWriter {
 		return .init(ReadWriteTest.allocator);
@@ -1540,53 +1540,53 @@ const ReadWriteTest = struct {
 	fn getReader(data: []const u8) BinaryReader {
 		return .init(data);
 	}
-	fn testInt(comptime intT: type, expected: intT) !void {
+	fn testInt(comptime IntT: type, expected: IntT) !void {
 		var writer = getWriter();
 		defer writer.deinit();
-		writer.writeInt(intT, expected);
+		writer.writeInt(IntT, expected);
 
-		const expectedWidth = std.math.divCeil(comptime_int, @bitSizeOf(intT), 8);
+		const expectedWidth = std.math.divCeil(comptime_int, @bitSizeOf(IntT), 8);
 		try std.testing.expectEqual(expectedWidth, writer.data.items.len);
 
 		var reader = getReader(writer.data.items);
-		const actual = try reader.readInt(intT);
+		const actual = try reader.readInt(IntT);
 
 		try std.testing.expectEqual(expected, actual);
 	}
-	fn testFloat(comptime floatT: type, expected: floatT) !void {
+	fn testFloat(comptime FloatT: type, expected: FloatT) !void {
 		var writer = getWriter();
 		defer writer.deinit();
-		writer.writeFloat(floatT, expected);
+		writer.writeFloat(FloatT, expected);
 
 		var reader = getReader(writer.data.items);
-		const actual = try reader.readFloat(floatT);
+		const actual = try reader.readFloat(FloatT);
 
 		try std.testing.expectEqual(expected, actual);
 	}
-	fn testEnum(comptime enumT: type, expected: enumT) !void {
+	fn testEnum(comptime EnumT: type, expected: EnumT) !void {
 		var writer = getWriter();
 		defer writer.deinit();
-		writer.writeEnum(enumT, expected);
+		writer.writeEnum(EnumT, expected);
 
 		var reader = getReader(writer.data.items);
-		const actual = try reader.readEnum(enumT);
+		const actual = try reader.readEnum(EnumT);
 
 		try std.testing.expectEqual(expected, actual);
 	}
-	fn TestEnum(comptime intT: type) type {
-		return enum(intT) {
-			first = std.math.minInt(intT),
-			center = (std.math.maxInt(intT) + std.math.minInt(intT))/2,
-			last = std.math.maxInt(intT),
+	fn TestEnum(comptime IntT: type) type {
+		return enum(IntT) {
+			first = std.math.minInt(IntT),
+			center = (std.math.maxInt(IntT) + std.math.minInt(IntT))/2,
+			last = std.math.maxInt(IntT),
 		};
 	}
-	fn testVec(comptime vecT: type, expected: vecT) !void {
+	fn testVec(comptime VecT: type, expected: VecT) !void {
 		var writer = getWriter();
 		defer writer.deinit();
-		writer.writeVec(vecT, expected);
+		writer.writeVec(VecT, expected);
 
 		var reader = getReader(writer.data.items);
-		const actual = try reader.readVec(vecT);
+		const actual = try reader.readVec(VecT);
 
 		try std.testing.expectEqual(expected, actual);
 	}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1719,6 +1719,37 @@ test "read/write Vec3f/Vec3d" {
 test "read/write mixed" {
 	ReadWriteTest.init();
 	defer ReadWriteTest.deinit();
+
+	const type_first = u4;
+	const expected_first = 5;
+
+	const type_second = main.vec.Vec3i;
+	const expected_second = type_second{3, -10, 44};
+
+	const type_third = enum(u3) {first, second, third};
+	const expected_third = .second;
+
+	const type_fourth = f32;
+	const expected_fourth = 0.1234;
+
+	const expected_fifth = "Hello World!";
+
+	var writer = ReadWriteTest.getWriter();
+	defer writer.deinit();
+
+	writer.writeInt(type_first, expected_first);
+	writer.writeVec(type_second, expected_second);
+	writer.writeEnum(type_third, expected_third);
+	writer.writeFloat(type_fourth, expected_fourth);
+	writer.writeSlice(expected_fifth);
+
+	var reader = ReadWriteTest.getReader(writer.data.items);
+
+	try std.testing.expectEqual(expected_first, try reader.readInt(type_first));
+	try std.testing.expectEqual(expected_second, try reader.readVec(type_second));
+	try std.testing.expectEqual(expected_third, try reader.readEnum(type_third));
+	try std.testing.expectEqual(expected_fourth, try reader.readFloat(type_fourth));
+	try std.testing.expectEqualStrings(expected_fifth, try reader.readSlice(expected_fifth.len));
 }
 
 // MARK: functionPtrCast()

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1531,14 +1531,11 @@ pub const BinaryWriter = struct {
 };
 
 const ReadWriteTest = struct {
-	fn init() void {
-		main.initThreadLocals();
-	}
-	fn deinit() void {
-		main.deinitThreadLocals();
-	}
+	pub var testingAllocator = main.heap.ErrorHandlingAllocator.init(std.testing.allocator);
+	pub var allocator = testingAllocator.allocator();
+
 	fn getWriter() BinaryWriter {
-		return .init(main.stackAllocator, .big);
+		return .init(ReadWriteTest.allocator, .big);
 	}
 	fn getReader(data: []const u8) BinaryReader {
 		return .init(data, .big);
@@ -1547,6 +1544,9 @@ const ReadWriteTest = struct {
 		var writer = getWriter();
 		defer writer.deinit();
 		writer.writeInt(intT, expected);
+
+		const expectedWidth = (@bitSizeOf(intT) + 7)/8;
+		try std.testing.expectEqual(expectedWidth, writer.data.items.len);
 
 		var reader = getReader(writer.data.items);
 		const actual = try reader.readInt(intT);
@@ -1593,45 +1593,23 @@ const ReadWriteTest = struct {
 };
 
 test "read/write unsigned int" {
-	ReadWriteTest.init();
-	defer ReadWriteTest.deinit();
-
-	try ReadWriteTest.testInt(u1, 0);
-	try ReadWriteTest.testInt(u1, 1);
-
-	inline for([_]type{u2, u4, u5, u8, u16, u31, u32, u64, u128}) |intT| {
+	inline for([_]type{u8, u1, u2, u4, u5, u8, u16, u31, u32, u64, u128}) |intT| {
+		const min = std.math.minInt(intT);
 		const max = std.math.maxInt(intT);
-		std.debug.assert(max != 0);
+		const mid = (max + min)/2;
 
-		const mid = (std.math.maxInt(intT) + std.math.minInt(intT))/2;
-		std.debug.assert(mid != 0);
-
-		try ReadWriteTest.testInt(intT, std.math.minInt(intT));
+		try ReadWriteTest.testInt(intT, min);
 		try ReadWriteTest.testInt(intT, mid);
 		try ReadWriteTest.testInt(intT, max);
 	}
 }
 
 test "read/write signed int" {
-	ReadWriteTest.init();
-	defer ReadWriteTest.deinit();
-
-	try ReadWriteTest.testInt(i2, 0);
-	try ReadWriteTest.testInt(i2, 1);
-	try ReadWriteTest.testInt(i2, -1);
-
-	inline for([_]type{i4, i5, i8, i16, i31, i32, i64, i128}) |intT| {
+	inline for([_]type{i1, i2, i4, i5, i8, i16, i31, i32, i64, i128}) |intT| {
 		const min = std.math.minInt(intT);
-		std.debug.assert(min != 0);
-
 		const lowerMid = std.math.minInt(intT)/2;
-		std.debug.assert(lowerMid != 0);
-
 		const upperMid = std.math.maxInt(intT)/2;
-		std.debug.assert(upperMid != 0);
-
 		const max = std.math.maxInt(intT);
-		std.debug.assert(max != 0);
 
 		try ReadWriteTest.testInt(intT, min);
 		try ReadWriteTest.testInt(intT, lowerMid);
@@ -1642,22 +1620,18 @@ test "read/write signed int" {
 }
 
 test "read/write float" {
-	ReadWriteTest.init();
-	defer ReadWriteTest.deinit();
-
 	inline for([_]type{f16, f32, f64, f80, f128}) |floatT| {
 		try ReadWriteTest.testFloat(floatT, std.math.floatMax(floatT));
 		try ReadWriteTest.testFloat(floatT, 0.0012443);
 		try ReadWriteTest.testFloat(floatT, 0.0);
 		try ReadWriteTest.testFloat(floatT, 6457.0);
+		try ReadWriteTest.testFloat(floatT, std.math.inf(floatT));
+		try ReadWriteTest.testFloat(floatT, -std.math.inf(floatT));
 		try ReadWriteTest.testFloat(floatT, std.math.floatMin(floatT));
 	}
 }
 
 test "read/write enum" {
-	ReadWriteTest.init();
-	defer ReadWriteTest.deinit();
-
 	inline for([_]type{
 		ReadWriteTest.TestEnum(u2),
 		ReadWriteTest.TestEnum(u4),
@@ -1679,9 +1653,6 @@ test "read/write enum" {
 }
 
 test "read/write Vec3i" {
-	ReadWriteTest.init();
-	defer ReadWriteTest.deinit();
-
 	try ReadWriteTest.testVec(main.vec.Vec3i, .{0, 0, 0});
 	try ReadWriteTest.testVec(main.vec.Vec3i, .{
 		std.math.maxInt(@typeInfo(main.vec.Vec3i).vector.child),
@@ -1696,9 +1667,6 @@ test "read/write Vec3i" {
 }
 
 test "read/write Vec3f/Vec3d" {
-	ReadWriteTest.init();
-	defer ReadWriteTest.deinit();
-
 	inline for([_]type{main.vec.Vec3f, main.vec.Vec3d}) |vecT| {
 		try ReadWriteTest.testVec(vecT, .{0, 0, 0});
 		try ReadWriteTest.testVec(vecT, .{0.0043, 0.01123, 0.05043});
@@ -1717,39 +1685,38 @@ test "read/write Vec3f/Vec3d" {
 }
 
 test "read/write mixed" {
-	ReadWriteTest.init();
-	defer ReadWriteTest.deinit();
+	const type0 = u4;
+	const expected0 = 5;
 
-	const type_first = u4;
-	const expected_first = 5;
+	const type1 = main.vec.Vec3i;
+	const expected1 = type1{3, -10, 44};
 
-	const type_second = main.vec.Vec3i;
-	const expected_second = type_second{3, -10, 44};
+	const type2 = enum(u3) {first, second, third};
+	const expected2 = .second;
 
-	const type_third = enum(u3) {first, second, third};
-	const expected_third = .second;
+	const type3 = f32;
+	const expected3 = 0.1234;
 
-	const type_fourth = f32;
-	const expected_fourth = 0.1234;
-
-	const expected_fifth = "Hello World!";
+	const expected4 = "Hello World!";
 
 	var writer = ReadWriteTest.getWriter();
 	defer writer.deinit();
 
-	writer.writeInt(type_first, expected_first);
-	writer.writeVec(type_second, expected_second);
-	writer.writeEnum(type_third, expected_third);
-	writer.writeFloat(type_fourth, expected_fourth);
-	writer.writeSlice(expected_fifth);
+	writer.writeInt(type0, expected0);
+	writer.writeVec(type1, expected1);
+	writer.writeEnum(type2, expected2);
+	writer.writeFloat(type3, expected3);
+	writer.writeSlice(expected4);
 
 	var reader = ReadWriteTest.getReader(writer.data.items);
 
-	try std.testing.expectEqual(expected_first, try reader.readInt(type_first));
-	try std.testing.expectEqual(expected_second, try reader.readVec(type_second));
-	try std.testing.expectEqual(expected_third, try reader.readEnum(type_third));
-	try std.testing.expectEqual(expected_fourth, try reader.readFloat(type_fourth));
-	try std.testing.expectEqualStrings(expected_fifth, try reader.readSlice(expected_fifth.len));
+	try std.testing.expectEqual(expected0, try reader.readInt(type0));
+	try std.testing.expectEqual(expected1, try reader.readVec(type1));
+	try std.testing.expectEqual(expected2, try reader.readEnum(type2));
+	try std.testing.expectEqual(expected3, try reader.readFloat(type3));
+	try std.testing.expectEqualStrings(expected4, try reader.readSlice(expected4.len));
+
+	try std.testing.expect(reader.remaining.len == 0);
 }
 
 // MARK: functionPtrCast()

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1535,10 +1535,10 @@ const ReadWriteTest = struct {
 	pub var allocator = testingAllocator.allocator();
 
 	fn getWriter() BinaryWriter {
-		return .init(ReadWriteTest.allocator, .big);
+		return .init(ReadWriteTest.allocator);
 	}
 	fn getReader(data: []const u8) BinaryReader {
-		return .init(data, .big);
+		return .init(data);
 	}
 	fn testInt(comptime intT: type, expected: intT) !void {
 		var writer = getWriter();

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1597,9 +1597,15 @@ test "read/write unsigned int" {
 	defer ReadWriteTest.deinit();
 
 	inline for([_]type{u1, u2, u4, u5, u8, u16, u31, u32, u64, u128}) |intT| {
+		const max = std.math.maxInt(intT);
+		std.debug.assert(max != 0);
+
+		const mid = (std.math.maxInt(intT) + std.math.minInt(intT))/2;
+		std.debug.assert(mid != 0);
+
 		try ReadWriteTest.testInt(intT, std.math.minInt(intT));
-		try ReadWriteTest.testInt(intT, (std.math.maxInt(intT) + std.math.minInt(intT))/2);
-		try ReadWriteTest.testInt(intT, std.math.maxInt(intT));
+		try ReadWriteTest.testInt(intT, mid);
+		try ReadWriteTest.testInt(intT, max);
 	}
 }
 
@@ -1608,11 +1614,23 @@ test "read/write signed int" {
 	defer ReadWriteTest.deinit();
 
 	inline for([_]type{i4, i5, i8, i16, i31, i32, i64, i128}) |intT| {
-		try ReadWriteTest.testInt(intT, std.math.minInt(intT));
-		try ReadWriteTest.testInt(intT, std.math.minInt(intT)/2);
+		const min = std.math.minInt(intT);
+		std.debug.assert(min != 0);
+
+		const lowerMid = std.math.minInt(intT)/2;
+		std.debug.assert(lowerMid != 0);
+
+		const upperMid = std.math.maxInt(intT)/2;
+		std.debug.assert(upperMid != 0);
+
+		const max = std.math.maxInt(intT);
+		std.debug.assert(max != 0);
+
+		try ReadWriteTest.testInt(intT, min);
+		try ReadWriteTest.testInt(intT, lowerMid);
 		try ReadWriteTest.testInt(intT, 0);
-		try ReadWriteTest.testInt(intT, std.math.maxInt(intT)/2);
-		try ReadWriteTest.testInt(intT, std.math.maxInt(intT));
+		try ReadWriteTest.testInt(intT, upperMid);
+		try ReadWriteTest.testInt(intT, max);
 	}
 }
 

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1596,7 +1596,10 @@ test "read/write unsigned int" {
 	ReadWriteTest.init();
 	defer ReadWriteTest.deinit();
 
-	inline for([_]type{u1, u2, u4, u5, u8, u16, u31, u32, u64, u128}) |intT| {
+	try ReadWriteTest.testInt(u1, 0);
+	try ReadWriteTest.testInt(u1, 1);
+
+	inline for([_]type{u2, u4, u5, u8, u16, u31, u32, u64, u128}) |intT| {
 		const max = std.math.maxInt(intT);
 		std.debug.assert(max != 0);
 
@@ -1612,6 +1615,10 @@ test "read/write unsigned int" {
 test "read/write signed int" {
 	ReadWriteTest.init();
 	defer ReadWriteTest.deinit();
+
+	try ReadWriteTest.testInt(i2, 0);
+	try ReadWriteTest.testInt(i2, 1);
+	try ReadWriteTest.testInt(i2, -1);
 
 	inline for([_]type{i4, i5, i8, i16, i31, i32, i64, i128}) |intT| {
 		const min = std.math.minInt(intT);
@@ -1707,6 +1714,11 @@ test "read/write Vec3f/Vec3d" {
 			std.math.floatMax(@typeInfo(vecT).vector.child),
 		});
 	}
+}
+
+test "read/write mixed" {
+	ReadWriteTest.init();
+	defer ReadWriteTest.deinit();
 }
 
 // MARK: functionPtrCast()

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1593,7 +1593,7 @@ const ReadWriteTest = struct {
 };
 
 test "read/write unsigned int" {
-	inline for([_]type{u8, u1, u2, u4, u5, u8, u16, u31, u32, u64, u128}) |intT| {
+	inline for([_]type{u0, u1, u2, u4, u5, u8, u16, u31, u32, u64, u128}) |intT| {
 		const min = std.math.minInt(intT);
 		const max = std.math.maxInt(intT);
 		const mid = (max + min)/2;

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1545,7 +1545,7 @@ const ReadWriteTest = struct {
 		defer writer.deinit();
 		writer.writeInt(intT, expected);
 
-		const expectedWidth = (@bitSizeOf(intT) + 7)/8;
+		const expectedWidth = std.math.divCeil(comptime_int, @bitSizeOf(intT), 8);
 		try std.testing.expectEqual(expectedWidth, writer.data.items.len);
 
 		var reader = getReader(writer.data.items);


### PR DESCRIPTION
This pull request adds unit tests for `BinaryReader` and `BinaryWriter` which verify that data does not change after being serialized and deserialized. Tests cover significant edge cases present in possible inputs.

Resolves: #1262