### PR TITLE
Track visited types to avoid infinite recursion for reference cycles

### DIFF
--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1747,3 +1747,7 @@ fn CastFunctionReturnToAnyopaqueType(Fn: type) type {
 pub fn castFunctionReturnToAnyopaque(function: anytype) *const CastFunctionReturnToAnyopaqueType(@TypeOf(function)) {
 	return @ptrCast(&function);
 }
+
+pub fn typeId(comptime T: type) usize {
+	return @intFromPtr(&@typeName(T));
+}


### PR DESCRIPTION
This pull request add type tracking to `refAllDeclsRecursiveExceptCImports` to avoid infinite recursion for reference cycles.

I ran into this issue again when working on #1289 so I figured Its time to fix it.