### PR TITLE
The new network system

### DIFF
--- a/src/gui/windows/debug_network.zig
+++ b/src/gui/windows/debug_network.zig
@@ -38,10 +38,16 @@ pub fn render() void {
 		const loss = @as(f64, @floatFromInt(resent))/@as(f64, @floatFromInt(sent))*100;
 		draw.print("Packet loss: {d:.1}% ({}/{})", .{loss, resent, sent}, 0, y, 8, .left);
 		y += 8;
+		draw.print("Internal message overhead: {}kiB", .{network.Connection.internalMessageOverhead.load(.monotonic) >> 10}, 0, y, 8, .left);
+		y += 8;
+		draw.print("Internal header overhead: {}kiB", .{network.Connection.internalHeaderOverhead.load(.monotonic) >> 10}, 0, y, 8, .left);
+		y += 8;
+		draw.print("External header overhead: {}kiB", .{network.Connection.externalHeaderOverhead.load(.monotonic) >> 10}, 0, y, 8, .left);
+		y += 8;
 		inline for(@typeInfo(network.Protocols).@"struct".decls) |decl| {
 			if(@TypeOf(@field(network.Protocols, decl.name)) == type) {
 				const id = @field(network.Protocols, decl.name).id;
-				draw.print("{s}: {}kiB in {} packets", .{decl.name, network.bytesReceived[id].load(.monotonic) >> 10, network.packetsReceived[id].load(.monotonic)}, 0, y, 8, .left);
+				draw.print("{s}: received {}kiB sent {}kiB", .{decl.name, network.Protocols.bytesReceived[id].load(.monotonic) >> 10, network.Protocols.bytesSent[id].load(.monotonic) >> 10}, 0, y, 8, .left);
 				y += 8;
 			}
 		}

--- a/src/gui/windows/debug_network.zig
+++ b/src/gui/windows/debug_network.zig
@@ -52,8 +52,8 @@ pub fn render() void {
 			}
 		}
 	}
-	if(window.size[1] != y) {
-		window.size[1] = y;
+	if(window.contentSize[1] != y) {
+		window.contentSize[1] = y;
 		window.updateWindowPosition();
 	}
 }

--- a/src/gui/windows/debug_network_advanced.zig
+++ b/src/gui/windows/debug_network_advanced.zig
@@ -31,7 +31,7 @@ fn renderConnectionData(conn: *main.network.Connection, name: []const u8, y: *f3
 	conn.lossyChannel.getStatistics(&unconfirmed[0], &queued[0]);
 	conn.fastChannel.getStatistics(&unconfirmed[1], &queued[1]);
 	conn.slowChannel.getStatistics(&unconfirmed[2], &queued[2]);
-	draw.print("{s} | RTT = {d:.1} ms | {d:.0} kiB/RTT", .{name, conn.rttEstimate/1000.0, conn.bandwidthEstimateInBytesPerRtt}, 0, y.*, 8, .left);
+	draw.print("{s} | RTT = {d:.1} ms | {d:.0} kiB/RTT", .{name, conn.rttEstimate/1000.0, conn.bandwidthEstimateInBytesPerRtt/1024.0}, 0, y.*, 8, .left);
 	y.* += 8;
 	draw.print("Waiting in queue:      {: >6} kiB |{: >6} kiB |{: >6} kiB", .{queued[0] >> 10, queued[1] >> 10, queued[2] >> 10}, 0, y.*, 8, .left);
 	y.* += 8;

--- a/src/gui/windows/debug_network_advanced.zig
+++ b/src/gui/windows/debug_network_advanced.zig
@@ -47,6 +47,7 @@ fn renderConnectionData(conn: *main.network.Connection, y: *f32) void {
 }
 
 pub fn render() void {
+	if(true) return; // TODO: Add network info for the new protocol
 	draw.setColor(0xffffffff);
 	var y: f32 = 0;
 	if(main.game.world != null) {

--- a/src/gui/windows/invite.zig
+++ b/src/gui/windows/invite.zig
@@ -59,18 +59,8 @@ fn copyIp(_: usize) void {
 	main.Window.setClipboardString(ipAddress);
 }
 
-fn inviteFromExternal(address: main.network.Address) void {
-	const ip = std.fmt.allocPrint(main.stackAllocator.allocator, "{}", .{address}) catch unreachable;
-	defer main.stackAllocator.free(ip);
-	const user = main.server.User.initAndIncreaseRefCount(main.server.connectionManager, ip) catch |err| {
-		std.log.err("Cannot connect user from external IP {}: {s}", .{address, @errorName(err)});
-		return;
-	};
-	user.decreaseRefCount();
-}
-
 fn makePublic(public: bool) void {
-	main.server.connectionManager.newConnectionCallback.store(if(public) &inviteFromExternal else null, .monotonic);
+	main.server.connectionManager.allowNewConnections.store(public, .monotonic);
 }
 
 pub fn onOpen() void {
@@ -84,7 +74,7 @@ pub fn onOpen() void {
 	list.add(ipAddressEntry);
 	list.add(Button.initText(.{0, 0}, 100, "Invite", .{.callback = &invite}));
 	list.add(Button.initText(.{0, 0}, 100, "Manage Players", gui.openWindowCallback("manage_players")));
-	list.add(CheckBox.init(.{0, 0}, width, "Allow anyone to join (requires a publicly visible IP address+port which may need some configuration in your router)", main.server.connectionManager.newConnectionCallback.load(.monotonic) != null, &makePublic));
+	list.add(CheckBox.init(.{0, 0}, width, "Allow anyone to join (requires a publicly visible IP address+port which may need some configuration in your router)", main.server.connectionManager.allowNewConnections.load(.monotonic), &makePublic));
 	list.finish(.center);
 	window.rootComponent = list.toComponent();
 	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));

--- a/src/network.zig
+++ b/src/network.zig
@@ -1803,7 +1803,7 @@ pub const Connection = struct { // MARK: Connection
 		if(self.slowStart) {
 			self.bandwidthEstimateInBytesPerRtt += fullPacketLen;
 		} else {
-			self.bandwidthEstimateInBytesPerRtt += fullPacketLen/self.bandwidthEstimateInBytesPerRtt*@as(f32, @floatFromInt(self.mtuEstimate));
+			self.bandwidthEstimateInBytesPerRtt += fullPacketLen/self.bandwidthEstimateInBytesPerRtt*@as(f32, @floatFromInt(self.mtuEstimate)) + fullPacketLen/100.0;
 		}
 	}
 

--- a/src/network.zig
+++ b/src/network.zig
@@ -1295,13 +1295,13 @@ pub const Connection = struct { // MARK: Connection
 		fn getHeaderInformation(self: *ReceiveBuffer) !?Header {
 			if(self.currentReadPosition == self.availablePosition) return null;
 			var header: Header = .{
-				.protocolIndex = self.buffer.getAtOffset(0) orelse return null,
+				.protocolIndex = self.buffer.getAtOffset(0) orelse unreachable,
 				.size = 0,
 			};
 			var i: u8 = 1;
 			while(true) : (i += 1) {
 				if(self.currentReadPosition +% i == self.availablePosition) return null;
-				const nextByte = self.buffer.getAtOffset(i) orelse return null;
+				const nextByte = self.buffer.getAtOffset(i) orelse unreachable;
 				header.size = header.size << 7 | (nextByte & 0x7f);
 				if(nextByte & 0x80 == 0) break;
 				if(header.size > std.math.maxInt(@TypeOf(header.size)) >> 7) return error.Invalid;
@@ -1319,7 +1319,7 @@ pub const Connection = struct { // MARK: Connection
 					self.protocolBuffer.ensureCapacity(main.globalAllocator, self.header.?.size);
 				}
 				const amount = @min(@as(usize, @intCast(self.availablePosition -% self.currentReadPosition)), self.header.?.size - self.protocolBuffer.items.len);
-				if(amount == 0) return;
+				if(self.availablePosition -% self.currentReadPosition == 0) return;
 
 				self.buffer.dequeueSlice(self.protocolBuffer.addManyAssumeCapacity(amount)) catch unreachable;
 				self.currentReadPosition +%= @intCast(amount);

--- a/src/network.zig
+++ b/src/network.zig
@@ -1326,15 +1326,15 @@ pub const Connection = struct { // MARK: Connection
 				const protocolReceive = Protocols.list[protocolIndex] orelse return error.Invalid;
 
 				if(Protocols.isAsynchronous[protocolIndex]) {
-					ProtocolTask.schedule(conn, protocolIndex, self.protocolBuffer.toOwnedSlice(main.globalAllocator));
+					ProtocolTask.schedule(conn, protocolIndex, self.protocolBuffer.items);
 				} else {
 					var reader = utils.BinaryReader.init(self.protocolBuffer.items);
 					try protocolReceive(conn, &reader);
+				}
 
-					self.protocolBuffer.clearRetainingCapacity();
-					if(self.protocolBuffer.items.len > 1 << 24) {
-						self.protocolBuffer.shrinkAndFree(main.globalAllocator, 1 << 24);
-					}
+				self.protocolBuffer.clearRetainingCapacity();
+				if(self.protocolBuffer.items.len > 1 << 24) {
+					self.protocolBuffer.shrinkAndFree(main.globalAllocator, 1 << 24);
 				}
 			}
 		}

--- a/src/network.zig
+++ b/src/network.zig
@@ -1872,7 +1872,7 @@ pub const Connection = struct { // MARK: Connection
 	}
 
 	pub fn receive(self: *Connection, data: []const u8) void {
-		self.flawedReceive(data) catch |err| {
+		self.tryReceive(data) catch |err| {
 			std.log.err("Got error while processing received network data: {s}", .{@errorName(err)});
 			if(@errorReturnTrace()) |trace| {
 				std.log.info("{}", .{trace});
@@ -1881,7 +1881,7 @@ pub const Connection = struct { // MARK: Connection
 		};
 	}
 
-	fn flawedReceive(self: *Connection, data: []const u8) !void {
+	fn tryReceive(self: *Connection, data: []const u8) !void {
 		std.debug.assert(self.manager.threadId == std.Thread.getCurrentId());
 		var reader = utils.BinaryReader.init(data);
 		const channel = try reader.readEnum(ChannelId);

--- a/src/network.zig
+++ b/src/network.zig
@@ -1457,9 +1457,8 @@ pub const Connection = struct { // MARK: Connection
 					smallestUnconfirmed = range.start;
 				}
 			}
-			var i: usize = self.lostRanges.startIndex;
-			while(i != self.lostRanges.endIndex) : (i = (i + 1) & self.lostRanges.mask) {
-				const range = self.lostRanges.mem[i];
+			for(0..self.lostRanges.len) |i| {
+				const range = self.lostRanges.getAtOffset(i) catch unreachable;
 				if(smallestUnconfirmed -% range.start > 0) {
 					smallestUnconfirmed = range.start;
 				}

--- a/src/network.zig
+++ b/src/network.zig
@@ -1606,7 +1606,6 @@ pub const Connection = struct { // MARK: Connection
 	connectionIdentifier: i64,
 	remoteConnectionIdentifier: i64,
 
-
 	mutex: std.Thread.Mutex = .{},
 
 	pub fn init(manager: *ConnectionManager, ipPort: []const u8, user: ?*main.server.User) !*Connection {

--- a/src/network.zig
+++ b/src/network.zig
@@ -404,7 +404,7 @@ pub const ConnectionManager = struct { // MARK: ConnectionManager
 				break :blk socket;
 			} else return err;
 		};
-		errdefer Socket.deinit(result.socket);
+		errdefer result.socket.deinit();
 		if(localPort == 0) result.localPort = try result.socket.getPort();
 
 		result.thread = try std.Thread.spawn(.{}, run, .{result});
@@ -422,7 +422,7 @@ pub const ConnectionManager = struct { // MARK: ConnectionManager
 
 		self.running.store(false, .monotonic);
 		self.thread.join();
-		Socket.deinit(self.socket);
+		self.socket.deinit();
 		self.connections.deinit();
 		for(self.requests.items) |request| {
 			request.requestNotifier.signal();

--- a/src/network.zig
+++ b/src/network.zig
@@ -1346,15 +1346,15 @@ pub const Connection = struct { // MARK: Connection
 
 		pub fn receive(self: *ReceiveBuffer, conn: *Connection, start: SequenceIndex, data: []const u8) !ReceiveStatus {
 			const len: SequenceIndex = @intCast(data.len);
-			if(start == self.currentReadPosition) {
-				self.buffer.insertSliceAtOffset(data, 0) catch return .rejected;
+			const offset: usize = @intCast(start -% self.currentReadPosition);
+			if(start == self.availablePosition) {
+				self.buffer.insertSliceAtOffset(data, offset) catch return .rejected;
 				self.ranges.append(main.globalAllocator, .{.start = start, .len = len});
 				try self.collectRangesAndExecuteProtocols(conn);
 				return .accepted;
 			}
 			if(start +% len -% self.currentReadPosition < 0) return .accepted; // We accepted it in the past.
-			const offset = start -% self.currentReadPosition;
-			self.buffer.insertSliceAtOffset(data, @intCast(offset)) catch return .rejected;
+			self.buffer.insertSliceAtOffset(data, offset) catch return .rejected;
 			self.ranges.append(main.globalAllocator, .{.start = start, .len = len});
 			return .accepted;
 		}

--- a/src/network.zig
+++ b/src/network.zig
@@ -1293,6 +1293,7 @@ pub const Connection = struct { // MARK: Connection
 		}
 
 		fn getHeaderInformation(self: *ReceiveBuffer) !?Header {
+			if(self.currentReadPosition == self.availablePosition) return null;
 			var header: Header = .{
 				.protocolIndex = self.buffer.getAtOffset(0) orelse return null,
 				.size = 0,

--- a/src/network.zig
+++ b/src/network.zig
@@ -1553,6 +1553,13 @@ pub const Connection = struct { // MARK: Connection
 			conn.manager.send(writer.data.items, conn.remoteAddress, null);
 			return writer.data.items.len;
 		}
+
+		pub fn getStatistics(self: *Channel, unconfirmed: *usize, queued: *usize) void {
+			for(self.sendBuffer.unconfirmedRanges.items) |range| {
+				unconfirmed.* += @intCast(range.len);
+			}
+			queued.* = @intCast(self.sendBuffer.nextIndex -% self.sendBuffer.highestSentIndex);
+		}
 	};
 
 	const ChannelId = enum(u8) { // MARK: ChannelId

--- a/src/network.zig
+++ b/src/network.zig
@@ -1468,7 +1468,7 @@ pub const Connection = struct { // MARK: Connection
 			if(self.highestSentIndex == self.fullyConfirmedIndex) {
 				self.lastUnsentTime = time;
 			}
-			if(data.len > std.math.maxInt(SequenceIndex)) return error.OutOfMemory;
+			if(data.len + self.buffer.len > std.math.maxInt(SequenceIndex)) return error.OutOfMemory;
 			self.buffer.enqueue(protocolIndex);
 			self.nextIndex +%= 1;
 			_ = internalHeaderOverhead.fetchAdd(1, .monotonic);

--- a/src/network.zig
+++ b/src/network.zig
@@ -1351,7 +1351,7 @@ pub const Connection = struct { // MARK: Connection
 
 		pub fn receive(self: *ReceiveBuffer, conn: *Connection, start: SequenceIndex, data: []const u8) !ReceiveStatus {
 			const len: SequenceIndex = @intCast(data.len);
-			if(start -% self.currentReadPosition < 0) return .accepted; // We accepted it in the past.
+			if(start -% self.availablePosition < 0) return .accepted; // We accepted it in the past.
 			const offset: usize = @intCast(start -% self.currentReadPosition);
 			if(start == self.availablePosition) {
 				self.buffer.insertSliceAtOffset(data, offset) catch return .rejected;

--- a/src/renderer/lighting.zig
+++ b/src/renderer/lighting.zig
@@ -254,7 +254,7 @@ pub const ChannelChunk = struct {
 	}
 
 	fn propagateFromNeighbor(self: *ChannelChunk, lightQueue: *main.utils.CircularBufferQueue(Entry), lights: []const Entry, lightRefreshList: *main.List(*chunk_meshing.ChunkMesh)) void {
-		std.debug.assert(lightQueue.startIndex == lightQueue.endIndex);
+		std.debug.assert(lightQueue.empty());
 		for(lights) |entry| {
 			const index = chunk.getIndex(entry.x, entry.y, entry.z);
 			var result = entry;
@@ -265,7 +265,7 @@ pub const ChannelChunk = struct {
 	}
 
 	fn propagateDestructiveFromNeighbor(self: *ChannelChunk, lightQueue: *main.utils.CircularBufferQueue(Entry), lights: []const Entry, constructiveEntries: *main.ListUnmanaged(ChunkEntries), lightRefreshList: *main.List(*chunk_meshing.ChunkMesh)) main.ListUnmanaged(PositionEntry) {
-		std.debug.assert(lightQueue.startIndex == lightQueue.endIndex);
+		std.debug.assert(lightQueue.empty());
 		for(lights) |entry| {
 			const index = chunk.getIndex(entry.x, entry.y, entry.z);
 			var result = entry;

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -125,13 +125,6 @@ pub const User = struct { // MARK: User
 		return self;
 	}
 
-	pub fn reinitialize(self: *User) void {
-		removePlayer(self);
-		self.timeDifference = .{};
-		main.globalAllocator.free(self.name);
-		self.name = "";
-	}
-
 	pub fn deinit(self: *User) void {
 		std.debug.assert(self.refCount.load(.monotonic) == 0);
 

--- a/src/settings.zig
+++ b/src/settings.zig
@@ -5,7 +5,7 @@ const ZonElement = @import("zon.zig").ZonElement;
 const main = @import("main");
 
 pub const defaultPort: u16 = 47649;
-pub const connectionTimeout = 60_000_000_000;
+pub const connectionTimeout = 60_000_000;
 
 pub const entityLookback: i16 = 100;
 

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -441,6 +441,9 @@ pub fn CircularBufferQueue(comptime T: type) type { // MARK: CircularBufferQueue
 		}
 
 		pub fn enqueueSlice(self: *Self, elems: []const T) void {
+			while(elems.len + self.len > self.mem.len) {
+				self.increaseCapacity();
+			}
 			const start = self.startIndex + self.len & self.mask;
 			const end = start + elems.len;
 			if(end < self.mem.len) {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -319,18 +319,18 @@ pub fn Array3D(comptime T: type) type { // MARK: Array3D
 	};
 }
 
-pub fn FixedSizeCircularBuffer(T: type, size: comptime_int) type { // MARK: FixedSizeCircularBuffer
-	std.debug.assert(size - 1 & size == 0 and size > 0);
-	const mask = size - 1;
+pub fn FixedSizeCircularBuffer(T: type, capacity: comptime_int) type { // MARK: FixedSizeCircularBuffer
+	std.debug.assert(capacity - 1 & capacity == 0 and capacity > 0);
+	const mask = capacity - 1;
 	return struct {
 		const Self = @This();
-		mem: *[size]T = undefined,
+		mem: *[capacity]T = undefined,
 		startIndex: usize = 0,
 		len: usize = 0,
 
 		pub fn init(allocator: NeverFailingAllocator) Self {
 			return .{
-				.mem = allocator.create([size]T),
+				.mem = allocator.create([capacity]T),
 			};
 		}
 
@@ -339,13 +339,13 @@ pub fn FixedSizeCircularBuffer(T: type, size: comptime_int) type { // MARK: Fixe
 		}
 
 		pub fn enqueue(self: *Self, elem: T) !void {
-			if(self.len >= size) return error.OutOfMemory;
+			if(self.len >= capacity) return error.OutOfMemory;
 			self.mem[self.startIndex + self.len & mask] = elem;
 			self.len += 1;
 		}
 
 		pub fn enqueueSlice(self: *Self, elems: []const T) !void {
-			if(elems.len + self.len > size) {
+			if(elems.len + self.len > capacity) {
 				return error.OutOfMemory;
 			}
 			for(elems) |elem| {
@@ -355,7 +355,7 @@ pub fn FixedSizeCircularBuffer(T: type, size: comptime_int) type { // MARK: Fixe
 		}
 
 		pub fn insertSliceAtOffset(self: *Self, elems: []const T, offset: usize) !void {
-			if(offset + elems.len > size) {
+			if(offset + elems.len > capacity) {
 				return error.OutOfMemory;
 			}
 			self.len = offset + elems.len;

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -441,9 +441,16 @@ pub fn CircularBufferQueue(comptime T: type) type { // MARK: CircularBufferQueue
 		}
 
 		pub fn enqueueSlice(self: *Self, elems: []const T) void {
-			for(elems) |elem| {
-				self.enqueue(elem);
+			const start = self.startIndex + self.len & self.mask;
+			const end = start + elems.len;
+			if(end < self.mem.len) {
+				@memcpy(self.mem[start..end], elems);
+			} else {
+				const mid = self.mem.len - start;
+				@memcpy(self.mem[start..], elems[0..mid]);
+				@memcpy(self.mem[0..end & self.mask], elems[mid..]);
 			}
+			self.len += elems.len;
 		}
 
 		pub fn enqueue_back(self: *Self, elem: T) void {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -358,7 +358,7 @@ pub fn FixedSizeCircularBuffer(T: type, capacity: comptime_int) type { // MARK: 
 			if(offset + elems.len > capacity) {
 				return error.OutOfMemory;
 			}
-			self.len = offset + elems.len;
+			self.len = @max(self.len, offset + elems.len);
 			for(elems, 0..) |elem, i| {
 				self.mem[self.startIndex + offset + i & mask] = elem;
 			}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -480,7 +480,7 @@ pub fn CircularBufferQueue(comptime T: type) type { // MARK: CircularBufferQueue
 
 		pub fn getSliceAtOffset(self: Self, offset: usize, result: []T) !void {
 			if(offset + result.len > (self.endIndex -% self.startIndex) & self.mask) return error.OutOfBounds;
-			for(result, offset .. offset + result.len) |*out, i| {
+			for(result, offset..offset + result.len) |*out, i| {
 				out.* = self.mem[(self.startIndex + i) & self.mask];
 			}
 		}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -448,7 +448,7 @@ pub fn CircularBufferQueue(comptime T: type) type { // MARK: CircularBufferQueue
 			} else {
 				const mid = self.mem.len - start;
 				@memcpy(self.mem[start..], elems[0..mid]);
-				@memcpy(self.mem[0..end & self.mask], elems[mid..]);
+				@memcpy(self.mem[0 .. end & self.mask], elems[mid..]);
 			}
 			self.len += elems.len;
 		}

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -272,7 +272,7 @@ pub fn ListUnmanaged(comptime T: type) type {
 			self.capacity = newAllocation.len;
 		}
 
-		fn ensureFreeCapacity(self: *@This(), allocator: NeverFailingAllocator, freeCapacity: usize) void {
+		pub fn ensureFreeCapacity(self: *@This(), allocator: NeverFailingAllocator, freeCapacity: usize) void {
 			if(freeCapacity + self.items.len <= self.capacity) return;
 			self.ensureCapacity(allocator, growCapacity(self.capacity, freeCapacity + self.items.len));
 		}


### PR DESCRIPTION
as described in #1259 

### Progress
- [x] make a first working prototype
- [x] implement congestion control
- [x] ensure that all the relevant sections are locked (everything touched by the `Connection.send()` function must be locked)
- [x] figure out what's breaking chunk transmission
- [x] figure out what's still breaking chunk transmission
- [x] re-add the network statistics to the debug menus
- [x] Investigate error caused in `if(header.size > std.math.maxInt(@TypeOf(header.size)) >> 7) return error.Invalid;`
- ~~Investiage crash from multiplayer session~~ I have fixed many issues since then and cannot reproduce it, so I'll assume it was silently fixed.
- [x] congestion control issues at high bandwidth due to long processing times of confirmations on the receive
  - [x] receiveConfirmationAndGetTimestamp is too slow since it needs to iterate through all sent packets
    → I tried using a hashmap+RangeBuffer, but the result was slower. The main bottleneck are the syscalls anyways
  - [x] Channel.send is slow in the enqueue function, which causes a delay in the network thread because it's done under the same lock.
- [x] disconnecting
- [x] timeout
- ~~implement delayed acks~~ → extracted to issue #1315 
- [x] Handle overlapping ranges in ReceiveBuffer.applyRanges
- ~~Use a monotonic clock~~ → extracted to issue #1314 
- [x] don't crash when the buffer reaches 2 GB, instead the player should be disconnected.
- ~~Readd the bruteforcing port section~~ → extracted to issue #1316 
- [x] benchmark maximum localhost bandwidth (→ #419 ) 
  → Maximum bandwidth on localhost now reaches 140 MB/s, it's a bit fragile though, but most of the time is spent on the `sendto` syscall, so I'm fairly confident that this is the most I can get without path MTU discovery.
- [x] benchmark the latency (→ #874 )
  → around 22-31 ms between breaking a block and receiving the block drop on localhost, most of it comes from the 10 ms send delay on both sides, and I think this is good enough.
- [x] Check if #416 is still happening
  → should not be relevant anymore, the new system is a lot more reliably, since it will never send more data than fits into the receive buffer
- [x] test if reconnection still works
- [x] test it under various simulated network conditions
  → it seems to struggle if the packet loss is above 0.1%.
- [x] Investigate random (non-congestive) packet loss behavior
- [x] fix memory leaks
- [x] fix formatting

### Future work
- #1314 
- #1315 
- #1316 
- #1317 
- #1318 
- #1319 

---

fixes #416 (no problems found even when 2 GB of data are in the queue)
fixes #419
fixes #420 (allocator is no longer relevant, since it's using circular buffers and persistent lists now, instead of reallocating individual packets)
fixes #874 
fixes #1096 
fixes #1258
fixes #1259