### PR TITLE
Allow ores on obsidian

### DIFF
--- a/assets/cubyz/blocks/obsidian.zig.zon
+++ b/assets/cubyz/blocks/obsidian.zig.zon
@@ -24,6 +24,7 @@
 			},
 		},
 	},
+	.allowOres = true,
 	.rotation = .stairs,
 	.model = "cubyz:cube",
 	.texture = "cubyz:obsidian",


### PR DESCRIPTION
Currently ores cannot spawn on obsidian, preventing any ores from appearing in lava caves. This fixes that.