### PR TITLE
Unify 'Registered x' log message format

### DIFF
--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -93,7 +93,6 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 	if(reverseIndices.contains(id)) {
 		std.log.err("Registered block with id {s} twice!", .{id});
 	}
-	defer size += 1;
 
 	_id[size] = allocator.dupe(u8, id);
 	reverseIndices.put(_id[size], @intCast(size)) catch unreachable;
@@ -142,6 +141,7 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 		});
 	}
 
+	defer size += 1;
 	std.log.debug("Registered block: {d: >5} '{s}'", .{size, id});
 	return @intCast(size);
 }

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -93,6 +93,8 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 	if(reverseIndices.contains(id)) {
 		std.log.err("Registered block with id {s} twice!", .{id});
 	}
+	defer size += 1;
+
 	_id[size] = allocator.dupe(u8, id);
 	reverseIndices.put(_id[size], @intCast(size)) catch unreachable;
 
@@ -140,8 +142,8 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 		});
 	}
 
-	size += 1;
-	return @intCast(size - 1);
+	std.log.debug("Registered block: {d: >5} '{s}'", .{size, id});
+	return @intCast(size);
 }
 
 fn registerBlockDrop(typ: u16, zon: ZonElement) void {

--- a/src/items.zig
+++ b/src/items.zig
@@ -850,14 +850,16 @@ pub fn globalInit() void {
 }
 
 pub fn register(_: []const u8, texturePath: []const u8, replacementTexturePath: []const u8, id: []const u8, zon: ZonElement) *BaseItem {
-	std.log.info("{s}", .{id});
 	if(reverseIndices.contains(id)) {
-		std.log.err("Registered item with id {s} twice!", .{id});
+		std.log.err("Registered item with id '{s}' twice!", .{id});
 	}
 	const newItem = &itemList[itemListSize];
+	defer itemListSize += 1;
+
 	newItem.init(arena.allocator(), texturePath, replacementTexturePath, id, zon);
 	reverseIndices.put(newItem.id, newItem) catch unreachable;
-	itemListSize += 1;
+
+	std.log.debug("Registered item: {d: >5} '{s}'", .{itemListSize, id});
 	return newItem;
 }
 
@@ -897,7 +899,6 @@ fn loadPixelSources(assetFolder: []const u8, id: []const u8, layerPostfix: []con
 }
 
 pub fn registerTool(assetFolder: []const u8, id: []const u8, zon: ZonElement) void {
-	std.log.info("Registering tool type {s}", .{id});
 	if(toolTypes.contains(id)) {
 		std.log.err("Registered tool type with id {s} twice!", .{id});
 	}
@@ -942,6 +943,8 @@ pub fn registerTool(assetFolder: []const u8, id: []const u8, zon: ZonElement) vo
 		.pixelSources = pixelSources,
 		.pixelSourcesOverlay = pixelSourcesOverlay,
 	}) catch unreachable;
+
+	std.log.debug("Registered tool: '{s}'", .{id});
 }
 
 fn parseRecipeItem(zon: ZonElement) !ItemStack {

--- a/src/server/command/_command.zig
+++ b/src/server/command/_command.zig
@@ -22,7 +22,7 @@ pub fn init() void {
 			.usage = @field(commandList, decl.name).usage,
 			.exec = &@field(commandList, decl.name).execute,
 		}) catch unreachable;
-		std.log.info("Registered command: '/{s}'", .{decl.name});
+		std.log.debug("Registered command: '/{s}'", .{decl.name});
 	}
 }
 

--- a/src/server/command/_command.zig
+++ b/src/server/command/_command.zig
@@ -22,7 +22,7 @@ pub fn init() void {
 			.usage = @field(commandList, decl.name).usage,
 			.exec = &@field(commandList, decl.name).execute,
 		}) catch unreachable;
-		std.log.info("Registered Command: /{s}", .{decl.name});
+		std.log.info("Registered command: '/{s}'", .{decl.name});
 	}
 }
 

--- a/src/server/terrain/biomes.zig
+++ b/src/server/terrain/biomes.zig
@@ -666,14 +666,15 @@ pub fn deinit() void {
 }
 
 pub fn register(id: []const u8, paletteId: u32, zon: ZonElement) void {
-	std.log.debug("Registered biome: {s}", .{id});
 	std.debug.assert(!finishedLoading);
 	var biome: Biome = undefined;
 	biome.init(id, paletteId, zon);
 	if(biome.isCave) {
 		caveBiomes.append(biome);
+		std.log.debug("Registered    cave biome: {d: >5} '{s}'", .{paletteId, id});
 	} else {
 		biomes.append(biome);
+		std.log.debug("Registered surface biome: {d: >5} '{s}'", .{paletteId, id});
 	}
 }
 

--- a/src/server/terrain/structure_building_blocks.zig
+++ b/src/server/terrain/structure_building_blocks.zig
@@ -200,20 +200,21 @@ pub fn registerSBB(structures: *std.StringHashMap(ZonElement)) !void {
 }
 
 pub fn registerChildBlock(numericId: u16, stringId: []const u8) void {
+	std.debug.assert(numericId != 0);
+
 	const index: u16 = @intCast(childBlockNumericIdMap.count());
 	childBlockNumericIdMap.put(arenaAllocator.allocator, numericId, index) catch unreachable;
 	// Take only color name from the ID.
 	var iterator = std.mem.splitBackwardsScalar(u8, stringId, '/');
 	const colorName = iterator.first();
 	childBlockStringId.append(arenaAllocator, arenaAllocator.dupe(u8, colorName));
-	std.log.debug("Structure child block '{s}' {} ('{s}' {}) ", .{colorName, index, stringId, numericId});
 }
 
 pub fn registerBlueprints(blueprints: *std.StringHashMap([]u8)) !void {
 	std.debug.assert(blueprintCache.capacity() == 0);
 
 	originBlockNumericId = main.blocks.parseBlock(originBlockStringId).typ;
-	std.log.debug("Origin block numeric id: {}", .{originBlockNumericId});
+	std.debug.assert(originBlockNumericId != 0);
 
 	blueprintCache.ensureTotalCapacity(arenaAllocator.allocator, blueprints.count()) catch unreachable;
 
@@ -234,7 +235,7 @@ pub fn registerBlueprints(blueprints: *std.StringHashMap([]u8)) !void {
 		};
 
 		blueprintCache.put(arenaAllocator.allocator, arenaAllocator.dupe(u8, stringId), rotatedBlueprints) catch unreachable;
-		std.log.debug("Registered blueprint: {s}", .{stringId});
+		std.log.debug("Registered blueprint: '{s}'", .{stringId});
 	}
 }
 


### PR DESCRIPTION
New message samples:

```
Registered command: '/clear'
Registered command: '/gamemode'
Registered command: '/help'

Registered block:     0 'cubyz:air'
Registered block:     1 'cubyz:chalk/grey'
Registered block:     2 'cubyz:pine_log'
Registered block:     3 'cubyz:cloth/lime'
Registered block:     4 'cubyz:clay'
Registered block:     5 'cubyz:iron_ore'

Registered item:     0 'cubyz:chalk/grey'
Registered item:     1 'cubyz:pine_log'
Registered item:     2 'cubyz:cloth/lime'
Registered item:     3 'cubyz:clay'
Registered item:     4 'cubyz:iron_ore'

Registered tool: 'cubyz:pickaxe'

Registered surface biome:     0 'cubyz:tall_mountain/slope5'
Registered    cave biome:     1 'cubyz:cave/void/void_crystal'
Registered surface biome:     2 'cubyz:prairie/dry_spell'
Registered surface biome:     3 'cubyz:volcano/slope3'
```

Extracted from: #1293 