### PR TITLE
Blueprint scopes

### DIFF
--- a/src/blueprint.zig
+++ b/src/blueprint.zig
@@ -129,7 +129,7 @@ pub const Blueprint = struct {
 			}
 		}
 	}
-	pub fn load(allocator: NeverFailingAllocator, inputBuffer: []u8) !Blueprint {
+	pub fn load(allocator: NeverFailingAllocator, inputBuffer: []const u8) !Blueprint {
 		var compressedReader = BinaryReader.init(inputBuffer);
 		const version = try compressedReader.readInt(u16);
 

--- a/src/server/command/worldedit/blueprint.zig
+++ b/src/server/command/worldedit/blueprint.zig
@@ -222,7 +222,6 @@ fn blueprintList(params: CommandParams, source: *User) void {
 				var blueprintsDir = addonDir.openDir("blueprints", .{.iterate = true}) catch continue;
 				defer blueprintsDir.close();
 
-
 				var walker = blueprintsDir.walk(main.stackAllocator.allocator) catch continue;
 				defer walker.deinit();
 

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -265,6 +265,17 @@ pub const User = struct { // MARK: User
 		defer main.stackAllocator.free(msg);
 		self.sendRawMessage(msg);
 	}
+
+	pub fn sendWarningAndLog(user: *User, comptime fmt: []const u8, args: anytype) void {
+		std.log.warn(fmt, args);
+		user.sendMessage("#ff0000" ++ fmt, args);
+	}
+
+	pub fn sendInfoAndLog(user: *User, comptime fmt: []const u8, args: anytype) void {
+		std.log.info(fmt, args);
+		user.sendMessage("#00ff00" ++ fmt, args);
+	}
+
 	fn sendRawMessage(self: *User, msg: []const u8) void {
 		main.network.Protocols.chat.send(self.conn, msg);
 	}


### PR DESCRIPTION
This pull request adds `--scope`/`-s` flag to simplify specifying where blueprint should be placed. Currently placing blueprint in `assets/cubyz/blueprints/` requires either manual action or tricks with relative paths. After that change to save blueprint in `assets/cubyz/blueprints` all you have to do is include `-s game` and blueprint will be placed in mentioned directory **on server side**. To download blueprint you can use `-s local`, then blueprint will be placed in local `./blueprints/` directory.
On top of that this PR changes how locations of blueprints are specified. Now instead of raw path user should specify ID of blueprint.

## Example:
`/blueprint save -s game cubyz:stem` will save clipboard to `./assets/cubyz/blueprints/stem.blp` i.e. exactly in place where sbb system will look for it.
`/blueprint list -s game` will list all blueprints in `assets` (in form of IDs)
`/blueprint save argmaster:stone -s world` will save clipboard in `./saves/{current}/assets/argmaster/blueprints/stone.blp`