### PR TITLE
Command name autocompletion

### DIFF
--- a/src/gui/components/TextInput.zig
+++ b/src/gui/components/TextInput.zig
@@ -47,6 +47,7 @@ const OptionalCallbacks = struct {
 	onUp: ?gui.Callback = null,
 	onDown: ?gui.Callback = null,
 	onTab: ?gui.Callback = null,
+	onCharacter: ?gui.Callback = null,
 };
 
 pub fn init(pos: Vec2f, maxWidth: f32, maxHeight: f32, text: []const u8, onNewline: gui.Callback, optional: OptionalCallbacks) *TextInput {
@@ -407,6 +408,7 @@ pub fn inputCharacter(self: *TextInput, character: u21) void {
 		self.reloadText();
 		cursor.* += @intCast(utf8.len);
 		self.ensureCursorVisibility();
+		if(self.optional.onCharacter) |cb| cb.run();
 	}
 }
 

--- a/src/gui/components/TextInput.zig
+++ b/src/gui/components/TextInput.zig
@@ -46,6 +46,7 @@ pub fn __deinit() void {
 const OptionalCallbacks = struct {
 	onUp: ?gui.Callback = null,
 	onDown: ?gui.Callback = null,
+	onTab: ?gui.Callback = null,
 };
 
 pub fn init(pos: Vec2f, maxWidth: f32, maxHeight: f32, text: []const u8, onNewline: gui.Callback, optional: OptionalCallbacks) *TextInput {
@@ -464,6 +465,14 @@ pub fn newline(self: *TextInput, mods: main.Window.Key.Modifiers) void {
 		return;
 	}
 	self.inputCharacter('\n');
+	self.ensureCursorVisibility();
+}
+
+pub fn tab(self: *TextInput, mods: main.Window.Key.Modifiers) void {
+	if(!mods.shift and self.optional.onTab != null) {
+		self.optional.onTab.?.run();
+		return;
+	}
 	self.ensureCursorVisibility();
 }
 

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -453,6 +453,11 @@ pub const textCallbacks = struct {
 			current.newline(mods);
 		}
 	}
+	pub fn tab(mods: main.Window.Key.Modifiers) void {
+		if(selectedTextInput) |current| {
+			current.tab(mods);
+		}
+	}
 };
 
 pub fn mainButtonPressed() void {

--- a/src/gui/windows/change_name.zig
+++ b/src/gui/windows/change_name.zig
@@ -49,7 +49,7 @@ pub fn onOpen() void {
 	list.add(Label.init(.{0, 0}, width, "\\**italic*\\* \\*\\***bold**\\*\\* \\_\\___underlined__\\_\\_ \\~\\~~~strike-through~~\\~\\~", .center));
 	list.add(Label.init(.{0, 0}, width, "Even colors are possible, using the hexadecimal color code:", .center));
 	list.add(Label.init(.{0, 0}, width, "\\##ff0000ff#ffffff00#ffffff00#ff0000red#ffffff \\##ff0000ff#00770077#ffffff00#ff7700orange#ffffff \\##ffffff00#00ff00ff#ffffff00#00ff00green#ffffff \\##ffffff00#ffffff00#0000ffff#0000ffblue", .center));
-	textComponent = TextInput.init(.{0, 0}, width, 32, if(settings.playerName.len == 0) "quanturmdoelvloper" else settings.playerName, .{.callback = &apply});
+	textComponent = TextInput.init(.{0, 0}, width, 32, if(settings.playerName.len == 0) "quanturmdoelvloper" else settings.playerName, .{.callback = &apply}, .{});
 	list.add(textComponent);
 	list.add(Button.initText(.{0, 0}, 100, "Apply", .{.callback = &apply}));
 	list.finish(.center);

--- a/src/gui/windows/chat.zig
+++ b/src/gui/windows/chat.zig
@@ -11,6 +11,7 @@ const Label = GuiComponent.Label;
 const MutexComponent = GuiComponent.MutexComponent;
 const TextInput = GuiComponent.TextInput;
 const VerticalList = @import("../components/VerticalList.zig");
+const FixedSizeCircularBuffer = main.utils.FixedSizeCircularBuffer;
 
 pub var window: GuiWindow = GuiWindow{
 	.relativePosition = .{
@@ -29,6 +30,7 @@ pub var window: GuiWindow = GuiWindow{
 const padding: f32 = 8;
 const messageTimeout: i32 = 10000;
 const messageFade = 1000;
+const reusableHistoryMaxSize = 8192;
 
 var history: main.List(*Label) = undefined;
 var messageQueue: main.utils.ConcurrentQueue([]const u8) = undefined;
@@ -37,9 +39,79 @@ var historyStart: u32 = 0;
 var fadeOutEnd: u32 = 0;
 pub var input: *TextInput = undefined;
 var hideInput: bool = true;
+var messageHistory: History = undefined;
+
+pub const History = struct {
+	up: FixedSizeCircularBuffer([]const u8, reusableHistoryMaxSize),
+	down: FixedSizeCircularBuffer([]const u8, reusableHistoryMaxSize),
+
+	fn init() History {
+		return .{
+			.up = .init(main.globalAllocator),
+			.down = .init(main.globalAllocator),
+		};
+	}
+	fn deinit(self: *History) void {
+		self.clear();
+		self.up.deinit(main.globalAllocator);
+		self.down.deinit(main.globalAllocator);
+	}
+	fn clear(self: *History) void {
+		while(self.up.dequeue()) |msg| {
+			main.globalAllocator.free(msg);
+		}
+		while(self.down.dequeue()) |msg| {
+			main.globalAllocator.free(msg);
+		}
+	}
+	fn flushUp(self: *History) void {
+		while(self.down.dequeueFront()) |msg| {
+			if(msg.len == 0) {
+				continue;
+			}
+
+			if(self.up.forceEnqueueFront(msg)) |old| {
+				main.globalAllocator.free(old);
+			}
+		}
+	}
+	pub fn isDuplicate(self: *History, new: []const u8) bool {
+		if(new.len == 0) return true;
+		if(self.down.peekFront()) |msg| {
+			if(std.mem.eql(u8, msg, new)) return true;
+		}
+		if(self.up.peekFront()) |msg| {
+			if(std.mem.eql(u8, msg, new)) return true;
+		}
+		return false;
+	}
+	pub fn pushDown(self: *History, new: []const u8) void {
+		if(self.down.forceEnqueueFront(new)) |old| {
+			main.globalAllocator.free(old);
+		}
+	}
+	pub fn pushUp(self: *History, new: []const u8) void {
+		if(self.up.forceEnqueueFront(new)) |old| {
+			main.globalAllocator.free(old);
+		}
+	}
+	pub fn cycleUp(self: *History) bool {
+		if(self.down.dequeueFront()) |msg| {
+			self.pushUp(msg);
+			return true;
+		}
+		return false;
+	}
+	pub fn cycleDown(self: *History) void {
+		if(self.up.dequeueFront()) |msg| {
+			self.pushDown(msg);
+		}
+	}
+};
 
 pub fn init() void {
 	history = .init(main.globalAllocator);
+	messageHistory = .init();
 	expirationTime = .init(main.globalAllocator);
 	messageQueue = .init(main.globalAllocator, 16);
 }
@@ -52,6 +124,7 @@ pub fn deinit() void {
 	while(messageQueue.dequeue()) |msg| {
 		main.globalAllocator.free(msg);
 	}
+	messageHistory.deinit();
 	messageQueue.deinit();
 	expirationTime.deinit();
 }
@@ -87,8 +160,30 @@ fn refresh() void {
 }
 
 pub fn onOpen() void {
-	input = TextInput.init(.{0, 0}, 256, 32, "", .{.callback = &sendMessage});
+	input = TextInput.init(.{0, 0}, 256, 32, "", .{.callback = &sendMessage}, .{.onUp = .{.callback = loadNextHistoryEntry}, .onDown = .{.callback = loadPreviousHistoryEntry}});
 	refresh();
+}
+
+pub fn loadNextHistoryEntry(_: usize) void {
+	const isSuccess = messageHistory.cycleUp();
+	if(messageHistory.isDuplicate(input.currentString.items)) {
+		if(isSuccess) messageHistory.cycleDown();
+		messageHistory.cycleDown();
+	} else {
+		messageHistory.pushDown(main.globalAllocator.dupe(u8, input.currentString.items));
+		messageHistory.cycleDown();
+	}
+	const msg = messageHistory.down.peekFront() orelse "";
+	input.setString(msg);
+}
+
+pub fn loadPreviousHistoryEntry(_: usize) void {
+	_ = messageHistory.cycleUp();
+	if(messageHistory.isDuplicate(input.currentString.items)) {} else {
+		messageHistory.pushUp(main.globalAllocator.dupe(u8, input.currentString.items));
+	}
+	const msg = messageHistory.down.peekFront() orelse "";
+	input.setString(msg);
 }
 
 pub fn onClose() void {
@@ -98,6 +193,7 @@ pub fn onClose() void {
 	while(messageQueue.dequeue()) |msg| {
 		main.globalAllocator.free(msg);
 	}
+	messageHistory.clear();
 	expirationTime.clearRetainingCapacity();
 	historyStart = 0;
 	fadeOutEnd = 0;
@@ -156,6 +252,11 @@ pub fn sendMessage(_: usize) void {
 		if(data.len > 10000 or main.graphics.TextBuffer.Parser.countVisibleCharacters(data) > 1000) {
 			std.log.err("Chat message is too long with {}/{} characters. Limits are 1000/10000", .{main.graphics.TextBuffer.Parser.countVisibleCharacters(data), data.len});
 		} else {
+			messageHistory.flushUp();
+			if(!messageHistory.isDuplicate(data)) {
+				messageHistory.pushUp(main.globalAllocator.dupe(u8, data));
+			}
+
 			main.network.Protocols.chat.send(main.game.world.?.conn, data);
 			input.clear();
 		}

--- a/src/gui/windows/chat.zig
+++ b/src/gui/windows/chat.zig
@@ -262,3 +262,8 @@ pub fn sendMessage(_: usize) void {
 		}
 	}
 }
+
+pub fn autocomplete(_: usize) void {
+	if(input.currentString.items.len == 0) return;
+	if(input.currentString.items[0] != '/') return;
+}

--- a/src/gui/windows/invite.zig
+++ b/src/gui/windows/invite.zig
@@ -70,7 +70,7 @@ pub fn onOpen() void {
 	ipAddressLabel = Label.init(.{0, 0}, width, "                      ", .center);
 	list.add(ipAddressLabel);
 	list.add(Button.initText(.{0, 0}, 100, "Copy IP", .{.callback = &copyIp}));
-	ipAddressEntry = TextInput.init(.{0, 0}, width, 32, settings.lastUsedIPAddress, .{.callback = &invite});
+	ipAddressEntry = TextInput.init(.{0, 0}, width, 32, settings.lastUsedIPAddress, .{.callback = &invite}, .{});
 	list.add(ipAddressEntry);
 	list.add(Button.initText(.{0, 0}, 100, "Invite", .{.callback = &invite}));
 	list.add(Button.initText(.{0, 0}, 100, "Manage Players", gui.openWindowCallback("manage_players")));

--- a/src/gui/windows/multiplayer.zig
+++ b/src/gui/windows/multiplayer.zig
@@ -92,7 +92,7 @@ pub fn onOpen() void {
 	ipAddressLabel = Label.init(.{0, 0}, width, "                      ", .center);
 	list.add(ipAddressLabel);
 	list.add(Button.initText(.{0, 0}, 100, "Copy IP", .{.callback = &copyIp}));
-	ipAddressEntry = TextInput.init(.{0, 0}, width, 32, settings.lastUsedIPAddress, .{.callback = &join});
+	ipAddressEntry = TextInput.init(.{0, 0}, width, 32, settings.lastUsedIPAddress, .{.callback = &join}, .{});
 	list.add(ipAddressEntry);
 	list.add(Button.initText(.{0, 0}, 100, "Join", .{.callback = &join}));
 	list.finish(.center);

--- a/src/gui/windows/save_creation.zig
+++ b/src/gui/windows/save_creation.zig
@@ -109,7 +109,7 @@ pub fn onOpen() void {
 	}
 	const name = std.fmt.allocPrint(main.stackAllocator.allocator, "Save{}", .{num}) catch unreachable;
 	defer main.stackAllocator.free(name);
-	textInput = TextInput.init(.{0, 0}, 128, 22, name, .{.callback = &createWorld});
+	textInput = TextInput.init(.{0, 0}, 128, 22, name, .{.callback = &createWorld}, .{});
 	list.add(textInput);
 
 	gamemodeInput = Button.initText(.{0, 0}, 128, @tagName(gamemode), .{.callback = &gamemodeCallback});

--- a/src/main.zig
+++ b/src/main.zig
@@ -403,6 +403,7 @@ pub const KeyBoard = struct { // MARK: KeyBoard
 		.{.name = "textPaste", .key = c.GLFW_KEY_V, .repeatAction = &gui.textCallbacks.paste},
 		.{.name = "textCut", .key = c.GLFW_KEY_X, .repeatAction = &gui.textCallbacks.cut},
 		.{.name = "textNewline", .key = c.GLFW_KEY_ENTER, .repeatAction = &gui.textCallbacks.newline},
+		.{.name = "textTab", .key = c.GLFW_KEY_TAB, .repeatAction = &gui.textCallbacks.tab},
 
 		// Hotbar shortcuts:
 		.{.name = "Hotbar 1", .key = c.GLFW_KEY_1, .pressAction = setHotbarSlot(1)},

--- a/src/main.zig
+++ b/src/main.zig
@@ -28,6 +28,7 @@ pub const Tag = tag.Tag;
 pub const utils = @import("utils.zig");
 pub const vec = @import("vec.zig");
 pub const ZonElement = @import("zon.zig").ZonElement;
+pub const server_commands = @import("server/command/_command.zig");
 
 pub const Window = @import("graphics/Window.zig");
 
@@ -573,6 +574,9 @@ pub fn main() void { // MARK: main()
 			}
 		}
 	} else |_| {}
+
+	server_commands.init();
+	defer server_commands.deinit();
 
 	gui.initWindowList();
 	defer gui.deinitWindowList();

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -288,7 +288,6 @@ pub var thread: ?std.Thread = null;
 
 fn init(name: []const u8, singlePlayerPort: ?u16) void { // MARK: init()
 	std.debug.assert(world == null); // There can only be one world.
-	command.init();
 	users = .init(main.globalAllocator);
 	userDeinitList = .init(main.globalAllocator, 16);
 	userConnectList = .init(main.globalAllocator, 16);
@@ -339,7 +338,6 @@ fn deinit() void {
 		_world.deinit();
 	}
 	world = null;
-	command.deinit();
 }
 
 pub fn getUserListAndIncreaseRefCount(allocator: main.heap.NeverFailingAllocator) []*User {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -338,10 +338,51 @@ pub fn FixedSizeCircularBuffer(T: type, capacity: comptime_int) type { // MARK: 
 			allocator.destroy(self.mem);
 		}
 
-		pub fn enqueue(self: *Self, elem: T) !void {
+		pub fn peekFront(self: Self) ?T {
+			if(self.len == 0) return null;
+			return self.mem[self.startIndex];
+		}
+
+		pub fn peekBack(self: Self) ?T {
+			if(self.len == 0) return null;
+			return self.mem[self.startIndex + self.len - 1 & mask];
+		}
+
+		pub fn enqueueFront(self: *Self, elem: T) !void {
 			if(self.len >= capacity) return error.OutOfMemory;
+			self.enqueueFrontAssumeCapacity(elem);
+		}
+
+		pub fn forceEnqueueFront(self: *Self, elem: T) ?T {
+			const result = if(self.len >= capacity) self.dequeueBack() else null;
+			self.enqueueFrontAssumeCapacity(elem);
+			return result;
+		}
+
+		pub fn enqueueFrontAssumeCapacity(self: *Self, elem: T) void {
+			self.startIndex = (self.startIndex -% 1) & mask;
+			self.mem[self.startIndex] = elem;
+			self.len += 1;
+		}
+
+		pub fn enqueue(self: *Self, elem: T) !void {
+			return self.enqueueBack(elem);
+		}
+
+		pub fn enqueueBack(self: *Self, elem: T) !void {
+			if(self.len >= capacity) return error.OutOfMemory;
+			self.enqueueBackAssumeCapacity(elem);
+		}
+
+		pub fn enqueueBackAssumeCapacity(self: *Self, elem: T) void {
 			self.mem[self.startIndex + self.len & mask] = elem;
 			self.len += 1;
+		}
+
+		pub fn forceEnqueueBack(self: *Self, elem: T) ?T {
+			const result = if(self.len >= capacity) self.dequeueFront() else null;
+			self.enqueueBackAssumeCapacity(elem);
+			return result;
 		}
 
 		pub fn enqueueSlice(self: *Self, elems: []const T) !void {
@@ -376,12 +417,22 @@ pub fn FixedSizeCircularBuffer(T: type, capacity: comptime_int) type { // MARK: 
 			}
 		}
 
+		pub fn dequeueFront(self: *Self) ?T {
+			return self.dequeue();
+		}
+
 		pub fn dequeue(self: *Self) ?T {
 			if(self.len == 0) return null;
 			const result = self.mem[self.startIndex];
 			self.startIndex = (self.startIndex + 1) & mask;
 			self.len -= 1;
 			return result;
+		}
+
+		pub fn dequeueBack(self: *Self) ?T {
+			if(self.len == 0) return null;
+			self.len -= 1;
+			return self.mem[self.startIndex + self.len & mask];
 		}
 
 		pub fn dequeueSlice(self: *Self, out: []T) !void {
@@ -474,6 +525,10 @@ pub fn CircularBufferQueue(comptime T: type) type { // MARK: CircularBufferQueue
 			self.len += elems.len;
 		}
 
+		pub inline fn enqueue_front(self: *Self, elem: T) void {
+			self.enqueue(elem);
+		}
+
 		pub fn enqueue_back(self: *Self, elem: T) void {
 			if(self.len == self.mem.len) {
 				self.increaseCapacity();
@@ -489,6 +544,10 @@ pub fn CircularBufferQueue(comptime T: type) type { // MARK: CircularBufferQueue
 			self.startIndex = (self.startIndex + 1) & self.mask;
 			self.len -= 1;
 			return result;
+		}
+
+		pub inline fn dequeue_back(self: *Self) ?T {
+			return self.dequeue();
 		}
 
 		pub fn dequeue_front(self: *Self) ?T {


### PR DESCRIPTION
## Description

This pull request adds the more trivial part of autocompletion - command name completion.

Behavior is as follows: use `tab` to find all partial matches, use `tab` again to cycle through them. Insert any character to confirm (eg. space). Completion for subcommands / command parameters is not supported yet. 

Depends on: #1244 due to optional callbacks, actual diff is smaller than presented by Github right now,

Implementation details:
- Moved command initialization to `fn main()` to guarantee command list is available. Right now we could WA this and just read command names, but this will be crucial for client side subcommand / parameter completion where callbacks for each command will be required.
- Completion prefers longest match, I decided that this is most likely to be most beneficial, although completion list is not sorted, only longest match is selected to be first in O(n) time while forming completion list.

## Links

Depends on: #1425 