### PR TITLE
[Structure Building Block] Allow specifying empty / sentinel children

### DIFF
--- a/src/server/terrain/simple_structures/SbbGen.zig
+++ b/src/server/terrain/simple_structures/SbbGen.zig
@@ -56,7 +56,7 @@ fn placeSbb(self: *SbbGen, structure: *const sbb.StructureBuildingBlock, placeme
 	rotated.blueprint.pasteInGeneration(pastePosition, chunk, self.placeMode);
 
 	for(rotated.childBlocks) |childBlock| {
-		const child = structure.pickChild(childBlock, seed);
+		const child = structure.pickChild(childBlock, seed) orelse continue;
 		placeSbb(self, child, pastePosition + childBlock.pos(), childBlock.direction(), chunk, seed);
 	}
 }

--- a/src/server/terrain/structure_building_blocks.zig
+++ b/src/server/terrain/structure_building_blocks.zig
@@ -165,8 +165,8 @@ const Child = struct {
 
 	fn initFromZon(parentId: []const u8, colorName: []const u8, colorIndex: usize, childIndex: usize, zon: ZonElement) !Child {
 		const structureId = zon.get(?[]const u8, "structure", null);
-		if(structureId != null and structureId.len != 0) {
-			childrenToResolve.append(.{.parentId = parentId, .colorName = colorName, .colorIndex = colorIndex, .childIndex = childIndex, .structureId = structureId});
+		if(structureId != null and structureId.?.len != 0) {
+			childrenToResolve.append(.{.parentId = parentId, .colorName = colorName, .colorIndex = colorIndex, .childIndex = childIndex, .structureId = structureId.?});
 		}
 		return .{
 			.structure = null,

--- a/src/server/terrain/structure_building_blocks.zig
+++ b/src/server/terrain/structure_building_blocks.zig
@@ -137,7 +137,7 @@ pub const StructureBuildingBlock = struct {
 	pub fn getBlueprint(self: StructureBuildingBlock, rotation: Degrees) *BlueprintEntry {
 		return &self.blueprints[@intFromEnum(rotation)];
 	}
-	pub fn pickChild(self: StructureBuildingBlock, block: BlueprintEntry.StructureBlock, seed: *u64) *const StructureBuildingBlock {
+	pub fn pickChild(self: StructureBuildingBlock, block: BlueprintEntry.StructureBlock, seed: *u64) ?*const StructureBuildingBlock {
 		return self.children[block.index].sample(seed).structure;
 	}
 };
@@ -160,18 +160,16 @@ fn initChildTableFromZon(parentId: []const u8, colorName: []const u8, colorIndex
 }
 
 const Child = struct {
-	structure: *StructureBuildingBlock,
+	structure: ?*StructureBuildingBlock,
 	chance: f32,
 
 	fn initFromZon(parentId: []const u8, colorName: []const u8, colorIndex: usize, childIndex: usize, zon: ZonElement) !Child {
-		const structureId = zon.get([]const u8, "structure", "");
-		if(structureId.len == 0) {
-			std.log.err("['{s}'->'{s}'->'{d}'] Child node has empty structure field, parent structure will be discarded.", .{parentId, colorName, childIndex});
-			return error.EmptyStructureId;
+		const structureId = zon.get(?[]const u8, "structure", null);
+		if(structureId != null and structureId.len != 0) {
+			childrenToResolve.append(.{.parentId = parentId, .colorName = colorName, .colorIndex = colorIndex, .childIndex = childIndex, .structureId = structureId});
 		}
-		childrenToResolve.append(.{.parentId = parentId, .colorName = colorName, .colorIndex = colorIndex, .childIndex = childIndex, .structureId = structureId});
 		return .{
-			.structure = undefined,
+			.structure = null,
 			.chance = zon.get(f32, "chance", 1.0),
 		};
 	}


### PR DESCRIPTION
Resolves: #1250

There are two recommended ways to specify sentinel (empty) child:
- `.structure = null` - explicitly setting `structure` field to null
- `.structure = ""` - using empty ID string (it is not a valid ID)

```zig
.{
	.blueprint = "<id>",
	.children = .{
		.blue = .{
			.{.structure = null, .chance = 1.0},
			.{.structure = "", .chance = 1.0},
		},
	},
}
```

Mind that empty child list declaration is still not valid, you must explicitly specify at least one empty child.
This is to avoid accidentally omitting children.

**invalid**:

```zig
.{
	.blueprint = "<id>",
	.children = .{
		.blue = .{},
	},
}
```

If it is intentional you can explicitly set child to `null`:

**valid**:

```zig
.{
	.blueprint = "<id>",
	.children = .{
		.blue = null,
	},
}
```
