### PR TITLE
Lower coal ore health

### DIFF
--- a/assets/cubyz/blocks/coal_ore.zig.zon
+++ b/assets/cubyz/blocks/coal_ore.zig.zon
@@ -1,6 +1,6 @@
 .{
 	.tags = .{.stone},
-	.blockHealth = 60,
+	.blockHealth = 16,
 	.blockResistance = 1,
 	.ore = .{
 		.veins = 5,


### PR DESCRIPTION
As discussed during playtest, coal ore should be lowered, both because irl its soft and because it is annoying to mine in game.