### PR TITLE
Make iron more elastic

### DIFF
--- a/assets/cubyz/items/iron_ingot.zig.zon
+++ b/assets/cubyz/items/iron_ingot.zig.zon
@@ -3,7 +3,7 @@
 	.texture = "iron_ingot.png",
 	.material = .{
 		.density = 7.5,
-		.elasticity = 5.0,
+		.elasticity = 8.0,
 		.hardness = 5.0,
 		.textureRoughness = 0.1,
 		.colors = .{


### PR DESCRIPTION
Currently Copper beats iron due to its low swing time.

This makes iron more elastic, giving it the same swing time as copper.
Both a copper-head and an iron-head pickaxe now have a swing time of 0.12s

This makes iron strictly better than copper, reducing it from the best metal in the game to a step in the progression, it's still required to mine iron. However the plan is to give it a come-back in the end game due to its high conductivity.