### PR TITLE
QoL changes for creative inventory

### DIFF
--- a/src/gui/components/TextInput.zig
+++ b/src/gui/components/TextInput.zig
@@ -46,8 +46,7 @@ pub fn __deinit() void {
 const OptionalCallbacks = struct {
 	onUp: ?gui.Callback = null,
 	onDown: ?gui.Callback = null,
-	onInputCharacter: ?gui.Callback = null,
-	onDelete: ?gui.Callback = null,
+	onChange: ?gui.Callback = null,
 };
 
 pub fn init(pos: Vec2f, maxWidth: f32, maxHeight: f32, text: []const u8, onNewline: gui.Callback, optional: OptionalCallbacks) *TextInput {
@@ -390,7 +389,7 @@ pub fn deleteLeft(self: *TextInput, _: main.Window.Key.Modifiers) void {
 	self.deleteSelection();
 	self.reloadText();
 	self.ensureCursorVisibility();
-	if(self.optional.onDelete) |cb| cb.run();
+	if(self.optional.onChange) |cb| cb.run();
 }
 
 pub fn deleteRight(self: *TextInput, _: main.Window.Key.Modifiers) void {
@@ -402,7 +401,7 @@ pub fn deleteRight(self: *TextInput, _: main.Window.Key.Modifiers) void {
 	self.deleteSelection();
 	self.reloadText();
 	self.ensureCursorVisibility();
-	if(self.optional.onDelete) |cb| cb.run();
+	if(self.optional.onChange) |cb| cb.run();
 }
 
 pub fn inputCharacter(self: *TextInput, character: u21) void {
@@ -414,7 +413,7 @@ pub fn inputCharacter(self: *TextInput, character: u21) void {
 		self.reloadText();
 		cursor.* += @intCast(utf8.len);
 		self.ensureCursorVisibility();
-		if(self.optional.onInputCharacter) |cb| cb.run();
+		if(self.optional.onChange) |cb| cb.run();
 	}
 }
 
@@ -455,6 +454,7 @@ pub fn paste(self: *TextInput, mods: main.Window.Key.Modifiers) void {
 		self.cursor.? += @intCast(string.len);
 		self.reloadText();
 		self.ensureCursorVisibility();
+		if(self.optional.onChange) |cb| cb.run();
 	}
 }
 
@@ -464,6 +464,7 @@ pub fn cut(self: *TextInput, mods: main.Window.Key.Modifiers) void {
 		self.deleteSelection();
 		self.reloadText();
 		self.ensureCursorVisibility();
+		if(self.optional.onChange) |cb| cb.run();
 	}
 }
 

--- a/src/gui/components/TextInput.zig
+++ b/src/gui/components/TextInput.zig
@@ -46,7 +46,6 @@ pub fn __deinit() void {
 const OptionalCallbacks = struct {
 	onUp: ?gui.Callback = null,
 	onDown: ?gui.Callback = null,
-	onChange: ?gui.Callback = null,
 };
 
 pub fn init(pos: Vec2f, maxWidth: f32, maxHeight: f32, text: []const u8, onNewline: gui.Callback, optional: OptionalCallbacks) *TextInput {
@@ -86,7 +85,6 @@ pub fn clear(self: *TextInput) void {
 	}
 	self.currentString.clearRetainingCapacity();
 	self.reloadText();
-	if(self.optional.onChange) |cb| cb.run();
 }
 
 pub fn toComponent(self: *TextInput) GuiComponent {
@@ -390,7 +388,6 @@ pub fn deleteLeft(self: *TextInput, _: main.Window.Key.Modifiers) void {
 	self.deleteSelection();
 	self.reloadText();
 	self.ensureCursorVisibility();
-	if(self.optional.onChange) |cb| cb.run();
 }
 
 pub fn deleteRight(self: *TextInput, _: main.Window.Key.Modifiers) void {
@@ -402,7 +399,6 @@ pub fn deleteRight(self: *TextInput, _: main.Window.Key.Modifiers) void {
 	self.deleteSelection();
 	self.reloadText();
 	self.ensureCursorVisibility();
-	if(self.optional.onChange) |cb| cb.run();
 }
 
 pub fn inputCharacter(self: *TextInput, character: u21) void {
@@ -414,7 +410,6 @@ pub fn inputCharacter(self: *TextInput, character: u21) void {
 		self.reloadText();
 		cursor.* += @intCast(utf8.len);
 		self.ensureCursorVisibility();
-		if(self.optional.onChange) |cb| cb.run();
 	}
 }
 
@@ -455,7 +450,6 @@ pub fn paste(self: *TextInput, mods: main.Window.Key.Modifiers) void {
 		self.cursor.? += @intCast(string.len);
 		self.reloadText();
 		self.ensureCursorVisibility();
-		if(self.optional.onChange) |cb| cb.run();
 	}
 }
 
@@ -465,7 +459,6 @@ pub fn cut(self: *TextInput, mods: main.Window.Key.Modifiers) void {
 		self.deleteSelection();
 		self.reloadText();
 		self.ensureCursorVisibility();
-		if(self.optional.onChange) |cb| cb.run();
 	}
 }
 

--- a/src/gui/components/TextInput.zig
+++ b/src/gui/components/TextInput.zig
@@ -86,6 +86,7 @@ pub fn clear(self: *TextInput) void {
 	}
 	self.currentString.clearRetainingCapacity();
 	self.reloadText();
+	if(self.optional.onChange) |cb| cb.run();
 }
 
 pub fn toComponent(self: *TextInput) GuiComponent {

--- a/src/gui/components/TextInput.zig
+++ b/src/gui/components/TextInput.zig
@@ -46,6 +46,8 @@ pub fn __deinit() void {
 const OptionalCallbacks = struct {
 	onUp: ?gui.Callback = null,
 	onDown: ?gui.Callback = null,
+	onInputCharacter: ?gui.Callback = null,
+	onDelete: ?gui.Callback = null,
 };
 
 pub fn init(pos: Vec2f, maxWidth: f32, maxHeight: f32, text: []const u8, onNewline: gui.Callback, optional: OptionalCallbacks) *TextInput {
@@ -388,6 +390,7 @@ pub fn deleteLeft(self: *TextInput, _: main.Window.Key.Modifiers) void {
 	self.deleteSelection();
 	self.reloadText();
 	self.ensureCursorVisibility();
+	if(self.optional.onDelete) |cb| cb.run();
 }
 
 pub fn deleteRight(self: *TextInput, _: main.Window.Key.Modifiers) void {
@@ -399,6 +402,7 @@ pub fn deleteRight(self: *TextInput, _: main.Window.Key.Modifiers) void {
 	self.deleteSelection();
 	self.reloadText();
 	self.ensureCursorVisibility();
+	if(self.optional.onDelete) |cb| cb.run();
 }
 
 pub fn inputCharacter(self: *TextInput, character: u21) void {
@@ -410,6 +414,7 @@ pub fn inputCharacter(self: *TextInput, character: u21) void {
 		self.reloadText();
 		cursor.* += @intCast(utf8.len);
 		self.ensureCursorVisibility();
+		if(self.optional.onInputCharacter) |cb| cb.run();
 	}
 }
 

--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -30,8 +30,6 @@ var items: main.List(Item) = undefined;
 var inventory: Inventory = undefined;
 var searchInput: *TextInput = undefined;
 var searchString: []const u8 = undefined;
-var searchSelectionStart: ?u32 = null;
-var searchCursor: ?u32 = null;
 
 fn lessThan(_: void, lhs: Item, rhs: Item) bool {
 	if(lhs == .baseItem and rhs == .baseItem) {
@@ -48,8 +46,6 @@ fn lessThan(_: void, lhs: Item, rhs: Item) bool {
 
 pub fn onOpen() void {
 	searchString = "";
-	searchSelectionStart = null;
-	searchCursor = null;
 	initContent();
 }
 
@@ -66,8 +62,6 @@ fn initContent() void {
 		const label = Label.init(.{0, 3}, 56, "Search:", .right);
 
 		searchInput = TextInput.init(.{0, 0}, 288, 22, searchString, .{.callback = &filter}, .{});
-		searchInput.cursor = searchCursor;
-		searchInput.selectionStart = searchSelectionStart;
 
 		row.add(label);
 		row.add(searchInput);
@@ -113,9 +107,6 @@ fn initContent() void {
 }
 
 fn deinitContent() void {
-	searchSelectionStart = searchInput.selectionStart;
-	searchCursor = searchInput.cursor;
-
 	if(window.rootComponent) |*comp| {
 		comp.deinit();
 	}
@@ -129,9 +120,13 @@ pub fn update() void {
 }
 
 fn filter(_: usize) void {
+	const cursor = searchInput.cursor;
+
 	main.globalAllocator.free(searchString);
 	searchString = main.globalAllocator.dupe(u8, searchInput.currentString.items);
 	deinitContent();
 	initContent();
+
+	searchInput.cursor = cursor;
 	searchInput.select();
 }

--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -50,45 +50,52 @@ pub fn onOpen() void {
 }
 
 fn initContent() void {
-	const list = VerticalList.init(.{padding, padding + 16}, 140, 0);
+	const root = VerticalList.init(.{padding, padding}, 300, 0);
 	{
+		const list = VerticalList.init(.{0, padding + padding}, 48, 0);
 		const row = HorizontalList.init();
-		const label = Label.init(.{0, 2}, 74, "Search: ", .right);
-		searchInput = TextInput.init(.{0, 0}, 284, 22, searchString, .{.callback = &filter}, .{});
+		const label = Label.init(.{0, 3}, 56, "Search:", .right);
+		searchInput = TextInput.init(.{0, 0}, 288, 22, searchString, .{.callback = &filter}, .{});
 		row.add(label);
 		row.add(searchInput);
 		list.add(row);
+		list.finish(.center);
+		root.add(list);
 	}
-
-	items = .init(main.globalAllocator);
-	var itemIterator = main.items.iterator();
-	while(itemIterator.next()) |item| {
-		if(searchString.len != 0 and std.mem.indexOf(u8, item.id(), searchString) == null) continue;
-		items.append(Item{.baseItem = item.*});
-	}
-
-	std.mem.sort(Item, items.items, {}, lessThan);
-	const slotCount = items.items.len + (slotsPerRow - items.items.len%slotsPerRow);
-	inventory = Inventory.init(main.globalAllocator, slotCount, .creative, .other);
-	for(0..items.items.len) |i| {
-		inventory.fillAmountFromCreative(@intCast(i), items.items[i], 1);
-	}
-	var i: u32 = 0;
-	while(i < items.items.len) {
-		const row = HorizontalList.init();
-		for(0..slotsPerRow) |_| {
-			if(i > slotCount) break;
-			if(i >= items.items.len) {
-				row.add(ItemSlot.init(.{0, 0}, inventory, i, .immutable, .immutable));
-			} else {
-				row.add(ItemSlot.init(.{0, 0}, inventory, i, .default, .takeOnly));
-			}
-			i += 1;
+	{
+		const list = VerticalList.init(.{0, padding}, 144, 0);
+		items = .init(main.globalAllocator);
+		var itemIterator = main.items.iterator();
+		while(itemIterator.next()) |item| {
+			if(searchString.len != 0 and std.mem.indexOf(u8, item.id(), searchString) == null) continue;
+			items.append(Item{.baseItem = item.*});
 		}
-		list.add(row);
+
+		std.mem.sort(Item, items.items, {}, lessThan);
+		const slotCount = items.items.len + (slotsPerRow - items.items.len%slotsPerRow);
+		inventory = Inventory.init(main.globalAllocator, slotCount, .creative, .other);
+		for(0..items.items.len) |i| {
+			inventory.fillAmountFromCreative(@intCast(i), items.items[i], 1);
+		}
+		var i: u32 = 0;
+		while(i < items.items.len) {
+			const row = HorizontalList.init();
+			for(0..slotsPerRow) |_| {
+				if(i > slotCount) break;
+				if(i >= items.items.len) {
+					row.add(ItemSlot.init(.{0, 0}, inventory, i, .immutable, .immutable));
+				} else {
+					row.add(ItemSlot.init(.{0, 0}, inventory, i, .default, .takeOnly));
+				}
+				i += 1;
+			}
+			list.add(row);
+		}
+		list.finish(.center);
+		root.add(list);
 	}
-	list.finish(.center);
-	window.rootComponent = list.toComponent();
+	root.finish(.center);
+	window.rootComponent = root.toComponent();
 	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));
 	gui.updateWindowPositions();
 }

--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -55,7 +55,7 @@ fn initContent() void {
 		const list = VerticalList.init(.{0, padding + padding}, 48, 0);
 		const row = HorizontalList.init();
 		const label = Label.init(.{0, 3}, 56, "Search:", .right);
-		searchInput = TextInput.init(.{0, 0}, 288, 22, searchString, .{.callback = &filter}, .{.onChange = .{.callback = &filter}});
+		searchInput = TextInput.init(.{0, 0}, 288, 22, searchString, .{.callback = &filter}, .{});
 		row.add(label);
 		row.add(searchInput);
 		list.add(row);
@@ -100,20 +100,25 @@ fn initContent() void {
 	gui.updateWindowPositions();
 }
 
-fn filter(_: usize) void {
-	main.globalAllocator.free(searchString);
-	searchString = main.globalAllocator.dupe(u8, searchInput.currentString.items);
-	deinitContent();
-	initContent();
-	searchInput.select();
-}
-
 fn deinitContent() void {
 	if(window.rootComponent) |*comp| {
 		comp.deinit();
 	}
 	items.deinit();
 	inventory.deinit(main.globalAllocator);
+}
+
+pub fn update() void {
+	if(std.mem.eql(u8, searchInput.currentString.items, searchString)) return;
+	filter(0);
+}
+
+fn filter(_: usize) void {
+	main.globalAllocator.free(searchString);
+	searchString = main.globalAllocator.dupe(u8, searchInput.currentString.items);
+	deinitContent();
+	initContent();
+	searchInput.select();
 }
 
 pub fn onClose() void {

--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -30,6 +30,8 @@ var items: main.List(Item) = undefined;
 var inventory: Inventory = undefined;
 var searchInput: *TextInput = undefined;
 var searchString: []const u8 = undefined;
+var searchSelectionStart: ?u32 = null;
+var searchCursor: ?u32 = null;
 
 fn lessThan(_: void, lhs: Item, rhs: Item) bool {
 	if(lhs == .baseItem and rhs == .baseItem) {
@@ -46,6 +48,8 @@ fn lessThan(_: void, lhs: Item, rhs: Item) bool {
 
 pub fn onOpen() void {
 	searchString = "";
+	searchSelectionStart = null;
+	searchCursor = null;
 	initContent();
 }
 
@@ -60,7 +64,11 @@ fn initContent() void {
 		const list = VerticalList.init(.{0, padding + padding}, 48, 0);
 		const row = HorizontalList.init();
 		const label = Label.init(.{0, 3}, 56, "Search:", .right);
+
 		searchInput = TextInput.init(.{0, 0}, 288, 22, searchString, .{.callback = &filter}, .{});
+		searchInput.cursor = searchCursor;
+		searchInput.selectionStart = searchSelectionStart;
+
 		row.add(label);
 		row.add(searchInput);
 		list.add(row);
@@ -105,6 +113,9 @@ fn initContent() void {
 }
 
 fn deinitContent() void {
+	searchSelectionStart = searchInput.selectionStart;
+	searchCursor = searchInput.cursor;
+
 	if(window.rootComponent) |*comp| {
 		comp.deinit();
 	}

--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -55,7 +55,7 @@ fn initContent() void {
 		const list = VerticalList.init(.{0, padding + padding}, 48, 0);
 		const row = HorizontalList.init();
 		const label = Label.init(.{0, 3}, 56, "Search:", .right);
-		searchInput = TextInput.init(.{0, 0}, 288, 22, searchString, .{.callback = &filter}, .{});
+		searchInput = TextInput.init(.{0, 0}, 288, 22, searchString, .{.callback = &filter}, .{.onInputCharacter = .{.callback = &filter}, .onDelete = .{.callback = &filter}});
 		row.add(label);
 		row.add(searchInput);
 		list.add(row);
@@ -105,6 +105,7 @@ fn filter(_: usize) void {
 	searchString = main.globalAllocator.dupe(u8, searchInput.currentString.items);
 	deinitContent();
 	initContent();
+	searchInput.select();
 }
 
 fn deinitContent() void {

--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -55,7 +55,7 @@ fn initContent() void {
 		const list = VerticalList.init(.{0, padding + padding}, 48, 0);
 		const row = HorizontalList.init();
 		const label = Label.init(.{0, 3}, 56, "Search:", .right);
-		searchInput = TextInput.init(.{0, 0}, 288, 22, searchString, .{.callback = &filter}, .{.onInputCharacter = .{.callback = &filter}, .onDelete = .{.callback = &filter}});
+		searchInput = TextInput.init(.{0, 0}, 288, 22, searchString, .{.callback = &filter}, .{.onChange = .{.callback = &filter}});
 		row.add(label);
 		row.add(searchInput);
 		list.add(row);

--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -120,6 +120,7 @@ pub fn update() void {
 }
 
 fn filter(_: usize) void {
+	const selectionStart = searchInput.selectionStart;
 	const cursor = searchInput.cursor;
 
 	main.globalAllocator.free(searchString);
@@ -127,6 +128,8 @@ fn filter(_: usize) void {
 	deinitContent();
 	initContent();
 
+	searchInput.selectionStart = selectionStart;
 	searchInput.cursor = cursor;
+
 	searchInput.select();
 }

--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -49,6 +49,11 @@ pub fn onOpen() void {
 	initContent();
 }
 
+pub fn onClose() void {
+	deinitContent();
+	main.globalAllocator.free(searchString);
+}
+
 fn initContent() void {
 	const root = VerticalList.init(.{padding, padding}, 300, 0);
 	{
@@ -81,7 +86,6 @@ fn initContent() void {
 		while(i < items.items.len) {
 			const row = HorizontalList.init();
 			for(0..slotsPerRow) |_| {
-				if(i > slotCount) break;
 				if(i >= items.items.len) {
 					row.add(ItemSlot.init(.{0, 0}, inventory, i, .immutable, .immutable));
 				} else {
@@ -119,9 +123,4 @@ fn filter(_: usize) void {
 	deinitContent();
 	initContent();
 	searchInput.select();
-}
-
-pub fn onClose() void {
-	deinitContent();
-	main.globalAllocator.free(searchString);
 }

--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -74,7 +74,7 @@ fn initContent() void {
 		items = .init(main.globalAllocator);
 		var itemIterator = main.items.iterator();
 		while(itemIterator.next()) |item| {
-			if(searchString.len != 0 and std.mem.indexOf(u8, item.id(), searchString) == null) continue;
+			if(searchString.len != 0 and !std.mem.containsAtLeast(u8, item.id(), 1, searchString)) continue;
 			items.append(Item{.baseItem = item.*});
 		}
 

--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -110,7 +110,7 @@ fn deinitContent() void {
 
 pub fn update() void {
 	if(std.mem.eql(u8, searchInput.currentString.items, searchString)) return;
-	filter(0);
+	filter(undefined);
 }
 
 fn filter(_: usize) void {


### PR DESCRIPTION
Although major UI changes are planned, they are expected in rather far future. Unfortunately current state of creative inventory makes it really frustrating to use when building and when testing newly added blocks. Therefore I have implemented a dead simple search bar which filters out all items with IDs that don't contain the searched phrase. I also made a sin of (subjectively) improving the look of item list by padding last row of item list with empty immutable slots if it was not filled with items found.

![Screenshot 2025-06-20 025239](https://github.com/user-attachments/assets/17f6ca67-fc65-4588-b76e-c5cb0fb65ff1)

![Screenshot 2025-06-20 025312](https://github.com/user-attachments/assets/e7af7498-4415-45d8-a72c-ef155683e91e)

![Screenshot 2025-06-20 025245](https://github.com/user-attachments/assets/6dbf2b30-c075-491a-803f-b1dd92efa49c)
