### PR TITLE
Speed boost when breaking a block based on leftover damage

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -1045,8 +1045,6 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 				mesh_storage.removeBreakingAnimation(lastSelectedBlockPos);
 				lastSelectedBlockPos = selectedPos;
 				currentBlockProgress = 0;
-				//currentSwingProgress = 0;
-				//currentSwingTime = 0;
 			}
 			const block = mesh_storage.getBlock(selectedPos[0], selectedPos[1], selectedPos[2]) orelse return;
 			const relPos: Vec3f = @floatCast(lastPos - @as(Vec3d, @floatFromInt(selectedPos)));

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -1045,8 +1045,8 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 				mesh_storage.removeBreakingAnimation(lastSelectedBlockPos);
 				lastSelectedBlockPos = selectedPos;
 				currentBlockProgress = 0;
-				currentSwingProgress = 0;
-				currentSwingTime = 0;
+				//currentSwingProgress = 0;
+				//currentSwingTime = 0;
 			}
 			const block = mesh_storage.getBlock(selectedPos[0], selectedPos[1], selectedPos[2]) orelse return;
 			const relPos: Vec3f = @floatCast(lastPos - @as(Vec3d, @floatFromInt(selectedPos)));
@@ -1084,6 +1084,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 
 						return;
 					} else {
+						currentSwingProgress += (currentBlockProgress - 1)*block.blockHealth()/damage*currentSwingTime;
 						mesh_storage.removeBreakingAnimation(lastSelectedBlockPos);
 						currentBlockProgress = 0;
 					}


### PR DESCRIPTION
This makes the DPS statistic more accurate and reduces the impact from off-by-one errors as described in #1643

fixes #1656 

@ikabod-kee please check this out