### PR TITLE
Garbage Collection - The Great Return

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -55,11 +55,80 @@ pub fn initThreadLocals() void {
 	seed = @bitCast(@as(i64, @truncate(std.time.nanoTimestamp())));
 	stackAllocatorBase = heap.StackAllocator.init(globalAllocator, 1 << 23);
 	stackAllocator = stackAllocatorBase.allocator();
+	GarbageCollection.addThread();
 }
 
 pub fn deinitThreadLocals() void {
 	stackAllocatorBase.deinit();
+	GarbageCollection.removeThread();
 }
+
+pub const GarbageCollection = struct {
+	var sharedState: std.atomic.Value(u32) = .init(0);
+	threadlocal var threadCycle: u1 = undefined;
+	threadlocal var lastSyncPointTime: i64 = undefined;
+	// TODO: Free lists
+
+	const State = packed struct {
+		waitingThreads: u16 = 0,
+		totalThreads: u15 = 0,
+		cycle: u1 = 0,
+	};
+
+	fn addThread() void {
+		const old: State = @bitCast(sharedState.fetchAdd(@bitCast(State{.totalThreads = 1}), .monotonic));
+		_ = old.totalThreads + 1; // Assert no overflow
+		threadCycle = old.cycle;
+		lastSyncPointTime = std.time.milliTimestamp();
+	}
+
+	fn removeThread() void {
+		const old: State = @bitCast(sharedState.fetchSub(@bitCast(State{.totalThreads = 1}), .monotonic));
+		_ = old.totalThreads - 1; // Assert no overflow
+		if(old.cycle != threadCycle) removeThreadFromWaiting();
+		const newTime = std.time.milliTimestamp();
+		if(newTime -% lastSyncPointTime > 10_000) {
+			std.log.err("No sync point executed in {} ms for thread. Did you forget to add a sync point in the thread's main loop?", .{newTime -% lastSyncPointTime});
+			std.debug.dumpCurrentStackTrace(null);
+		}
+	}
+
+	fn assertAllThreadsStopped() void {
+		std.debug.assert(sharedState.load(.unordered) & ~@as(u32, 0x7fffffff) == 0);
+	}
+
+	fn removeThreadFromWaiting() void {
+		const old: State = @bitCast(sharedState.fetchSub(@bitCast(State{.waitingThreads = 1}), .acq_rel));
+		_ = old.waitingThreads - 1; // Assert no overflow
+		threadCycle = old.cycle;
+
+		// Start a new cycle
+		if(old.waitingThreads == 1) {
+			var cur = sharedState.load(.unordered);
+			while(true) {
+				var new: State = @bitCast(cur);
+				new.waitingThreads = new.totalThreads;
+				new.cycle +%= 1;
+				cur = sharedState.cmpxchgWeak(cur, @bitCast(new), .monotonic, .monotonic) orelse break;
+			}
+		}
+	}
+
+	/// Must be called when no objects originating from other threads are held on the current function stack
+	pub fn syncPoint() void {
+		const newTime = std.time.milliTimestamp();
+		if(newTime -% lastSyncPointTime > 10_000) {
+			std.log.err("No sync point executed in {} ms. Did you forget to add a sync point in the thread's main loop", .{newTime -% lastSyncPointTime});
+			std.debug.dumpCurrentStackTrace(null);
+		}
+		lastSyncPointTime = newTime;
+
+		const old: State = @bitCast(sharedState.load(.unordered));
+		if(old.cycle == threadCycle) return;
+		removeThreadFromWaiting();
+		// TODO: Free all the data here and swap lists
+	}
+};
 
 fn cacheStringImpl(comptime len: usize, comptime str: [len]u8) []const u8 {
 	return str[0..len];
@@ -549,6 +618,7 @@ pub fn main() void { // MARK: main()
 	defer if(global_gpa.deinit() == .leak) {
 		std.log.err("Memory leak", .{});
 	};
+	defer GarbageCollection.assertAllThreadsStopped();
 	initThreadLocals();
 	defer deinitThreadLocals();
 
@@ -672,6 +742,7 @@ pub fn main() void { // MARK: main()
 	audio.setMusic("cubyz:cubyz");
 
 	while(c.glfwWindowShouldClose(Window.window) == 0) {
+		GarbageCollection.syncPoint();
 		const isHidden = c.glfwGetWindowAttrib(Window.window, c.GLFW_ICONIFIED) == c.GLFW_TRUE;
 		if(!isHidden) {
 			c.glfwSwapBuffers(Window.window);

--- a/src/network.zig
+++ b/src/network.zig
@@ -587,6 +587,7 @@ pub const ConnectionManager = struct { // MARK: ConnectionManager
 
 		var lastTime: i64 = networkTimestamp();
 		while(self.running.load(.monotonic)) {
+			main.GarbageCollection.syncPoint();
 			self.waitingToFinishReceive.broadcast();
 			var source: Address = undefined;
 			if(self.socket.receive(&self.receiveBuffer, 1, &source)) |data| {

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -442,6 +442,7 @@ pub fn start(name: []const u8, port: ?u16) void {
 	defer deinit();
 	running.store(true, .release);
 	while(running.load(.monotonic)) {
+		main.GarbageCollection.syncPoint();
 		const newTime = std.time.nanoTimestamp();
 		if(newTime -% lastTime < updateNanoTime) {
 			std.Thread.sleep(@intCast(lastTime +% updateNanoTime -% newTime));

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -749,15 +749,15 @@ pub fn BlockingMaxHeap(comptime T: type) type { // MARK: BlockingMaxHeap
 
 		/// Returns the biggest element and removes it from the heap.
 		/// If empty blocks until a new object is added or the datastructure is closed.
-		pub fn extractMax(self: *@This()) !T {
+		pub fn extractMax(self: *@This()) error{Timeout, Closed}!T {
 			self.mutex.lock();
 			defer self.mutex.unlock();
 
 			while(true) {
 				if(self.size == 0) {
 					self.waitingThreadCount += 1;
-					self.waitingThreads.wait(&self.mutex);
-					self.waitingThreadCount -= 1;
+					defer self.waitingThreadCount -= 1;
+					try self.waitingThreads.timedWait(&self.mutex, 100_000_000);
 				} else {
 					const ret = self.array[0];
 					self.removeIndex(0);
@@ -909,9 +909,13 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 		defer main.deinitThreadLocals();
 
 		var lastUpdate = std.time.milliTimestamp();
-		while(true) {
+		outer: while(true) {
+			main.GarbageCollection.syncPoint();
 			{
-				const task = self.loadList.extractMax() catch break;
+				const task = self.loadList.extractMax() catch |err| switch(err) {
+					error.Timeout => continue :outer,
+					error.Closed => break :outer,
+				};
 				self.currentTasks[id].store(task.vtable, .monotonic);
 				const start = std.time.microTimestamp();
 				task.vtable.run(task.self);


### PR DESCRIPTION
This is a first attempt to get rid of of reference counting #1413

Basically all threads execute a global sync point, this allows determining a time when all temporary resources (such as meshes on the client side used in lighting on other threads) have been freed with 100% certainty.

Remaining work:
- [x] Implement the sync point
- [ ] Implement free lists and free the resources
- [ ] Determine if this is worth it performance wise
  - [ ] Use this for chunk meshes
  - [ ] Remove reference counting and the locks on the chunk storage data structure
  - [ ] Measure performance of gathering many light samples and compare it with master