### PR TITLE
Make the new cactus block craft the cactus arm instead of the old one.

### DIFF
--- a/assets/cubyz/recipes/wood_recipes.zig.zon
+++ b/assets/cubyz/recipes/wood_recipes.zig.zon
@@ -144,7 +144,7 @@
 		.output = "cubyz:sign/willow",
 	},
 	.{
-		.inputs = .{"cubyz:cactus"},
+		.inputs = .{"cubyz:log/cactus"},
 		.output = "2 cubyz:cactus_arm",
 	},
 	.{


### PR DESCRIPTION
fixes #1693 