### PR TITLE
Make reading light data thread safe without mutexes

### DIFF
--- a/src/block_entity.zig
+++ b/src/block_entity.zig
@@ -478,10 +478,6 @@ pub const BlockEntityTypes = struct {
 
 				c.glUniform1i(uniforms.quadIndex, @intFromEnum(quad));
 				const mesh = main.renderer.mesh_storage.getMesh(main.chunk.ChunkPosition.initFromWorldPos(signData.blockPos, 1)) orelse continue :outer;
-				mesh.lightingData[0].lock.lockRead();
-				defer mesh.lightingData[0].lock.unlockRead();
-				mesh.lightingData[1].lock.lockRead();
-				defer mesh.lightingData[1].lock.unlockRead();
 				const light: [4]u32 = main.renderer.chunk_meshing.PrimitiveMesh.getLight(mesh, signData.blockPos -% Vec3i{mesh.pos.wx, mesh.pos.wy, mesh.pos.wz}, 0, quad);
 				c.glUniform4ui(uniforms.lightData, light[0], light[1], light[2], light[3]);
 				c.glUniform3i(uniforms.chunkPos, signData.blockPos[0] & ~main.chunk.chunkMask, signData.blockPos[1] & ~main.chunk.chunkMask, signData.blockPos[2] & ~main.chunk.chunkMask);

--- a/src/chunk.zig
+++ b/src/chunk.zig
@@ -286,7 +286,7 @@ pub const Chunk = struct { // MARK: Chunk
 	fn deinitContent(self: *Chunk) void {
 		std.debug.assert(self.blockPosToEntityDataMap.count() == 0);
 		self.blockPosToEntityDataMap.deinit(main.globalAllocator.allocator);
-		self.data.deinit();
+		self.data.deferredDeinit();
 	}
 
 	pub fn unloadBlockEntities(self: *Chunk, comptime side: main.utils.Side) void {

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -381,8 +381,6 @@ pub const PrimitiveMesh = struct { // MARK: PrimitiveMesh
 		self.max = @splat(-std.math.floatMax(f32));
 
 		self.lock.lockRead();
-		parent.lightingData[0].lock.lockRead();
-		parent.lightingData[1].lock.lockRead();
 		for(self.completeList.getEverything()) |*face| {
 			const light = getLight(parent, .{face.position.x, face.position.y, face.position.z}, face.blockAndQuad.texture, face.blockAndQuad.quadIndex);
 			const result = lightMap.getOrPut(light) catch unreachable;
@@ -401,8 +399,6 @@ pub const PrimitiveMesh = struct { // MARK: PrimitiveMesh
 				self.max = @max(self.max, basePos + cornerPos);
 			}
 		}
-		parent.lightingData[0].lock.unlockRead();
-		parent.lightingData[1].lock.unlockRead();
 		self.lock.unlockRead();
 	}
 
@@ -421,10 +417,6 @@ pub const PrimitiveMesh = struct { // MARK: PrimitiveMesh
 			return getValues(parent, wx, wy, wz);
 		}
 		const neighborMesh = mesh_storage.getMesh(.{.wx = wx, .wy = wy, .wz = wz, .voxelSize = parent.pos.voxelSize}) orelse return .{0, 0, 0, 0, 0, 0};
-		neighborMesh.lightingData[0].lock.lockRead();
-		neighborMesh.lightingData[1].lock.lockRead();
-		defer neighborMesh.lightingData[0].lock.unlockRead();
-		defer neighborMesh.lightingData[1].lock.unlockRead();
 		return getValues(neighborMesh, wx, wy, wz);
 	}
 

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -807,7 +807,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 		self.mutex.unlock();
 		self.lightingData[0].propagateLights(lightEmittingBlocks.items, true, lightRefreshList);
 		sunLight: {
-			var allSun: bool = self.chunk.data.palette().len == 1 and self.chunk.data.palette()[0].typ == 0;
+			var allSun: bool = self.chunk.data.palette().len == 1 and self.chunk.data.palette()[0].load(.unordered).typ == 0;
 			var sunStarters: [chunk.chunkSize*chunk.chunkSize][3]u8 = undefined;
 			var index: usize = 0;
 			const lightStartMap = mesh_storage.getLightMapPiece(self.pos.wx, self.pos.wy, self.pos.voxelSize) orelse break :sunLight;
@@ -918,7 +918,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 		var paletteCache = main.stackAllocator.alloc(OcclusionInfo, self.chunk.data.palette().len);
 		defer main.stackAllocator.free(paletteCache);
 		for(0..self.chunk.data.palette().len) |i| {
-			const block = self.chunk.data.palette()[i];
+			const block = self.chunk.data.palette()[i].load(.unordered);
 			const model = blocks.meshes.model(block).model();
 			var result: OcclusionInfo = .{};
 			if(model.noNeighborsOccluded or block.viewThrough()) {
@@ -1002,7 +1002,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 						hasFaces[x][y] |= setBit;
 					}
 					if(occlusionInfo.hasInternalQuads) {
-						const block = self.chunk.data.palette()[paletteId];
+						const block = self.chunk.data.palette()[paletteId].load(.unordered);
 						if(block.transparent()) {
 							appendInternalQuads(block, x, y, z, false, &transparentCore, main.stackAllocator);
 						} else {

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -807,7 +807,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 		self.mutex.unlock();
 		self.lightingData[0].propagateLights(lightEmittingBlocks.items, true, lightRefreshList);
 		sunLight: {
-			var allSun: bool = self.chunk.data.paletteLength == 1 and self.chunk.data.palette[0].typ == 0;
+			var allSun: bool = self.chunk.data.palette().len == 1 and self.chunk.data.palette()[0].typ == 0;
 			var sunStarters: [chunk.chunkSize*chunk.chunkSize][3]u8 = undefined;
 			var index: usize = 0;
 			const lightStartMap = mesh_storage.getLightMapPiece(self.pos.wx, self.pos.wy, self.pos.voxelSize) orelse break :sunLight;
@@ -915,10 +915,10 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 			hasInternalQuads: bool = false,
 			alwaysViewThrough: bool = false,
 		};
-		var paletteCache = main.stackAllocator.alloc(OcclusionInfo, self.chunk.data.paletteLength);
+		var paletteCache = main.stackAllocator.alloc(OcclusionInfo, self.chunk.data.palette().len);
 		defer main.stackAllocator.free(paletteCache);
-		for(0..self.chunk.data.paletteLength) |i| {
-			const block = self.chunk.data.palette[i];
+		for(0..self.chunk.data.palette().len) |i| {
+			const block = self.chunk.data.palette()[i];
 			const model = blocks.meshes.model(block).model();
 			var result: OcclusionInfo = .{};
 			if(model.noNeighborsOccluded or block.viewThrough()) {
@@ -946,7 +946,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 				const y: u5 = @intCast(_y);
 				for(0..chunk.chunkSize) |_z| {
 					const z: u5 = @intCast(_z);
-					const paletteId = self.chunk.data.data.getValue(chunk.getIndex(x, y, z));
+					const paletteId = self.chunk.data.impl.raw.data.getValue(chunk.getIndex(x, y, z));
 					const occlusionInfo = paletteCache[paletteId];
 					const setBit = @as(u32, 1) << z;
 					if(occlusionInfo.alwaysViewThrough or (!occlusionInfo.canSeeAllNeighbors and occlusionInfo.canSeeNeighbor == 0)) {
@@ -986,7 +986,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 				const y: u5 = @intCast(_y);
 				for(0..chunk.chunkSize) |_z| {
 					const z: u5 = @intCast(_z);
-					const paletteId = self.chunk.data.data.getValue(chunk.getIndex(x, y, z));
+					const paletteId = self.chunk.data.impl.raw.data.getValue(chunk.getIndex(x, y, z));
 					const occlusionInfo = paletteCache[paletteId];
 					const setBit = @as(u32, 1) << z;
 					if(depthFilteredViewThroughMask[x][y] & setBit != 0) {} else if(occlusionInfo.canSeeAllNeighbors) {
@@ -1002,7 +1002,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 						hasFaces[x][y] |= setBit;
 					}
 					if(occlusionInfo.hasInternalQuads) {
-						const block = self.chunk.data.palette[paletteId];
+						const block = self.chunk.data.palette()[paletteId];
 						if(block.transparent()) {
 							appendInternalQuads(block, x, y, z, false, &transparentCore, main.stackAllocator);
 						} else {

--- a/src/renderer/lighting.zig
+++ b/src/renderer/lighting.zig
@@ -41,7 +41,7 @@ pub const ChannelChunk = struct {
 	}
 
 	pub fn deinit(self: *ChannelChunk) void {
-		self.data.deinit();
+		self.data.deferredDeinit();
 		memoryPool.destroy(self);
 	}
 
@@ -331,11 +331,11 @@ pub const ChannelChunk = struct {
 	pub fn propagateUniformSun(self: *ChannelChunk, lightRefreshList: *main.List(chunk.ChunkPosition)) void {
 		std.debug.assert(self.isSun);
 		self.lock.lockWrite();
-		if(self.data.paletteLength != 1) {
-			self.data.deinit();
+		if(self.data.palette().len != 1) {
+			self.data.deferredDeinit();
 			self.data.init();
 		}
-		self.data.palette[0] = .{255, 255, 255};
+		self.data.palette()[0] = .{255, 255, 255};
 		self.lock.unlockWrite();
 		const val = 255 -| 8*|@as(u8, @intCast(self.ch.pos.voxelSize));
 		var lightQueue = main.utils.CircularBufferQueue(Entry).init(main.stackAllocator, 1 << 12);

--- a/src/renderer/lighting.zig
+++ b/src/renderer/lighting.zig
@@ -343,11 +343,7 @@ pub const ChannelChunk = struct {
 	pub fn propagateUniformSun(self: *ChannelChunk, lightRefreshList: *main.List(chunk.ChunkPosition)) void {
 		std.debug.assert(self.isSun);
 		self.mutex.lock();
-		if(self.data.palette().len != 1) {
-			self.data.deferredDeinit();
-			self.data.init();
-		}
-		self.data.palette()[0].store(.fromArray(.{255, 255, 255}), .unordered);
+		self.data.fillUniform(.fromArray(.{255, 255, 255}));
 		self.mutex.unlock();
 		const val = 255 -| 8*|@as(u8, @intCast(self.ch.pos.voxelSize));
 		var lightQueue = main.utils.CircularBufferQueue(Entry).init(main.stackAllocator, 1 << 12);

--- a/src/renderer/lighting.zig
+++ b/src/renderer/lighting.zig
@@ -81,7 +81,6 @@ pub const ChannelChunk = struct {
 	};
 
 	pub fn getValue(self: *ChannelChunk, x: i32, y: i32, z: i32) [3]u8 {
-		self.lock.assertLockedRead();
 		const index = chunk.getIndex(x, y, z);
 		return self.data.getValue(index).toArray();
 	}

--- a/src/renderer/mesh_storage.zig
+++ b/src/renderer/mesh_storage.zig
@@ -197,10 +197,6 @@ pub fn getLight(wx: i32, wy: i32, wz: i32) ?[6]u8 {
 	const x = (wx >> mesh.chunk.voxelSizeShift) & chunk.chunkMask;
 	const y = (wy >> mesh.chunk.voxelSizeShift) & chunk.chunkMask;
 	const z = (wz >> mesh.chunk.voxelSizeShift) & chunk.chunkMask;
-	mesh.lightingData[0].lock.lockRead();
-	defer mesh.lightingData[0].lock.unlockRead();
-	mesh.lightingData[1].lock.lockRead();
-	defer mesh.lightingData[1].lock.unlockRead();
 	return mesh.lightingData[1].getValue(x, y, z) ++ mesh.lightingData[0].getValue(x, y, z);
 }
 

--- a/src/server/storage.zig
+++ b/src/server/storage.zig
@@ -284,7 +284,7 @@ pub const ChunkCompression = struct { // MARK: ChunkCompression
 	fn compressBlockData(ch: *chunk.Chunk, allowLossy: bool, writer: *BinaryWriter) void {
 		if(ch.data.palette().len == 1) {
 			writer.writeEnum(ChunkCompressionAlgo, .uniform);
-			writer.writeInt(u32, ch.data.palette()[0].toInt());
+			writer.writeInt(u32, ch.data.palette()[0].load(.unordered).toInt());
 			return;
 		}
 		if(ch.data.palette().len < 256) {
@@ -293,7 +293,7 @@ pub const ChunkCompression = struct { // MARK: ChunkCompression
 			for(0..chunk.chunkVolume) |i| {
 				uncompressedData[i] = @intCast(ch.data.impl.raw.data.getValue(i));
 				if(allowLossy) {
-					const block = ch.data.palette()[uncompressedData[i]];
+					const block = ch.data.palette()[uncompressedData[i]].load(.unordered);
 					const model = main.blocks.meshes.model(block).model();
 					const occluder = model.allNeighborsOccluded and !block.viewThrough();
 					if(occluder) {
@@ -326,7 +326,7 @@ pub const ChunkCompression = struct { // MARK: ChunkCompression
 			writer.writeInt(u8, @intCast(ch.data.palette().len));
 
 			for(0..ch.data.palette().len) |i| {
-				writer.writeInt(u32, ch.data.palette()[i].toInt());
+				writer.writeInt(u32, ch.data.palette()[i].load(.unordered).toInt());
 			}
 			writer.writeVarInt(usize, compressedData.len);
 			writer.writeSlice(compressedData);
@@ -375,7 +375,7 @@ pub const ChunkCompression = struct { // MARK: ChunkCompression
 				ch.data.initCapacity(paletteLength);
 
 				for(0..paletteLength) |i| {
-					ch.data.palette()[i] = main.blocks.Block.fromInt(try reader.readInt(u32));
+					ch.data.palette()[i] = .init(main.blocks.Block.fromInt(try reader.readInt(u32)));
 				}
 
 				const decompressedData = main.stackAllocator.alloc(u8, chunk.chunkVolume);
@@ -392,7 +392,7 @@ pub const ChunkCompression = struct { // MARK: ChunkCompression
 				}
 			},
 			.uniform => {
-				ch.data.palette()[0] = main.blocks.Block.fromInt(try reader.readInt(u32));
+				ch.data.palette()[0] = .init(main.blocks.Block.fromInt(try reader.readInt(u32)));
 			},
 		}
 	}

--- a/src/server/storage.zig
+++ b/src/server/storage.zig
@@ -282,18 +282,18 @@ pub const ChunkCompression = struct { // MARK: ChunkCompression
 	}
 
 	fn compressBlockData(ch: *chunk.Chunk, allowLossy: bool, writer: *BinaryWriter) void {
-		if(ch.data.paletteLength == 1) {
+		if(ch.data.palette().len == 1) {
 			writer.writeEnum(ChunkCompressionAlgo, .uniform);
-			writer.writeInt(u32, ch.data.palette[0].toInt());
+			writer.writeInt(u32, ch.data.palette()[0].toInt());
 			return;
 		}
-		if(ch.data.paletteLength < 256) {
+		if(ch.data.palette().len < 256) {
 			var uncompressedData: [chunk.chunkVolume]u8 = undefined;
 			var solidMask: [chunk.chunkSize*chunk.chunkSize]u32 = undefined;
 			for(0..chunk.chunkVolume) |i| {
-				uncompressedData[i] = @intCast(ch.data.data.getValue(i));
+				uncompressedData[i] = @intCast(ch.data.impl.raw.data.getValue(i));
 				if(allowLossy) {
-					const block = ch.data.palette[uncompressedData[i]];
+					const block = ch.data.palette()[uncompressedData[i]];
 					const model = main.blocks.meshes.model(block).model();
 					const occluder = model.allNeighborsOccluded and !block.viewThrough();
 					if(occluder) {
@@ -323,10 +323,10 @@ pub const ChunkCompression = struct { // MARK: ChunkCompression
 			defer main.stackAllocator.free(compressedData);
 
 			writer.writeEnum(ChunkCompressionAlgo, .deflate_with_8bit_palette);
-			writer.writeInt(u8, @intCast(ch.data.paletteLength));
+			writer.writeInt(u8, @intCast(ch.data.palette().len));
 
-			for(0..ch.data.paletteLength) |i| {
-				writer.writeInt(u32, ch.data.palette[i].toInt());
+			for(0..ch.data.palette().len) |i| {
+				writer.writeInt(u32, ch.data.palette()[i].toInt());
 			}
 			writer.writeVarInt(usize, compressedData.len);
 			writer.writeSlice(compressedData);
@@ -347,7 +347,7 @@ pub const ChunkCompression = struct { // MARK: ChunkCompression
 	}
 
 	fn decompressBlockData(ch: *chunk.Chunk, reader: *BinaryReader) !void {
-		std.debug.assert(ch.data.paletteLength == 1);
+		std.debug.assert(ch.data.palette().len == 1);
 
 		const compressionAlgorithm = try reader.readEnum(ChunkCompressionAlgo);
 
@@ -371,11 +371,11 @@ pub const ChunkCompression = struct { // MARK: ChunkCompression
 			.deflate_with_8bit_palette, .deflate_with_8bit_palette_no_block_entities => {
 				const paletteLength = try reader.readInt(u8);
 
-				ch.data.deinit();
+				ch.data.deferredDeinit();
 				ch.data.initCapacity(paletteLength);
 
 				for(0..paletteLength) |i| {
-					ch.data.palette[i] = main.blocks.Block.fromInt(try reader.readInt(u32));
+					ch.data.palette()[i] = main.blocks.Block.fromInt(try reader.readInt(u32));
 				}
 
 				const decompressedData = main.stackAllocator.alloc(u8, chunk.chunkVolume);
@@ -392,7 +392,7 @@ pub const ChunkCompression = struct { // MARK: ChunkCompression
 				}
 			},
 			.uniform => {
-				ch.data.palette[0] = main.blocks.Block.fromInt(try reader.readInt(u32));
+				ch.data.palette()[0] = main.blocks.Block.fromInt(try reader.readInt(u32));
 			},
 		}
 	}

--- a/src/server/terrain/chunkgen/TerrainGenerator.zig
+++ b/src/server/terrain/chunkgen/TerrainGenerator.zig
@@ -45,15 +45,11 @@ pub fn generate(worldSeed: u64, chunk: *main.chunk.ServerChunk, caveMap: CaveMap
 			}
 		}
 		if(minHeight > chunk.super.pos.wz +| chunk.super.width) {
-			chunk.super.data.deferredDeinit();
-			chunk.super.data.init();
-			chunk.super.data.palette()[0] = .init(stone);
+			chunk.super.data.fillUniform(stone);
 			return;
 		}
 		if(maxHeight < chunk.super.pos.wz) {
-			chunk.super.data.deferredDeinit();
-			chunk.super.data.init();
-			chunk.super.data.palette()[0] = .init(air);
+			chunk.super.data.fillUniform(air);
 			return;
 		}
 	}

--- a/src/server/terrain/chunkgen/TerrainGenerator.zig
+++ b/src/server/terrain/chunkgen/TerrainGenerator.zig
@@ -45,15 +45,15 @@ pub fn generate(worldSeed: u64, chunk: *main.chunk.ServerChunk, caveMap: CaveMap
 			}
 		}
 		if(minHeight > chunk.super.pos.wz +| chunk.super.width) {
-			chunk.super.data.deinit();
+			chunk.super.data.deferredDeinit();
 			chunk.super.data.init();
-			chunk.super.data.palette[0] = stone;
+			chunk.super.data.palette()[0] = stone;
 			return;
 		}
 		if(maxHeight < chunk.super.pos.wz) {
-			chunk.super.data.deinit();
+			chunk.super.data.deferredDeinit();
 			chunk.super.data.init();
-			chunk.super.data.palette[0] = air;
+			chunk.super.data.palette()[0] = air;
 			return;
 		}
 	}

--- a/src/server/terrain/chunkgen/TerrainGenerator.zig
+++ b/src/server/terrain/chunkgen/TerrainGenerator.zig
@@ -47,13 +47,13 @@ pub fn generate(worldSeed: u64, chunk: *main.chunk.ServerChunk, caveMap: CaveMap
 		if(minHeight > chunk.super.pos.wz +| chunk.super.width) {
 			chunk.super.data.deferredDeinit();
 			chunk.super.data.init();
-			chunk.super.data.palette()[0] = stone;
+			chunk.super.data.palette()[0] = .init(stone);
 			return;
 		}
 		if(maxHeight < chunk.super.pos.wz) {
 			chunk.super.data.deferredDeinit();
 			chunk.super.data.init();
-			chunk.super.data.palette()[0] = air;
+			chunk.super.data.palette()[0] = .init(air);
 			return;
 		}
 	}

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -329,7 +329,7 @@ const ChunkManager = struct { // MARK: ChunkManager
 		}
 		if(pos.voxelSize != 1) { // Generate LOD replacements
 			for(ch.super.data.palette()) |*block| {
-				block.typ = block.lodReplacement();
+				block.store(.{.typ = block.load(.unordered).lodReplacement(), .data = block.load(.unordered).data}, .unordered);
 			}
 		}
 		return ch;

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -328,7 +328,7 @@ const ChunkManager = struct { // MARK: ChunkManager
 			generator.generate(server.world.?.seed ^ generator.generatorSeed, ch, caveMap, biomeMap);
 		}
 		if(pos.voxelSize != 1) { // Generate LOD replacements
-			for(ch.super.data.palette[0..ch.super.data.paletteLength]) |*block| {
+			for(ch.super.data.palette()) |*block| {
 				block.typ = block.lodReplacement();
 			}
 		}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1184,7 +1184,7 @@ pub fn PaletteCompressedRegion(T: type, size: comptime_int) type { // MARK: Pale
 			var impl = self.impl.raw;
 			std.debug.assert(impl.paletteLength <= impl.palette.len);
 			var paletteIndex: u32 = 0;
-			while(paletteIndex < impl.paletteLength) : (paletteIndex += 1) { // TODO: There got to be a faster way to do this. Either using SIMD or using a cache or hashmap.
+			while(paletteIndex < impl.paletteLength) : (paletteIndex += 1) {
 				if(std.meta.eql(impl.palette[paletteIndex].load(.unordered), val)) {
 					break;
 				}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1167,6 +1167,19 @@ pub fn PaletteCompressedRegion(T: type, size: comptime_int) type { // MARK: Pale
 			return impl.palette[0..impl.paletteLength];
 		}
 
+		pub fn fillUniform(self: *Self, value: T) void {
+			const impl = self.impl.raw;
+			if(impl.paletteLength == 1) {
+				impl.palette[0].store(value, .unordered);
+				return;
+			}
+			var newSelf: Self = undefined;
+			newSelf.init();
+			newSelf.impl.raw.palette[0] = .init(value);
+			newSelf.impl.raw = self.impl.swap(newSelf.impl.raw, .release);
+			newSelf.deferredDeinit();
+		}
+
 		fn getOrInsertPaletteIndex(noalias self: *Self, val: T) u32 {
 			var impl = self.impl.raw;
 			std.debug.assert(impl.paletteLength <= impl.palette.len);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1261,7 +1261,10 @@ pub fn PaletteCompressedRegion(T: type, size: comptime_int) type { // MARK: Pale
 				var iNew: u32 = 0;
 				var iOld: u32 = 0;
 				const len: u32 = impl.paletteLength;
-				while(iOld < len) : ({iNew += 1; iOld += 1;}) outer: {
+				while(iOld < len) : ({
+					iNew += 1;
+					iOld += 1;
+				}) outer: {
 					while(impl.paletteOccupancy[iOld] == 0) {
 						iOld += 1;
 						if(iOld >= len) break :outer;


### PR DESCRIPTION
After failing in #1725 I decided to use a different approach at atomizing the palette compressed data, I added a new indirection which can be used to swap the entire content in one atomic operation. This should make the process itself cheaper than what I had implemented before.

related: https://github.com/PixelGuys/Cubyz/issues/1471 https://github.com/PixelGuys/Cubyz/issues/1413

improves https://github.com/PixelGuys/Cubyz/issues/277

Remaining work:
- [x] double check the implementation
- [x] Fully remove the ReadWriteLock
- [x] Check if this improved meshing performance → yes it did by 10-20%
- [x] Check if this improved block update speed → yes it did by ~25%