### PR TITLE
Surface biome fogs

### DIFF
--- a/assets/cubyz/biomes/desert/_defaults.zig.zon
+++ b/assets/cubyz/biomes/desert/_defaults.zig.zon
@@ -1,0 +1,4 @@
+.{
+	.fogDensity = 1.5,
+	.fogColor = 0xe9f2e2,
+}

--- a/assets/cubyz/biomes/ferrock_mountains.zig.zon
+++ b/assets/cubyz/biomes/ferrock_mountains.zig.zon
@@ -10,6 +10,8 @@
 	.maxHeight = 256,
 	.minRadius = 240,
 	.maxRadius = 256,
+	.fogDensity = 1.5,
+	.fogColor = 0xe9f2e2,
 	.roughness = 10,
 	.mountains = 20,
 	.smoothBeaches = true,

--- a/assets/cubyz/biomes/glacier.zig.zon
+++ b/assets/cubyz/biomes/glacier.zig.zon
@@ -8,7 +8,8 @@
 	.minHeight = 80,
 	.maxHeight = 256,
 	.smoothBeaches = true,
-
+	.fogDensity = 1.5,
+	.fogColor = 0xe2f2ff,
 	.minRadius = 150,
 	.maxRadius = 300,
 	.roughness = 50,

--- a/assets/cubyz/biomes/peak.zig.zon
+++ b/assets/cubyz/biomes/peak.zig.zon
@@ -9,7 +9,8 @@
 	.minHeight = 120,
 	.maxHeight = 256,
 	.smoothBeaches = true,
-
+	.fogDensity = 1.5,
+	.fogColor = 0xe2f2ff,
 	.mountains = 125,
 
 	.music = "cubyz:DarkTimes",

--- a/assets/cubyz/biomes/savannah/_defaults.zig.zon
+++ b/assets/cubyz/biomes/savannah/_defaults.zig.zon
@@ -1,0 +1,4 @@
+.{
+	.fogDensity = 1.5,
+	.fogColor = 0xe9f2e2,
+}

--- a/assets/cubyz/biomes/swamp/_defaults.zig.zon
+++ b/assets/cubyz/biomes/swamp/_defaults.zig.zon
@@ -1,0 +1,4 @@
+.{
+	.fogDensity = 2,
+	.fogColor = 0xb0e9d2,
+}

--- a/assets/cubyz/biomes/taiga/cold.zig.zon
+++ b/assets/cubyz/biomes/taiga/cold.zig.zon
@@ -6,6 +6,8 @@
 	.minHeightLimit = 7,
 	.minHeight = 22,
 	.maxHeight = 40,
+	.fogDensity = 1.5,
+	.fogColor = 0xe2f2ff,
 	.maxHeightLimit = 60,
 	.smoothBeaches = true,
 	.minRadius = 256,

--- a/assets/cubyz/biomes/volcano/_defaults.zig.zon
+++ b/assets/cubyz/biomes/volcano/_defaults.zig.zon
@@ -1,0 +1,5 @@
+.{
+	.fogDensity = 2,
+	.fogColor = 0xb4b2b2,
+	.skyColor = 0x9abbe3,
+}

--- a/assets/cubyz/biomes/wetlands/_defaults.zig.zon
+++ b/assets/cubyz/biomes/wetlands/_defaults.zig.zon
@@ -1,0 +1,4 @@
+.{
+	.fogDensity = 2,
+	.fogColor = 0xb0e9d2,
+}


### PR DESCRIPTION
Sandy fog, in deserts, savannas, and ferrock mountains
<img width="1891" height="960" alt="image" src="https://github.com/user-attachments/assets/261320d9-d00e-48c3-b695-fa9d05413dc3" />

Snowy fog, in glaciers, peaks, and cold taigas
<img width="1906" height="994" alt="snowy fog" src="https://github.com/user-attachments/assets/3cc591a9-5230-4c28-919f-65cfc3014d7d" />

Swampy fog in swamps and wetlands
<img width="1845" height="957" alt="wampy fog" src="https://github.com/user-attachments/assets/4d72eb81-b914-4388-8711-f9f76790423c" />

Ash fog in volcanoes
<img width="1797" height="992" alt="volancano fog" src="https://github.com/user-attachments/assets/e0ff090f-0bb4-42c3-a35f-18864ca16bc7" />

Everything else keeps the default "temperate" fog
