### PR TITLE
snow shadow fix

### DIFF
--- a/assets/cubyz/blocks/snow.zig.zon
+++ b/assets/cubyz/blocks/snow.zig.zon
@@ -4,6 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}},
 	},
+	.absorbedLight = 0x555544,
 	.model = "cubyz:cube",
 	.texture = "cubyz:snow",
 }


### PR DESCRIPTION
#1777 
with slight blue tint to snow blocks.

setting `.absorbedLight = 0x555544,`

<img width="600" height="auto" alt="with_555544" src="https://github.com/user-attachments/assets/eab92740-67fb-4c17-94a0-46cb8edea3ad" />
<img width="600" height="auto" alt="without" src="https://github.com/user-attachments/assets/9246bb78-b05b-4a96-8720-27ba60376804" />

note changes in foreground and background.

