### PR TITLE
Make amber spawn on beaches

### DIFF
--- a/assets/cubyz/biomes/beach.zig.zon
+++ b/assets/cubyz/biomes/beach.zig.zon
@@ -27,5 +27,5 @@
 			.depth = 1,
 			.smoothness = 0.1,
 		},
-	}
+	},
 }

--- a/assets/cubyz/biomes/beach.zig.zon
+++ b/assets/cubyz/biomes/beach.zig.zon
@@ -13,7 +13,19 @@
 
 	.music = "cubyz:tides",
 
+	.stoneBlock = "cubyz:sandstone",
 	.ground_structure = .{
 		"2 to 4 cubyz:sand",
 	},
+	.structures = .{
+		.{
+			.id = "cubyz:ground_patch",
+			.block = "cubyz:amber_ore:cubyz:sand",
+			.chance = 0.002,
+			.width = 1,
+			.variation = 2,
+			.depth = 1,
+			.smoothness = 0.1,
+		},
+	}
 }


### PR DESCRIPTION
progress towards #1326 
Amber spawns on beaches, rarely. It's like a special little treat when you find some.

Here's a big patch:
<img width="894" height="442" alt="image" src="https://github.com/user-attachments/assets/0947a956-f5c9-4f39-a5c3-ce0fcdf216fc" />

On average it's more like this:
<img width="937" height="519" alt="image" src="https://github.com/user-attachments/assets/452817c6-7369-43f0-b89e-16a2bad5f6c3" />

Also made the stoneBlock of beaches sandstone... because sand