### PR TITLE
Do not connect fences to viewThrough blocks

### DIFF
--- a/mods/cubyz/rotation/fence.zig
+++ b/mods/cubyz/rotation/fence.zig
@@ -106,7 +106,7 @@ pub fn updateData(block: *Block, neighbor: Neighbor, neighborBlock: Block) bool 
 	const blockBaseModelIndex = blocks.meshes.modelIndexStart(block.*);
 	const neighborBaseModelIndex = blocks.meshes.modelIndexStart(neighborBlock);
 	const neighborModel = blocks.meshes.model(neighborBlock).model();
-	const targetVal = !neighborBlock.replacable() and (blockBaseModelIndex == neighborBaseModelIndex or neighborModel.isNeighborOccluded[neighbor.reverse().toInt()]);
+	const targetVal = !neighborBlock.replacable() and !neighborBlock.viewThrough() and (blockBaseModelIndex == neighborBaseModelIndex or neighborModel.isNeighborOccluded[neighbor.reverse().toInt()]);
 	var currentData: FenceData = @bitCast(@as(u4, @truncate(block.data)));
 	switch(neighbor) {
 		.dirNegX => {


### PR DESCRIPTION
Does this make sense?
If I don't have that check then fences connect to void blocks and they shouldn't do that, that is my main concern.