### PR TITLE
Use "xdg-open" instead of "open"

### DIFF
--- a/src/files.zig
+++ b/src/files.zig
@@ -13,7 +13,7 @@ pub fn openDirInWindow(path: []const u8) void {
 		std.mem.replaceScalar(u8, newPath, '/', '\\');
 	}
 
-	const command = if(builtin.os.tag == .windows) .{"explorer", newPath} else .{"open", newPath};
+	const command = if(builtin.os.tag == .windows) .{"explorer", newPath} else .{"xdg-open", newPath};
 
 	const result = std.process.Child.run(.{
 		.allocator = main.stackAllocator.allocator,


### PR DESCRIPTION
Simple change to use xdg-open command for opening system file manager on Linux instead of outdated "open".

xdg-open is a standardized way of opening files/folders/URLs with a default program on Linux.

Unlike `xdg-open`, `open` doesn't come by default on Ubuntu 25 or Fedora 41, and it's missing from Arch repos completely (only available on AUR).