### PR TITLE
Fix being able to place blocks in your own characters hitbox while on the edge of a block

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -971,7 +971,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 	}
 
 	fn canPlaceBlock(pos: Vec3i, block: main.blocks.Block) bool {
-		if(main.game.collision.collideWithBlock(block, pos[0], pos[1], pos[2], main.game.Player.getPosBlocking() + main.game.Player.outerBoundingBox.center(), main.game.Player.outerBoundingBox.extent() - @as(Vec3d, @splat(0.00005)), .{0, 0, 0}) != null) {
+		if(main.game.collision.collideWithBlock(block, pos[0], pos[1], pos[2], main.game.Player.getPosBlocking() + main.game.Player.outerBoundingBox.center(), main.game.Player.outerBoundingBox.extent(), .{0, 0, 0}) != null) {
 			return false;
 		}
 		return true; // TODO: Check other entities


### PR DESCRIPTION
fixes https://github.com/PixelGuys/Cubyz/issues/1901
The problem was being able to place blocks in yourself while on the edge of the block,
it allowed insanely fast building upwards, as fast as you can click to place blocks as being inside a block teleports you up

fix was removing " - @as(Vec3d, @splat(0.00005)) "  - this part decreased the characters hitbox during collision check

I guess its intended function was to fix possible false positives from floating point precision error while placing blocks,
after the change i did some testing with placing blocks on the edge of characters hitbox but didn't experience any problems