### PR TITLE
Disable zig formatter in VSCode by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "zig.formattingProvider": "off",
+    "zig.path": "${workspaceFolder}/compiler/zig/zig.exe"
+}


### PR DESCRIPTION
The contributing guide states

> you need to disable zig's formatter (In VSCode you can disable this in the Zig extension settings)

So I figured it would be a good idea to just have the project do that automatically.