### PR TITLE
Fix allowing for clicking gui window buttons (zoomin, zoomout, close) while moving the cursor

### DIFF
--- a/src/gui/GuiWindow.zig
+++ b/src/gui/GuiWindow.zig
@@ -174,7 +174,6 @@ pub fn mainButtonReleased(self: *GuiWindow, mousePosition: Vec2f) void {
 		const zoomInPos = btnPos[2];
 		const mousePositionRelative = mousePosition - self.pos;
 		const grabPositionRelative = if(grabPosition) |gp| gp - self.pos else @as(@Vector(2, f32), .{0.0, 0.0});
-		const windowEnd: f32 = closePos + (btnPos[0] - btnPos[1]);
 
 		if(mousePositionRelative[1] >= 0 and mousePositionRelative[1] <= titleBarHeight) {
 			if(mousePositionRelative[0] > zoomInPos and mousePositionRelative[0] <= zoomOutPos and grabPositionRelative[0] > zoomInPos and grabPositionRelative[0] <= zoomOutPos) {
@@ -198,7 +197,7 @@ pub fn mainButtonReleased(self: *GuiWindow, mousePosition: Vec2f) void {
 				gui.updateWindowPositions();
 				gui.save();
 			}
-			if(mousePositionRelative[0] > closePos and mousePositionRelative[0] <= windowEnd and grabPositionRelative[0] > closePos and grabPositionRelative[0] <= windowEnd) {
+			if(mousePositionRelative[0] > closePos and grabPositionRelative[0] > closePos) {
 				// Close
 				if(self.closeable) gui.closeWindowFromRef(self);
 			}


### PR DESCRIPTION
Fix https://github.com/PixelGuys/Cubyz/issues/1942
If mouse click and release position weren't identical clicking a button wouldn't work
Now it works when original click position and mouse release position are on the same button

This only applies to the zoomIn zoomOut and close  buttons for managing gui window
normal in gui window buttons like "Settings" are working correctly

Why was this a problem:
while clicking a mouse button user can experience slight mouse movement which would invalidate the button click