### PR TITLE
Skip durability cost on blocks that don’t match tool (part of #1023)

### DIFF
--- a/src/items.zig
+++ b/src/items.zig
@@ -849,15 +849,22 @@ pub const Tool = struct { // MARK: Tool
 		return self.tooltip.items;
 	}
 
+	pub fn isEffectiveOn(self: *Tool, block: main.blocks.Block) bool {
+		for(block.blockTags()) |blockTag| {
+			for(self.type.blockTags()) |toolTag| {
+				if(toolTag == blockTag) return true;
+			}
+		}
+		return false;
+	}
+
 	pub fn getBlockDamage(self: *Tool, block: main.blocks.Block) f32 {
 		var damage = self.damage;
 		for(self.modifiers) |modifier| {
 			damage = modifier.changeBlockDamage(damage, block);
 		}
-		for(block.blockTags()) |blockTag| {
-			for(self.type.blockTags()) |toolTag| {
-				if(toolTag == blockTag) return damage;
-			}
+		if(self.isEffectiveOn(block)) {
+			return damage;
 		}
 		return 0;
 	}

--- a/src/rotation.zig
+++ b/src/rotation.zig
@@ -106,7 +106,7 @@ pub const RotationMode = struct { // MARK: RotationMode
 				}
 				damage -= oldBlock.blockResistance();
 				if(damage > 0) {
-					if(isTool) {
+					if(isTool and item.item.?.tool.isEffectiveOn(oldBlock)) {
 						return .{.yes_costsDurability = 1};
 					} else return .yes;
 				}


### PR DESCRIPTION
Adds the Tool.isEffectiveOn(block) helper to avoid duplication and uses it in canBeChangedInto and getBlockDamage.

Doesn't cause a change in in-game behavior yet. This will have an actual effect and resolve​ #1023 once the block-breaking code treats ineffective tools as non-tool items (planned for follow-up PR).