### PR TITLE
Treat tools as non-tool items when ineffective on block (completes #1023)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -418,6 +418,7 @@ pub const Player = struct { // MARK: Player
 	pub const inventorySize = 32;
 	pub var inventory: Inventory = undefined;
 	pub var selectedSlot: u32 = 0;
+	pub const defaultBlockDamage: f32 = 1;
 
 	pub var selectionPosition1: ?Vec3i = null;
 	pub var selectionPosition2: ?Vec3i = null;

--- a/src/items.zig
+++ b/src/items.zig
@@ -25,8 +25,6 @@ const modifierRestrictionList = @import("tool/modifiers/restrictions/_list.zig")
 
 pub const Inventory = @import("Inventory.zig");
 
-pub const defaultBlockDamage: f32 = 1;
-
 const Material = struct { // MARK: Material
 	massDamage: f32 = undefined,
 	hardnessDamage: f32 = undefined,
@@ -868,7 +866,7 @@ pub const Tool = struct { // MARK: Tool
 		if(self.isEffectiveOn(block)) {
 			return damage;
 		}
-		return defaultBlockDamage;
+		return main.game.Player.defaultBlockDamage;
 	}
 
 	pub fn onUseReturnBroken(self: *Tool) bool {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -1063,7 +1063,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 
 			main.items.Inventory.Sync.ClientSide.mutex.lock();
 			if(!game.Player.isCreative()) {
-				var damage: f32 = main.items.defaultBlockDamage;
+				var damage: f32 = main.game.Player.defaultBlockDamage;
 				const isTool = stack.item != null and stack.item.? == .tool;
 				if(isTool) {
 					damage = stack.item.?.tool.getBlockDamage(block);

--- a/src/rotation.zig
+++ b/src/rotation.zig
@@ -99,7 +99,7 @@ pub const RotationMode = struct { // MARK: RotationMode
 			if(oldBlock == newBlock) return .no;
 			if(oldBlock.typ == newBlock.typ) return .yes;
 			if(!oldBlock.replacable()) {
-				var damage: f32 = main.items.defaultBlockDamage;
+				var damage: f32 = main.game.Player.defaultBlockDamage;
 				const isTool = item.item != null and item.item.? == .tool;
 				if(isTool) {
 					damage = item.item.?.tool.getBlockDamage(oldBlock);


### PR DESCRIPTION
Removes the restriction that prevents block breaking when using an ineffective tool by making `getBlockDamage` return the default non-tool damage. Sets `swingTime` in `breakBlock` to the default value when the tool is not effective. Defines a shared constant `defaultBlockDamage` to remove magic numbers.

Combined with previous durability cost logic change, this fully fixes #1023.