### PR TITLE
Dynamic nametag scaling based on player distance

### DIFF
--- a/src/entity.zig
+++ b/src/entity.zig
@@ -178,7 +178,7 @@ pub const ClientEntityManager = struct {
 			var buf = graphics.TextBuffer.init(main.stackAllocator, ent.name, .{.color = 0}, false, .center);
 			defer buf.deinit();
 			const size = buf.calculateLineBreaks(48/dstclamped*heightRef, 1024);
-			buf.render(xCenter - size[0]/2, yCenter - size[1], 48/dstclamped*heightRef);
+			buf.renderTextWithoutShadow(xCenter - size[0]/2, yCenter - size[1], 48/dstclamped*heightRef);
 		}
 	}
 


### PR DESCRIPTION
Font size changes from 48px to 16px from 1 - 100 blocks
Tested on different resolutions