### PR TITLE
Add a way seamlessly build/run on NixOS like on other systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ test.png
 !/assets/backgrounds/default_background.png
 /assets/cubyz/music
 /assets/cubyz/fonts
+
+# nix-build result
+/result

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ sudo apt install libgl-dev libasound2-dev libx11-dev libxcursor-dev libxrandr-de
 3. Run `run_linux.sh` or `run_windows.bat`, if you already have Zig installed on your computer (it must be a compatible version) you can also just use `zig build run`
 4. When you want to update your local version you can use `git pull`. This keeps everything in one place, avoiding repeatedly downloading the compiler on every update.
 
+### For Nix/NixOS users
+
+Follow the download steps above, except instead of running `run_linux.sh`:
+1. Run `nix-build cubyz-fhs-dev.nix` once (you do not need to do this again to recompile)
+2. Run `./result/bin/cubyz-fhs-dev run_linux.sh`
+
+This will install the required libraries and compile the game from the code on your local machine.
+
 # Contributing
 ### Code
 Check out the [Contributing Guidelines](https://github.com/PixelGuys/Cubyz/blob/master/docs/CONTRIBUTING.md)

--- a/cubyz-fhs-dev.nix
+++ b/cubyz-fhs-dev.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.buildFHSEnv {
+  name = "cubyz-fhs-dev";
+  
+  targetPkgs = p: with p; [
+    xorg.libX11
+    xorg.libXcursor
+    xorg_sys_opengl
+    libGL
+    alsa-lib
+    vulkan-loader
+    vulkan-validation-layers
+    vulkan-tools
+    bash
+  ];
+
+  runScript = ''
+    bash "$@"
+  '';
+}


### PR DESCRIPTION
README contains the required steps

This would somewhat fix #658 (the author would then be able to work on cubyz, as they requested), but due to the zig compiler and cubyz-libs being vendored, it does not fix it in the way that was described in the issue discussion. This PR doesn't touch the existing build process because I decided that was beyond the scope of what i needed, wanted, and was able to do, but a "proper" nix build would allow for a `shell.nix` instead of just a wrapper for the existing run scripts. That would have several benefits over this (not needing a wrapper, being able to provide a language server, not relying on blobs) - but it is also very difficult to do without fundamentally altering the build process.