### PR TITLE
Make white glass craftable

### DIFF
--- a/assets/cubyz/recipes/special_recipes.zig.zon
+++ b/assets/cubyz/recipes/special_recipes.zig.zon
@@ -48,6 +48,10 @@
 		.output = "cubyz:terracotta",
 	},
 	.{
+		.inputs = .{"cubyz:coal_ore", "cubyz:sand"},
+		.output = "cubyz:glass/white",
+	},
+	.{
 		.inputs = .{"1 cubyz:torch", "2 cubyz:iron_ingot"},
 		.output = "cubyz:lamp",
 	},

--- a/assets/cubyz/recipes/special_recipes.zig.zon
+++ b/assets/cubyz/recipes/special_recipes.zig.zon
@@ -44,12 +44,12 @@
 		.output = "cubyz:uranium_ingot",
 	},
 	.{
-		.inputs = .{"cubyz:coal_ore", "cubyz:clay"},
-		.output = "cubyz:terracotta",
+		.inputs = .{"cubyz:coal_ore", "8 cubyz:clay"},
+		.output = "8 cubyz:terracotta",
 	},
 	.{
-		.inputs = .{"cubyz:coal_ore", "cubyz:sand"},
-		.output = "cubyz:glass/white",
+		.inputs = .{"cubyz:coal_ore", "8 cubyz:sand"},
+		.output = "8 cubyz:glass/white",
 	},
 	.{
 		.inputs = .{"1 cubyz:torch", "2 cubyz:iron_ingot"},


### PR DESCRIPTION
If Snale can magically smelt metal ingots, surely they can smelt glass as well.

Considering we already have temporary recipes for clay -> terracotta and glass -> uranium glass, I don't see why we can't have glass craftable.