### PR TITLE
Fix menu fov overriding fov setting

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -593,6 +593,7 @@ pub const MenuBackGround = struct {
 		const viewMatrix = Mat4f.rotationZ(angle);
 		pipeline.bind(null);
 		updateViewport(main.Window.width, main.Window.height, 70.0);
+		defer updateViewport(Window.width, Window.height, settings.fov);
 
 		c.glUniformMatrix4fv(uniforms.viewMatrix, 1, c.GL_TRUE, @ptrCast(&viewMatrix));
 		c.glUniformMatrix4fv(uniforms.projectionMatrix, 1, c.GL_TRUE, @ptrCast(&game.projectionMatrix));


### PR DESCRIPTION
Fixes #1962 by adding a defer which sets the viewport fov to whatever the selected fov is in settings. This line is located right under the one which sets the fov to 70 while in the main menu. So upon entering a world from now on, the fov should properly be adjusted to whatever you chose.

I'm still pretty new to GitHub and this is my first pull request, so please let me know if there are any issues or if I can do anything better.