### PR TITLE
Always display stack size for stackable items

### DIFF
--- a/src/gui/components/ItemSlot.zig
+++ b/src/gui/components/ItemSlot.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 
 const main = @import("main");
 const Inventory = main.items.Inventory;
-const Item = main.items.Item;
 const graphics = main.graphics;
 const draw = graphics.draw;
 const Texture = graphics.Texture;


### PR DESCRIPTION
Hi, first time contributing, looking to contribute to a cool project and learn a new language! I'm quite into UX at the moment.

Closes: #1628 

See below, I checked how it looks in a chest, user inventory, craft window, workbench as well as the creative window. I've made the assumption that the creative window should have no stack size, to maintain visual clarity (it's just a bunch of 1s otherwise).

<img width="2553" height="1390" alt="image" src="https://github.com/user-attachments/assets/acc77d40-5acb-461b-b1e1-0812c675b004" />

<img width="1285" height="856" alt="image" src="https://github.com/user-attachments/assets/cc9c890f-1aa4-4a09-886b-5b3d3a615e26" />
