### PR TITLE
Better name bar rendering

### DIFF
--- a/src/entity.zig
+++ b/src/entity.zig
@@ -153,7 +153,6 @@ pub const ClientEntityManager = struct {
 		mutex.lock();
 		defer mutex.unlock();
 
-		// this value is relative to the fov-y and window size
 		const screenUnits = @as(f32, @floatFromInt(main.Window.height))/1024;
 		const fontBaseSize = 128.0;
 		const fontMinScreenSize = 16.0;


### PR DESCRIPTION
Reduces visual noise when many players are connected. Makes it possible to estimate the distance of any given player from you.

- now text size is relative to world units;
- added fadeout on long distances.

Alternative to #1963.

<img width="680" alt="image_2025-10-14_10-17-29" src="https://github.com/user-attachments/assets/6af93d99-9904-4620-83f6-c3cdd2a53c67" />
<img width="680" alt="image_2025-10-14_10-17-57" src="https://github.com/user-attachments/assets/36a27981-5954-4fb4-a5e2-c058969a8dba" />
<img width="680" alt="image_2025-10-14_10-19-07" src="https://github.com/user-attachments/assets/f65680f2-ba9c-431b-b396-3691c8f7c7ce" />
<img width="680" alt="image_2025-10-14_10-19-42" src="https://github.com/user-attachments/assets/30e20c42-a966-4191-a477-90269e564041" />
