### PR TITLE
Provide detailed message on disconnection

### DIFF
--- a/src/gui/windows/manage_players.zig
+++ b/src/gui/windows/manage_players.zig
@@ -23,7 +23,7 @@ const padding: f32 = 8;
 var userList: []*main.server.User = &.{};
 
 fn kick(conn: *main.network.Connection) void {
-	conn.disconnect(.kicked);
+	conn.disconnect(.kicked, null);
 }
 
 pub fn onOpen() void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -655,7 +655,6 @@ pub fn main() void { // MARK: main()
 			shouldExitToMenu.store(false, .monotonic);
 			Window.setMouseGrabbed(false);
 			if(game.world) |world| {
-				server.kickPlayers(.serverStopped);
 				world.deinit();
 				game.world = null;
 			}


### PR DESCRIPTION
Fix #1828

I started working on this issue, as it stated "contributor friendly" and "short-term goal". 
I think I encountered an issue (don't know if it's workings as intended but), the disconnect function is called twice by the client:
- when received a disconnect packet on `disconnect` channel
- when the client calls the `deinit()` method from the `Connection` struct.

Tested in debug mode with two local clients.