### PR TITLE
Implement culling in VerticalList.render

### DIFF
--- a/src/gui/components/VerticalList.zig
+++ b/src/gui/components/VerticalList.zig
@@ -139,7 +139,7 @@ pub fn render(self: *VerticalList, mousePosition: Vec2f) void {
 		const itemYPos = child.pos()[1];
 		const adjustedYPos = itemYPos + shiftedPos[1];
 
-		if(adjustedYPos + child.size()[1] < 0 or adjustedYPos > self.maxHeight + child.size()[1]) {
+		if(adjustedYPos + child.size()[1] < 0 or adjustedYPos - child.size()[1] > self.maxHeight + child.size()[1]) {
 			continue;
 		}
 		child.render(mousePosition - shiftedPos);


### PR DESCRIPTION
Fixes #1991

Items that do not fall within the bounds of the guiwindow are not
rendered.

Whether a item is within view or not is determined by calculating the
item's position in the list and the item's position offset by the scrollbar's
position

If that offset value is < 0, skip rendering
If that offset value is > self.maxHeight, skip rendering.