### PR TITLE
Add debug info showing update times

### DIFF
--- a/src/gui/windows/debug.zig
+++ b/src/gui/windows/debug.zig
@@ -41,6 +41,10 @@ pub fn render() void {
 	y += 8;
 	draw.print("frameTime: {d:.1} ms", .{main.lastFrameTime.load(.monotonic)*1000.0}, 0, y, 8, .left);
 	y += 8;
+	draw.print("gameUpdateTime: {d:.1} ms", .{main.lastGameUpdateTimeMs.load(.monotonic)}, 0, y, 8, .left);
+	y += 8;
+	draw.print("renderTime: {d:.1} ms", .{main.lastRenderTimeMs.load(.monotonic)}, 0, y, 8, .left);
+	y += 8;
 	draw.print("window size: {}×{}", .{main.Window.width, main.Window.height}, 0, y, 8, .left);
 	y += 8;
 	if(main.game.world != null) {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -2285,3 +2285,21 @@ pub fn panicWithMessage(comptime fmt: []const u8, args: anytype) noreturn {
 	const message = std.fmt.allocPrint(main.stackAllocator.allocator, fmt, args) catch unreachable;
 	@panic(message);
 }
+
+pub const TimeMeasure = struct {
+	start: i128,
+
+	pub fn init() TimeMeasure {
+		return .{.start = std.time.nanoTimestamp()};
+	}
+	pub fn elapsedNano(self: *const TimeMeasure) i128 {
+		return std.time.nanoTimestamp() -% self.start;
+	}
+	pub fn elapsedMilli(self: *const TimeMeasure) f64 {
+		return @as(f64, @floatFromInt(self.elapsedNano()))/std.time.ns_per_ms;
+	}
+	/// Elapsed time in seconds
+	pub fn elapsed(self: *const TimeMeasure) f64 {
+		return @as(f64, @floatFromInt(self.elapsedNano()))/std.time.ns_per_s;
+	}
+};


### PR DESCRIPTION
This adds measurements to debug window about how much render+update  took. It also adds utility for measuring times and uses it for existing measurements in the main loop.