### PR TITLE
Add ability to toggle sprint

### DIFF
--- a/src/graphics/Window.zig
+++ b/src/graphics/Window.zig
@@ -271,6 +271,7 @@ pub const GamepadAxis = struct {
 pub const Key = struct { // MARK: Key
 	name: []const u8,
 	pressed: bool = false,
+	isToggling: IsToggling = .never,
 	modsOnPress: Modifiers = .{},
 	value: f32 = 0.0,
 	key: c_int = c.GLFW_KEY_UNKNOWN,
@@ -284,6 +285,12 @@ pub const Key = struct { // MARK: Key
 	notifyRequirement: Requirement = .always,
 	grabbedOnPress: bool = false,
 	requiredModifiers: Modifiers = .{},
+
+	pub const IsToggling = enum {
+		never,
+		no,
+		yes,
+	};
 
 	pub const Modifiers = packed struct(u6) {
 		shift: bool = false,
@@ -428,6 +435,12 @@ pub const Key = struct { // MARK: Key
 	}
 
 	fn setPressed(self: *Key, newPressed: bool, isGrabbed: bool, mods: Modifiers, textKeyPressedInTextField: bool) void {
+		if(self.isToggling == .yes) {
+			if(newPressed) {
+				self.pressed = !self.pressed;
+			}
+			return;
+		}
 		if(newPressed != self.pressed) {
 			self.pressed = newPressed;
 			self.modsOnPress = mods;

--- a/src/gui/windows/controls.zig
+++ b/src/gui/windows/controls.zig
@@ -61,6 +61,10 @@ fn invertMouseYCallback(newValue: bool) void {
 	main.settings.invertMouseY = newValue;
 	main.settings.save();
 }
+fn sprintIsToggleCallback(newValue: bool) void {
+	main.KeyBoard.setIsToggling("sprint", newValue);
+	main.settings.save();
+}
 
 fn updateDeadzone(deadzone: f32) void {
 	main.settings.controllerAxisDeadzone = deadzone;
@@ -96,6 +100,7 @@ pub fn onOpen() void {
 	list.add(Button.initText(.{0, 0}, 128, if(editingKeyboard) "Gamepad" else "Keyboard", .{.callback = &toggleKeyboard}));
 	list.add(ContinuousSlider.init(.{0, 0}, 256, 0, 5, if(editingKeyboard) main.settings.mouseSensitivity else main.settings.controllerSensitivity, &updateSensitivity, &sensitivityFormatter));
 	list.add(CheckBox.init(.{0, 0}, 256, "Invert mouse Y", main.settings.invertMouseY, &invertMouseYCallback));
+	list.add(CheckBox.init(.{0, 0}, 256, "Toggle sprint", main.KeyBoard.key("sprint").isToggling == .yes, &sprintIsToggleCallback));
 
 	if(!editingKeyboard) {
 		list.add(ContinuousSlider.init(.{0, 0}, 256, 0, 5, main.settings.controllerAxisDeadzone, &updateDeadzone, &deadzoneFormatter));

--- a/src/main.zig
+++ b/src/main.zig
@@ -360,7 +360,7 @@ pub const KeyBoard = struct { // MARK: KeyBoard
 		.{.name = "left", .key = c.GLFW_KEY_A, .gamepadAxis = .{.axis = c.GLFW_GAMEPAD_AXIS_LEFT_X, .positive = false}},
 		.{.name = "backward", .key = c.GLFW_KEY_S, .gamepadAxis = .{.axis = c.GLFW_GAMEPAD_AXIS_LEFT_Y, .positive = true}},
 		.{.name = "right", .key = c.GLFW_KEY_D, .gamepadAxis = .{.axis = c.GLFW_GAMEPAD_AXIS_LEFT_X, .positive = true}},
-		.{.name = "sprint", .key = c.GLFW_KEY_LEFT_CONTROL, .gamepadButton = c.GLFW_GAMEPAD_BUTTON_LEFT_THUMB},
+		.{.name = "sprint", .key = c.GLFW_KEY_LEFT_CONTROL, .gamepadButton = c.GLFW_GAMEPAD_BUTTON_LEFT_THUMB, .isToggling = .no},
 		.{.name = "jump", .key = c.GLFW_KEY_SPACE, .gamepadButton = c.GLFW_GAMEPAD_BUTTON_A},
 		.{.name = "crouch", .key = c.GLFW_KEY_LEFT_SHIFT, .gamepadButton = c.GLFW_GAMEPAD_BUTTON_RIGHT_THUMB},
 		.{.name = "fly", .key = c.GLFW_KEY_F, .gamepadButton = c.GLFW_GAMEPAD_BUTTON_DPAD_DOWN, .pressAction = &game.flyToggle},
@@ -434,14 +434,33 @@ pub const KeyBoard = struct { // MARK: KeyBoard
 		.{.name = "advancedNetworkDebugOverlay", .key = c.GLFW_KEY_F7, .pressAction = &toggleAdvancedNetworkDebugOverlay},
 	};
 
-	pub fn key(name: []const u8) *const Window.Key { // TODO: Maybe I should use a hashmap here?
+	fn findKey(name: []const u8) ?*Window.Key { // TODO: Maybe I should use a hashmap here?
 		for(&keys) |*_key| {
 			if(std.mem.eql(u8, name, _key.name)) {
 				return _key;
 			}
 		}
-		std.log.err("Couldn't find keyboard key with name {s}", .{name});
-		return &.{.name = ""};
+		return null;
+	}
+	pub fn key(name: []const u8) *const Window.Key {
+		return findKey(name) orelse {
+			std.log.err("Couldn't find keyboard key with name {s}", .{name});
+			return &.{.name = ""};
+		};
+	}
+	pub fn setIsToggling(name: []const u8, value: bool) void {
+		if(findKey(name)) |theKey| {
+			if(theKey.isToggling == .never) {
+				std.log.err("Tried setting toggling on non-toggling key with name {s}", .{name});
+				return;
+			}
+			theKey.isToggling = if(value) .yes else .no;
+			if(!value) {
+				theKey.pressed = false;
+			}
+		} else {
+			std.log.err("Couldn't find keyboard key to toggle with name {s}", .{name});
+		}
 	}
 };
 

--- a/src/settings.zig
+++ b/src/settings.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 
 const ZonElement = @import("zon.zig").ZonElement;
 const main = @import("main");
+const Window = @import("graphics/Window.zig");
 
 pub const version = @import("utils/version.zig");
 
@@ -104,6 +105,9 @@ pub fn init() void {
 		key.key = keyZon.get(c_int, "key", key.key);
 		key.mouseButton = keyZon.get(c_int, "mouseButton", key.mouseButton);
 		key.scancode = keyZon.get(c_int, "scancode", key.scancode);
+		if(key.isToggling != .never) {
+			key.isToggling = std.meta.stringToEnum(Window.Key.IsToggling, keyZon.get([]const u8, "isToggling", "")) orelse key.isToggling;
+		}
 	}
 }
 
@@ -157,6 +161,9 @@ pub fn save() void {
 		keyZon.put("key", key.key);
 		keyZon.put("mouseButton", key.mouseButton);
 		keyZon.put("scancode", key.scancode);
+		if(key.isToggling != .never) {
+			keyZon.put("isToggling", @tagName(key.isToggling));
+		}
 		keyboard.put(key.name, keyZon);
 	}
 	zonObject.put("keyboard", keyboard);


### PR DESCRIPTION
Closes #554

There is a new option in settings, a checkbox that makes it so that sprint is enabled by the sprint button - not exactly "toggled" because another press does not stop sprinting. Sprinting is stopped when player stops pressing any movement buttons, or when player is stopped by an obstacle.