### PR TITLE
Fix item tooltip obstructing items and overflowing

### DIFF
--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -769,26 +769,29 @@ pub const inventory = struct { // MARK: inventory
 				const tooltip = item.getTooltip();
 				var textBuffer = graphics.TextBuffer.init(main.stackAllocator, tooltip, .{}, false, .left);
 				defer textBuffer.deinit();
-				var size = textBuffer.calculateLineBreaks(16, 300);
+				const fontSize = 16;
+				var size = textBuffer.calculateLineBreaks(fontSize, 300);
 				size[0] = 0;
 				for(textBuffer.lineBreaks.items) |lineBreak| {
 					size[0] = @max(size[0], lineBreak.width);
 				}
+				const windowSize = main.Window.getWindowSize()/@as(Vec2f, @splat(scale));
+				const xOffset = 18;
+				const padding: f32 = 1;
+				const border: f32 = padding + 1;
 				var pos = mousePos;
-				if(pos[0] + size[0] >= main.Window.getWindowSize()[0]/scale) {
-					pos[0] -= size[0];
+				if(pos[0] + size[0] + border + xOffset >= windowSize[0]) {
+					pos[0] -= size[0] + xOffset;
+				} else {
+					pos[0] += xOffset;
 				}
-				if(pos[1] + size[1] >= main.Window.getWindowSize()[1]/scale) {
-					pos[1] -= size[1];
-				}
-				pos = @max(pos, Vec2f{0, 0});
-				const border1: f32 = 2;
-				const border2: f32 = 1;
+				pos[1] = @min(pos[1] - fontSize, windowSize[1] - size[1] - border);
+				pos = @max(pos, Vec2f{border, border});
 				draw.setColor(0xffffff00);
-				draw.rect(pos - @as(Vec2f, @splat(border1)), size + @as(Vec2f, @splat(2*border1)));
+				draw.rect(pos - @as(Vec2f, @splat(border)), size + @as(Vec2f, @splat(2*border)));
 				draw.setColor(0xff000000);
-				draw.rect(pos - @as(Vec2f, @splat(border2)), size + @as(Vec2f, @splat(2*border2)));
-				textBuffer.render(pos[0], pos[1], 16);
+				draw.rect(pos - @as(Vec2f, @splat(padding)), size + @as(Vec2f, @splat(2*padding)));
+				textBuffer.render(pos[0], pos[1], fontSize);
 			}
 		};
 	}


### PR DESCRIPTION
Currently, the item tooltip has a few problems:
- It renders directly under the mouse
- It obstructs the item being hovered over
- The yellow border can overflow past the edges of the screen
- The tooltip flips vertically when near the bottom of the screen, which I find distracting

This implements the following fixes:
- Horizontally offset the tooltip so the item underneath is visible
- Vertically aligned the tooltip's first line with the mouse's position so it feels more centered without being unpredictable
- Made the tooltip butt up against the bottom of the screen instead of vertically flipping
- Cleaned up the handling of border/padding offsets so the tooltip never escapes the edges of the screen

https://github.com/user-attachments/assets/b6e5fb26-c06b-4d34-b298-f2e48f5089f2