### PR TITLE
Checkbox context

### DIFF
--- a/src/graphics/Window.zig
+++ b/src/graphics/Window.zig
@@ -465,6 +465,17 @@ pub const Key = struct { // MARK: Key
 			.repeat => if(self.repeatAction) |a| a(mods),
 		}
 	}
+
+	pub fn toggleIsToggling(self: *Key) void {
+		if(self.isToggling == .never) {
+			std.log.err("Tried setting toggling on non-toggling key with name {s}", .{self.name});
+			return;
+		}
+		self.isToggling = if(self.isToggling == .no) .yes else .no;
+		if(self.isToggling == .no) {
+			self.pressed = false;
+		}
+	}
 };
 
 pub const GLFWCallbacks = struct { // MARK: GLFWCallbacks

--- a/src/gui/components/CheckBox.zig
+++ b/src/gui/components/CheckBox.zig
@@ -32,7 +32,8 @@ size: Vec2f,
 state: bool = false,
 pressed: bool = false,
 hovered: bool = false,
-onAction: *const fn(bool) void,
+ctx: *anyopaque,
+onAction: *const fn(ctx: *anyopaque) void,
 label: *Label,
 
 pub fn __init() void {
@@ -53,13 +54,14 @@ pub fn __deinit() void {
 	textureEmptyPressed.deinit();
 }
 
-pub fn init(pos: Vec2f, width: f32, text: []const u8, initialValue: bool, onAction: *const fn(bool) void) *CheckBox {
+pub fn init(pos: Vec2f, width: f32, text: []const u8, initialValue: bool, ctx: *anyopaque, onAction: *const fn(ctx: *anyopaque) void) *CheckBox {
 	const label = Label.init(undefined, width - 3*border - boxSize, text, .left);
 	const self = main.globalAllocator.create(CheckBox);
 	self.* = CheckBox{
 		.pos = pos,
 		.size = Vec2f{@max(width, label.size[0] + 3*border + boxSize), label.size[1] + 3*border},
 		.state = initialValue,
+		.ctx = ctx,
 		.onAction = onAction,
 		.label = label,
 	};
@@ -88,7 +90,7 @@ pub fn mainButtonReleased(self: *CheckBox, mousePosition: Vec2f) void {
 		self.pressed = false;
 		if(GuiComponent.contains(self.pos, self.size, mousePosition)) {
 			self.state = !self.state;
-			self.onAction(self.state);
+			self.onAction(self.ctx);
 		}
 	}
 }

--- a/src/gui/windows/graphics.zig
+++ b/src/gui/windows/graphics.zig
@@ -84,14 +84,14 @@ fn lodDistanceCallback(newValue: f32) void {
 	settings.save();
 }
 
-fn bloomCallback(newValue: bool) void {
-	settings.bloom = newValue;
+fn toggleSettingCallback(ctx: *anyopaque) void {
+	const theValue: *bool = @ptrCast(@alignCast(ctx));
+	theValue.* = !theValue.*;
 	settings.save();
 }
 
-fn vsyncCallback(newValue: bool) void {
-	settings.vsync = newValue;
-	settings.save();
+fn toggleWindowSettingCallback(ctx: *anyopaque) void {
+	toggleSettingCallback(ctx);
 	main.Window.reloadSettings();
 }
 
@@ -109,12 +109,6 @@ fn resolutionScaleCallback(newValue: u16) void {
 	main.Window.GLFWCallbacks.framebufferSize(null, main.Window.width, main.Window.height);
 }
 
-fn vulkanTestingWindowCallback(newValue: bool) void {
-	settings.vulkanTestingWindow = newValue;
-	settings.save();
-	main.Window.reloadSettings();
-}
-
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
 	list.add(ContinuousSlider.init(.{0, 0}, 128, 10.0, 154.0, @floatFromInt(settings.fpsCap orelse 154), &fpsCapCallback, &fpsCapFormatter));
@@ -125,8 +119,8 @@ pub fn onOpen() void {
 	list.add(DiscreteSlider.init(.{0, 0}, 128, "#ffffffLeaves Quality (TODO: requires reload): ", "{}", &leavesQualities, settings.leavesQuality - leavesQualities[0], &leavesQualityCallback));
 	list.add(ContinuousSlider.init(.{0, 0}, 128, 50.0, 400.0, settings.@"lod0.5Distance", &lodDistanceCallback, &lodDistanceFormatter));
 	list.add(ContinuousSlider.init(.{0, 0}, 128, 40.0, 120.0, settings.fov, &fovCallback, &fovFormatter));
-	list.add(CheckBox.init(.{0, 0}, 128, "Bloom", settings.bloom, &bloomCallback));
-	list.add(CheckBox.init(.{0, 0}, 128, "Vertical Synchronization", settings.vsync, &vsyncCallback));
+	list.add(CheckBox.init(.{0, 0}, 128, "Bloom", settings.bloom, &settings.bloom, &toggleSettingCallback));
+	list.add(CheckBox.init(.{0, 0}, 128, "Vertical Synchronization", settings.vsync, &settings.vsync, &toggleWindowSettingCallback));
 	list.add(DiscreteSlider.init(.{0, 0}, 128, "#ffffffAnisotropic Filtering: ", "{}x", &anisotropy, switch(settings.anisotropicFiltering) {
 		1 => 0,
 		2 => 1,
@@ -136,7 +130,7 @@ pub fn onOpen() void {
 		else => 2,
 	}, &anisotropicFilteringCallback));
 	list.add(DiscreteSlider.init(.{0, 0}, 128, "#ffffffResolution Scale: ", "{}%", &resolutions, @as(u16, @intFromFloat(@log2(settings.resolutionScale) + 2.0)), &resolutionScaleCallback));
-	list.add(CheckBox.init(.{0, 0}, 128, "Vulkan testing window (requires restart)", settings.vulkanTestingWindow, &vulkanTestingWindowCallback));
+	list.add(CheckBox.init(.{0, 0}, 128, "Vulkan testing window (requires restart)", settings.vulkanTestingWindow, &settings.vulkanTestingWindow, &toggleWindowSettingCallback));
 	list.finish(.center);
 	window.rootComponent = list.toComponent();
 	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));

--- a/src/gui/windows/save_creation.zig
+++ b/src/gui/windows/save_creation.zig
@@ -29,21 +29,20 @@ var textInput: *TextInput = undefined;
 var gamemode: main.game.Gamemode = .creative;
 var gamemodeInput: *Button = undefined;
 
-var allowCheats: bool = true;
+const defaultAllowCheats = true;
+var allowCheats: bool = defaultAllowCheats;
 
-var testingMode: bool = false;
+const defaultTestingMode = false;
+var testingMode: bool = defaultTestingMode;
 
 fn gamemodeCallback(_: usize) void {
 	gamemode = std.meta.intToEnum(main.game.Gamemode, @intFromEnum(gamemode) + 1) catch @enumFromInt(0);
 	gamemodeInput.child.label.updateText(@tagName(gamemode));
 }
 
-fn allowCheatsCallback(allow: bool) void {
-	allowCheats = allow;
-}
-
-fn testingModeCallback(enabled: bool) void {
-	testingMode = enabled;
+fn toggleBoolCallback(ctx: *anyopaque) void {
+	const theValue: *bool = @ptrCast(@alignCast(ctx));
+	theValue.* = !theValue.*;
 }
 
 fn createWorld(_: usize) void {
@@ -161,10 +160,12 @@ pub fn onOpen() void {
 	gamemodeInput = Button.initText(.{0, 0}, 128, @tagName(gamemode), .{.callback = &gamemodeCallback});
 	list.add(gamemodeInput);
 
-	list.add(CheckBox.init(.{0, 0}, 128, "Allow Cheats", true, &allowCheatsCallback));
+	allowCheats = defaultAllowCheats;
+	list.add(CheckBox.init(.{0, 0}, 128, "Allow Cheats", allowCheats, &allowCheats, &toggleBoolCallback));
 
 	if(!build_options.isTaggedRelease) {
-		list.add(CheckBox.init(.{0, 0}, 128, "Testing mode (for developers)", false, &testingModeCallback));
+		testingMode = defaultTestingMode;
+		list.add(CheckBox.init(.{0, 0}, 128, "Testing mode (for developers)", testingMode, &testingMode, &toggleBoolCallback));
 	}
 
 	list.add(Button.initText(.{0, 0}, 128, "Create World", .{.callback = &createWorld}));

--- a/src/main.zig
+++ b/src/main.zig
@@ -362,7 +362,7 @@ pub const KeyBoard = struct { // MARK: KeyBoard
 		.{.name = "right", .key = c.GLFW_KEY_D, .gamepadAxis = .{.axis = c.GLFW_GAMEPAD_AXIS_LEFT_X, .positive = true}},
 		.{.name = "sprint", .key = c.GLFW_KEY_LEFT_CONTROL, .gamepadButton = c.GLFW_GAMEPAD_BUTTON_LEFT_THUMB, .isToggling = .no},
 		.{.name = "jump", .key = c.GLFW_KEY_SPACE, .gamepadButton = c.GLFW_GAMEPAD_BUTTON_A},
-		.{.name = "crouch", .key = c.GLFW_KEY_LEFT_SHIFT, .gamepadButton = c.GLFW_GAMEPAD_BUTTON_RIGHT_THUMB},
+		.{.name = "crouch", .key = c.GLFW_KEY_LEFT_SHIFT, .gamepadButton = c.GLFW_GAMEPAD_BUTTON_RIGHT_THUMB, .isToggling = .no},
 		.{.name = "fly", .key = c.GLFW_KEY_F, .gamepadButton = c.GLFW_GAMEPAD_BUTTON_DPAD_DOWN, .pressAction = &game.flyToggle},
 		.{.name = "ghost", .key = c.GLFW_KEY_G, .pressAction = &game.ghostToggle},
 		.{.name = "hyperSpeed", .key = c.GLFW_KEY_H, .pressAction = &game.hyperSpeedToggle},
@@ -447,20 +447,6 @@ pub const KeyBoard = struct { // MARK: KeyBoard
 			std.log.err("Couldn't find keyboard key with name {s}", .{name});
 			return &.{.name = ""};
 		};
-	}
-	pub fn setIsToggling(name: []const u8, value: bool) void {
-		if(findKey(name)) |theKey| {
-			if(theKey.isToggling == .never) {
-				std.log.err("Tried setting toggling on non-toggling key with name {s}", .{name});
-				return;
-			}
-			theKey.isToggling = if(value) .yes else .no;
-			if(!value) {
-				theKey.pressed = false;
-			}
-		} else {
-			std.log.err("Couldn't find keyboard key to toggle with name {s}", .{name});
-		}
 	}
 };
 


### PR DESCRIPTION
This is a followup to #2026 - I am leaving this PR as draft until that PR merges.

Closes #2049
Closes #2050


In this PR I changed signature of CheckBox callback to use context instead of boolean value. The context has been added to the CheckBox structure. This allows the CheckBox to handle multiple values/purposes without specific callback for each of them.

I have used this to automatically generate checkboxes for "IsToggling". I have also added the checkbox for crouch key.
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/97308455-af8e-46de-b698-7b1c0eb598c6" />

Also this PR fixes #2049 but doesn't really solve the root cause. The initial CheckBox state is very detached from the actual value. Checkbox internally keeps its own state and that makes it easy for developer to make mistake and then overlook it - because the checkbox will look like its working, even though in fact it may be not working. Maybe the state should be passed into CheckBox as callback that returns boolean? Then CheckBox would always look at return value of the callback instead of keeping its own state?

The #2050 mentions fly, ghost, hyperspeed. Flying and ghost does not seem to fit this feature, as they have some additional logic surrounding them - they are intertwined. Maybe if the logic handled both ghost and flying and the state would be separated. I guess that would be simple enough to do. Hyperspeed seems to fit nicely already, but it is atomic, unlike the keys, so I am not sure what to do with that. Should I maybe also do the keys state atomic? Or just move the things to keys state and non-atomic?
