### PR TITLE
Group control settings

### DIFF
--- a/src/graphics/Window.zig
+++ b/src/graphics/Window.zig
@@ -79,7 +79,7 @@ pub const Gamepad = struct {
 				}
 			}
 			const isGrabbed = grabbed;
-			for(&main.KeyBoard.keys) |*key| {
+			for(main.KeyBoard.allKeys()) |*key| {
 				if(key.gamepadAxis == null) {
 					if(key.gamepadButton >= 0) {
 						const oldPressed = oldState.buttons[@intCast(key.gamepadButton)] != 0;
@@ -476,7 +476,7 @@ pub const GLFWCallbacks = struct { // MARK: GLFWCallbacks
 		const textKeyPressedInTextField = main.gui.selectedTextInput != null and c.glfwGetKeyName(glfw_key, scancode) != null;
 		const isGrabbed = grabbed;
 		if(action == c.GLFW_PRESS or action == c.GLFW_RELEASE) {
-			for(&main.KeyBoard.keys) |*key| {
+			for(main.KeyBoard.allKeys()) |*key| {
 				if(glfw_key == key.key) {
 					if(glfw_key != c.GLFW_KEY_UNKNOWN or scancode == key.scancode) {
 						key.setPressed(action == c.GLFW_PRESS, isGrabbed, mods, textKeyPressedInTextField);
@@ -490,7 +490,7 @@ pub const GLFWCallbacks = struct { // MARK: GLFWCallbacks
 				}
 			}
 		} else if(action == c.GLFW_REPEAT) {
-			for(&main.KeyBoard.keys) |*key| {
+			for(main.KeyBoard.allKeys()) |*key| {
 				if(glfw_key == key.key) {
 					if(glfw_key != c.GLFW_KEY_UNKNOWN or scancode == key.scancode) {
 						key.action(.repeat, isGrabbed, mods, textKeyPressedInTextField);
@@ -547,7 +547,7 @@ pub const GLFWCallbacks = struct { // MARK: GLFWCallbacks
 		const mods: Key.Modifiers = @bitCast(@as(u6, @intCast(_mods)));
 		const isGrabbed = grabbed;
 		if(action == c.GLFW_PRESS or action == c.GLFW_RELEASE) {
-			for(&main.KeyBoard.keys) |*key| {
+			for(main.KeyBoard.allKeys()) |*key| {
 				if(button == key.mouseButton) {
 					key.setPressed(action == c.GLFW_PRESS, isGrabbed, mods, false);
 				}
@@ -629,7 +629,7 @@ fn updateCursor() void {
 
 fn releaseButtonsOnGrabChange(grab: bool) void {
 	const state: Key.Requirement = if(grab) .inMenu else .inGame;
-	for(&main.KeyBoard.keys) |*key| {
+	for(main.KeyBoard.allKeys()) |*key| {
 		if(key.notifyRequirement == state and key.pressed) {
 			key.pressed = false;
 			key.modsOnPress = .{};

--- a/src/gui/windows/controls.zig
+++ b/src/gui/windows/controls.zig
@@ -108,7 +108,7 @@ pub fn onOpen() void {
 	}
 
 	inline for (std.meta.fields(main.KeyGroup)) |keyGroupField| {
-		const groupKeys: []*Window.Key = @field(&main.KeyBoard.keys, keyGroupField.name);
+		const groupKeys: []Window.Key = @field(main.KeyBoard.keys, keyGroupField.name);
 		const groupDisplayLabel = Label.init(.{0, 0}, 320, keyGroupField, .center);
 		groupDisplayLabel.alpha = 0.9;
 		const titleRow = HorizontalList.init();

--- a/src/main.zig
+++ b/src/main.zig
@@ -455,12 +455,25 @@ pub const KeyBoard = struct { // MARK: KeyBoard
 		},
 	};
 
-	pub const keys = @as(KeyGroup, _keys);
+	pub const keys = _keys;
+
+	pub fn allKeys() []Window.Key {
+		var buffer: [1024]Window.Key = undefined;
+		var i: usize = 0;
+		inline for (std.meta.fields(@TypeOf(_keys))) |keyField| {
+			const group_keys = @field(_keys, keyField.name);
+			inline for (group_keys) |_key|{
+				buffer[i] = _key;
+				i+=1;
+			}
+		}
+		return buffer[0..i];
+	}
 
 	fn findKey(name: []const u8) ?*Window.Key { // TODO: Maybe I should use a hashmap here?
-		inline for (std.meta.fields(KeyGroup)) |key_group_field| {
-			const group_keys = @field(keys, key_group_field.name);
-			for(group_keys) |*_key| {
+		inline for (std.meta.fields(@TypeOf(_keys))) |key_group_field| {
+			const group_keys = @as([]Window.Key, @field(_keys, key_group_field.name));
+			for(group_keys) |_key| {
 				if(std.mem.eql(u8, name, _key.name)) {
 					return _key;
 				}

--- a/src/settings.zig
+++ b/src/settings.zig
@@ -100,7 +100,7 @@ pub fn init() void {
 
 	// keyboard settings:
 	const keyboard = zon.getChild("keyboard");
-	for(&main.KeyBoard.keys) |*key| {
+	for(main.KeyBoard.allKeys()) |*key| {
 		const keyZon = keyboard.getChild(key.name);
 		key.key = keyZon.get(c_int, "key", key.key);
 		key.mouseButton = keyZon.get(c_int, "mouseButton", key.mouseButton);
@@ -156,7 +156,7 @@ pub fn save() void {
 
 	// keyboard settings:
 	const keyboard = ZonElement.initObject(main.stackAllocator);
-	for(&main.KeyBoard.keys) |key| {
+	for(main.KeyBoard.allKeys()) |key| {
 		const keyZon = ZonElement.initObject(main.stackAllocator);
 		keyZon.put("key", key.key);
 		keyZon.put("mouseButton", key.mouseButton);


### PR DESCRIPTION
Closes: #1569 

Group the controls together.

Doing this I did want to add some buttons either on the side of the window or top to have the ability to 'jump to' the headings, though that would have changed much more code so decided to keep it simple.

Couple screenshots:
<img width="1172" height="1210" alt="image" src="https://github.com/user-attachments/assets/a531feaa-e4e2-407b-a667-642b7553174e" />

<img width="1161" height="1199" alt="image" src="https://github.com/user-attachments/assets/5f622a34-8009-4e70-a2a0-63bc8415c48d" />
