### PR TITLE
Migrate from cImport to build system

### DIFF
--- a/src/audio.zig
+++ b/src/audio.zig
@@ -3,11 +3,7 @@ const std = @import("std");
 const main = @import("main");
 const utils = main.utils;
 
-const c = @cImport({
-	@cInclude("miniaudio.h");
-	@cDefine("STB_VORBIS_HEADER_ONLY", "");
-	@cInclude("stb/stb_vorbis.h");
-});
+const c = @import("audio_c");
 
 fn handleError(miniaudioError: c.ma_result) !void {
 	if(miniaudioError != c.MA_SUCCESS) {

--- a/src/cImports/audio.c
+++ b/src/cImports/audio.c
@@ -1,0 +1,4 @@
+
+#include <miniaudio.h>
+#define STB_VORBIS_HEADER_ONLY=""
+#include <stb/stb_vorbis.h>

--- a/src/cImports/file_monitor_linux.c
+++ b/src/cImports/file_monitor_linux.c
@@ -1,0 +1,5 @@
+
+#include <sys/inotify.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <errno.h>

--- a/src/cImports/file_monitor_windows.c
+++ b/src/cImports/file_monitor_windows.c
@@ -1,0 +1,2 @@
+
+#include <fileapi.h>

--- a/src/cImports/glad.c
+++ b/src/cImports/glad.c
@@ -1,0 +1,3 @@
+
+#include <glad/gl.h>
+#include <glad/vulkan.h>

--- a/src/cImports/glslang.c
+++ b/src/cImports/glslang.c
@@ -1,0 +1,3 @@
+
+#include <glslang/Include/glslang_c_interface.h>
+#include <glslang/Public/resource_limits_c.h>

--- a/src/cImports/hbft.c
+++ b/src/cImports/hbft.c
@@ -1,0 +1,12 @@
+
+#include <freetype/ftadvanc.h>
+#include <freetype/ftbbox.h>
+#include <freetype/ftbitmap.h>
+#include <freetype/ftcolor.h>
+#include <freetype/ftlcdfil.h>
+#include <freetype/ftsizes.h>
+#include <freetype/ftstroke.h>
+#include <freetype/fttrigon.h>
+#include <freetype/ftsynth.h>
+#include <hb.h>
+#include <hb-ft.h>

--- a/src/cImports/stb.c
+++ b/src/cImports/stb.c
@@ -1,0 +1,3 @@
+
+#include <stb/stb_image.h>
+#include <stb/stb_image_write.h>

--- a/src/cImports/window.c
+++ b/src/cImports/window.c
@@ -1,0 +1,4 @@
+
+#include <glad/gl.h>
+#include <glad/vulkan.h>
+#include <GLFW/glfw3.h>

--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -2,19 +2,7 @@
 /// Also contains some basic 2d drawing stuff.
 const std = @import("std");
 
-pub const hbft = @cImport({
-	@cInclude("freetype/ftadvanc.h");
-	@cInclude("freetype/ftbbox.h");
-	@cInclude("freetype/ftbitmap.h");
-	@cInclude("freetype/ftcolor.h");
-	@cInclude("freetype/ftlcdfil.h");
-	@cInclude("freetype/ftsizes.h");
-	@cInclude("freetype/ftstroke.h");
-	@cInclude("freetype/fttrigon.h");
-	@cInclude("freetype/ftsynth.h");
-	@cInclude("hb.h");
-	@cInclude("hb-ft.h");
-});
+pub const hbft = @import("hbft_c");
 
 const vec = @import("vec.zig");
 const Mat4f = vec.Mat4f;
@@ -29,20 +17,11 @@ const Window = main.Window;
 
 const NeverFailingAllocator = main.heap.NeverFailingAllocator;
 
-pub const c = @cImport({
-	@cInclude("glad/gl.h");
-	@cInclude("glad/vulkan.h");
-});
+pub const c = @import("glad_c");
 
-pub const stb_image = @cImport({
-	@cInclude("stb/stb_image.h");
-	@cInclude("stb/stb_image_write.h");
-});
+pub const stb_image = @import("stb_c");
 
-const glslang = @cImport({
-	@cInclude("glslang/Include/glslang_c_interface.h");
-	@cInclude("glslang/Public/resource_limits_c.h");
-});
+const glslang = @import("glslang_c");
 
 pub const draw = struct { // MARK: draw
 	var color: u32 = 0;

--- a/src/graphics/Window.zig
+++ b/src/graphics/Window.zig
@@ -9,11 +9,7 @@ const Vec2f = vec.Vec2f;
 
 const vulkan = @import("vulkan.zig");
 
-pub const c = @cImport({
-	@cInclude("glad/gl.h");
-	@cInclude("glad/vulkan.h");
-	@cInclude("GLFW/glfw3.h");
-});
+pub const c = @import("window_c");
 
 var isFullscreen: bool = false;
 pub var lastUsedMouse: bool = true;

--- a/src/utils/file_monitor.zig
+++ b/src/utils/file_monitor.zig
@@ -41,12 +41,7 @@ const NoImpl = struct {
 };
 
 const LinuxImpl = struct { // MARK: LinuxImpl
-	const c = @cImport({
-		@cInclude("sys/inotify.h");
-		@cInclude("sys/ioctl.h");
-		@cInclude("unistd.h");
-		@cInclude("errno.h");
-	});
+	const c = @import("file_monitor_linux_c");
 
 	const DirectoryInfo = struct {
 		callback: CallbackFunction,
@@ -211,9 +206,7 @@ const LinuxImpl = struct { // MARK: LinuxImpl
 };
 
 const WindowsImpl = struct { // MARK: WindowsImpl
-	const c = @cImport({
-		@cInclude("fileapi.h");
-	});
+	const c = @import("file_monitor_windows_c");
 	const HANDLE = std.os.windows.HANDLE;
 	var notificationHandlers: std.StringHashMap(*DirectoryInfo) = undefined;
 	var callbacks: main.List(*DirectoryInfo) = undefined;


### PR DESCRIPTION
Because `@cImport` is scheduled for removal in ziglang/zig/issues/20630

