### PR TITLE
Fix tooltip flicker

### DIFF
--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -538,10 +538,9 @@ pub fn updateWindowPositions() void {
 	}
 }
 
-pub fn updateAndRenderGui() void {
+pub fn updateHover() void {
 	const mousePos = main.Window.getMousePosition()/@as(Vec2f, @splat(scale));
 	hoveredAWindow = false;
-	GuiCommandQueue.executeCommands();
 	if(!main.Window.grabbed) {
 		if(selectedWindow) |selected| {
 			selected.updateSelected(mousePos);
@@ -559,6 +558,11 @@ pub fn updateAndRenderGui() void {
 		}
 		inventory.update();
 	}
+}
+pub fn updateAndRenderGui() void {
+	GuiCommandQueue.executeCommands();
+	updateHover();
+	const mousePos = main.Window.getMousePosition()/@as(Vec2f, @splat(scale));
 	for(openWindows.items) |window| {
 		window.update();
 	}

--- a/src/gui/windows/inventory_crafting.zig
+++ b/src/gui/windows/inventory_crafting.zig
@@ -143,6 +143,7 @@ fn refresh() void {
 	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));
 	window.contentSize[0] = @max(window.contentSize[0], window.getMinWindowWidth());
 	gui.updateWindowPositions();
+	gui.updateHover();
 }
 
 pub fn onOpen() void {


### PR DESCRIPTION
Closes #1869

When inventory crafting is recreated on update (any time inventory changes I think), the hovered item slot gets deleted. This causes tooltip to be lost and then re-created on next updateAndRenderGUI causing the flicker

I am quite unhappy with this solution because it does not solve the underlying problem properly and it is very likely that similiar bug will happen in future if the GUI system does not change. Fixing this "properly" would probably require large refactoring, which would require a lot of thought about how to do it well.