### PR TITLE
fix a bug where instance was erroneously set to `null`, then asserted to be non-`null`

### DIFF
--- a/src/itemdrop.zig
+++ b/src/itemdrop.zig
@@ -490,8 +490,8 @@ pub const ClientItemDropManager = struct { // MARK: ClientItemDropManager
 
 	pub fn deinit(self: *ClientItemDropManager) void {
 		std.debug.assert(instance != null); // Double deinit.
-		instance = null;
 		self.super.deinit();
+		instance = null;
 	}
 
 	pub fn readPosition(self: *ClientItemDropManager, time: i16, itemData: []ItemDropNetworkData) void {


### PR DESCRIPTION


I received this crash report from iNiKKo, admin of Ashframe:

```
[error]: This is a bug, please report it on the issue tracker.
----8<---- start of panic
panic: attempt to use null value
error return trace: null
[error]: stack trace: /home/minipc/Desktop/cubyz_auth_server/src/itemdrop.zig:525:16: 0x14324cf in processChanges (Cubyz)
  for(&instance.?.interpolation.lastVel) |*lastVel| {
               ^
/home/minipc/Desktop/cubyz_auth_server/src/itemdrop.zig:86:22: 0x13f7915 in deinit (Cubyz)
  self.processChanges();
                     ^
/home/minipc/Desktop/cubyz_auth_server/src/itemdrop.zig:494:20: 0x132b271 in deinit (Cubyz)
  self.super.deinit();
                   ^
/home/minipc/Desktop/cubyz_auth_server/src/main.zig:787:17: 0x1310596 in main (Cubyz)
    world.deinit();
                ^
/home/minipc/Desktop/cubyz_auth_server/compiler/zig/lib/std/start.zig:672:22: 0x12fdb35 in main (Cubyz)
            root.main();
                     ^
../sysdeps/nptl/libc_start_call_main.h:58:16: 0x7fec66a27674 in libc_start_call_main (../sysdeps/x86/libc-start.c)
../csu/libc-start.c:360:3: 0x7fec66a27728 in libc_start_main_impl (../sysdeps/x86/libc-start.c)
???:?:?: 0x12fd7d4 in ??? (???)
???:?:?: 0x0 in ??? (???)

[error]: ----8<---- end of panic
```

`ClientItemDropManager.deinit` sets instance to null, then calls `ItemDropManager.deinit`:

```zig
        instance = null;
        self.super.deinit();
```

`ItemDropManager.deinit` calls `processChanges` calls `internalAdd` calls `clientSideInternalAdd`, which asserts that `instance` is non-null:

```zig
        for(&instance.?.interpolation.lastVel) |*lastVel| {
```

Therefore, setting `instance` to `null` before calling `ItemDropManager.deinit` is a bug, and it should be set to `null` afterwards instead.