### PR TITLE
Add an option to change block contrast

### DIFF
--- a/src/gui/windows/graphics.zig
+++ b/src/gui/windows/graphics.zig
@@ -84,6 +84,15 @@ fn lodDistanceCallback(newValue: f32) void {
 	settings.save();
 }
 
+fn contrastFormatter(allocator: main.heap.NeverFailingAllocator, value: f32) []const u8 {
+	return std.fmt.allocPrint(allocator.allocator, "#ffffffBlock Contrast: {d:.0}%", .{@round(value*100)}) catch unreachable;
+}
+
+fn contrastCallback(newValue: f32) void {
+	settings.blockContrast = @round(newValue*100)/100;
+	settings.save();
+}
+
 fn bloomCallback(newValue: bool) void {
 	settings.bloom = newValue;
 	settings.save();
@@ -124,6 +133,7 @@ pub fn onOpen() void {
 	}
 	list.add(DiscreteSlider.init(.{0, 0}, 128, "#ffffffLeaves Quality (TODO: requires reload): ", "{}", &leavesQualities, settings.leavesQuality - leavesQualities[0], &leavesQualityCallback));
 	list.add(ContinuousSlider.init(.{0, 0}, 128, 50.0, 400.0, settings.@"lod0.5Distance", &lodDistanceCallback, &lodDistanceFormatter));
+	list.add(ContinuousSlider.init(.{0, 0}, 128, 0.0, 0.5, settings.blockContrast, &contrastCallback, &contrastFormatter));
 	list.add(ContinuousSlider.init(.{0, 0}, 128, 40.0, 120.0, settings.fov, &fovCallback, &fovFormatter));
 	list.add(CheckBox.init(.{0, 0}, 128, "Bloom", settings.bloom, &bloomCallback));
 	list.add(CheckBox.init(.{0, 0}, 128, "Vertical Synchronization", settings.vsync, &vsyncCallback));

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -184,7 +184,7 @@ fn bindCommonUniforms(locations: *UniformStruct, projMatrix: Mat4f, ambient: Vec
 
 	c.glUniform1f(locations.reflectionMapSize, renderer.reflectionCubeMapSize);
 
-	c.glUniform1f(locations.contrast, 0);
+	c.glUniform1f(locations.contrast, main.settings.blockContrast);
 
 	c.glUniform1f(locations.lodDistance, main.settings.@"lod0.5Distance");
 

--- a/src/settings.zig
+++ b/src/settings.zig
@@ -55,6 +55,8 @@ pub var leavesQuality: u16 = 2;
 
 pub var @"lod0.5Distance": f32 = 200;
 
+pub var blockContrast: f32 = 0;
+
 pub var storageTime: i64 = 5000;
 
 pub var updateRepeatSpeed: u31 = 200;


### PR DESCRIPTION
Adds a Block Contrast slider in the graphics settings window with:
- a minimum value of 0%, which produces the default flat shading;
- a maximum value of 50%, at which the bottom sides of blocks are pitch black. Higher values are pointless as they would actually decrease the contrast by bringing other faces closer to black;
- a step of 1%.

Resolves #1906.

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/85567c7c-44c7-4be5-b707-894bbb0f5533" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/cdb67c67-237e-4b82-ba8a-bd5ec9d1cd91" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/646d2d48-9ada-476f-9212-a6e9fe25a005" />