### PR TITLE
Attempt to fix #2005

### DIFF
--- a/src/blueprint.zig
+++ b/src/blueprint.zig
@@ -193,10 +193,17 @@ pub const Blueprint = struct {
 		defer main.stackAllocator.free(decompressedData);
 		var decompressedReader = BinaryReader.init(decompressedData);
 
-		const palette = try loadBlockPalette(main.stackAllocator, paletteBlockCount, &decompressedReader);
-		defer main.stackAllocator.free(palette);
+		const palette_in = try loadBlockPalette(main.stackAllocator, paletteBlockCount, &decompressedReader);
+		var palette_temp_list: main.List([]const u8) = .init(main.stackAllocator);
+		for(palette_in) |item| {
+			palette_temp_list.append(item);
+		}
+		var palette: main.assets.Palette = .{
+			.palette = palette_temp_list,
+		};
+		main.migrations.apply(.block, &palette);
 
-		const blueprintIdToGameIdMap = makeBlueprintIdToGameIdMap(main.stackAllocator, palette);
+		const blueprintIdToGameIdMap = makeBlueprintIdToGameIdMap(main.stackAllocator, palette_in);
 		defer main.stackAllocator.free(blueprintIdToGameIdMap);
 
 		for(self.blocks.mem) |*block| {


### PR DESCRIPTION
Possibly incorrect approach as I don't know much about blueprints.

For now it just runs the migrations after constructing a proper palette object.

But it's unclear to me whether something more than this was meant in #2005.