### PR TITLE
fix a bug where crafting with a full inventory crashes the server

### DIFF
--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -236,7 +236,7 @@ pub const Sync = struct { // MARK: Sync
 					if(self.managed == .internallyManaged) {
 						if(self.inv.type.shouldDepositToUserOnClose()) {
 							const playerInventory = getInventoryFromSource(.{.playerInventory = user.id}) orelse @panic("Could not find player inventory");
-							Sync.ServerSide.executeCommand(.{.depositOrDrop = .{.dest = playerInventory, .source = self.inv}}, null);
+							Sync.ServerSide.executeCommand(.{.depositOrDrop = .{.dest = playerInventory, .source = self.inv}}, user);
 						}
 						self.deinit();
 					}


### PR DESCRIPTION
this fixes a crash where the server would mistakenly unwrap a null user.

the root cause of the issue is `user` being passed as null to `depositOrDrop`.

```
thread 13163 panic: attempt to use null value
src/Inventory.zig:1671:69: 0x1648434 in run (Cubyz)
     const direction = vec.rotateZ(vec.rotateX(Vec3f{0, 1, 0}, -user.?.player.rot[0]), -user.?.player.rot[2]);
                                                                    ^
src/Inventory.zig:857:20: 0x15b7c90 in do (Cubyz)
    try payload.run(allocator, self, side, user, gamemode);
                   ^
src/Inventory.zig:308:14: 0x15b26c8 in executeCommand (Cubyz)
   command.do(main.globalAllocator, .server, source, if(source) |s| s.gamemode.raw else .creative) catch {
             ^
src/Inventory.zig:248:38: 0x15ae695 in removeUser (Cubyz)
       Sync.ServerSide.executeCommand(.{.depositOrDrop = .{.dest = playerInventory, .source = self.inv}}, null);
                                     ^
src/Inventory.zig:440:56: 0x15ae262 in closeInventory (Cubyz)
   inventories.items[@intFromEnum(serverId)].removeUser(user, clientId);
                                                       ^
src/Inventory.zig:1324:38: 0x15ae8af in deserialize (Cubyz)
   try Sync.ServerSide.closeInventory(user.?, id);
                                     ^
src/Inventory.zig:355:130: 0x15b1ba4 in receiveCommand (Cubyz)
    inline else => |_typ| @unionInit(Command.Payload, @tagName(_typ), try @FieldType(Command.Payload, @tagName(_typ)).deserialize(reader, .server, source)),
                                                                                                                                 ^
src/network.zig:1261:51: 0x1527320 in receive (Cubyz)
    items.Inventory.Sync.ServerSide.receiveCommand(user, reader) catch |err| {
                                                  ^
src/network.zig:1557:25: 0x18406c0 in collectRangesAndExecuteProtocols (Cubyz)
     try protocolReceive(conn, &reader);
                        ^
src/network.zig:1580:46: 0x1840ece in receive (Cubyz)
    try self.collectRangesAndExecuteProtocols(conn);
                                             ^
src/network.zig:1775:37: 0x184140e in receive (Cubyz)
   return self.receiveBuffer.receive(conn, start, data);
                                    ^
src/network.zig:2138:36: 0x1842a17 in tryReceive (Cubyz)
    if(try self.fastChannel.receive(self, start, reader.remaining) == .accepted) {
                                   ^
src/network.zig:2051:18: 0x17d72e4 in receive (Cubyz)
  self.tryReceive(data) catch |err| {
                 ^
src/network.zig:552:18: 0x1771ed1 in onReceive (Cubyz)
     conn.receive(data);
                 ^
src/network.zig:597:19: 0x16f1f37 in run (Cubyz)
    self.onReceive(data, source);
                  ^
compiler/zig/lib/std/Thread.zig:510:13: 0x165ac7a in callFn__anon_89839 (Cubyz)
            @call(.auto, f, args);
            ^
compiler/zig/lib/std/Thread.zig:782:30: 0x15bff03 in entryFn (Cubyz)
                return callFn(f, args_ptr.*);
```