### PR TITLE
Add grass block recipes

### DIFF
--- a/assets/cubyz/recipes/grass_recipes.zig.zon
+++ b/assets/cubyz/recipes/grass_recipes.zig.zon
@@ -1,0 +1,18 @@
+.{
+	.{
+		.inputs = .{"4 cubyz:soil", "cubyz:grass_vegetation"},
+		.output = "4 cubyz:grass",
+	},
+	.{
+		.inputs = .{"4 cubyz:mud", "cubyz:lush_grass_vegetation"},
+		.output = "4 cubyz:lush_grass",
+	},
+	.{
+		.inputs = .{"4 cubyz:dirt", "cubyz:dry_grass_vegetation"},
+		.output = "4 cubyz:dry_grass",
+	},
+	.{
+		.inputs = .{"4 cubyz:permafrost", "cubyz:cold_grass_vegetation"},
+		.output = "4 cubyz:cold_grass",
+	},
+}


### PR DESCRIPTION
Adds recipes for each grass block, they can be crafted with their corresponding ground and vegetation type.

- 4x `soil` + `grass_vegetation` = 4x `grass`
- 4x `mud` + `lush_grass_vegetation` = 4x `lush_grass`
- 4x `dirt` + `dry_grass_vegetation` = 4x `dry_grass`
- 4x `permafrost` + `cold_grass_vegetation` = 4x `cold_grass`

<img width="264" height="305" alt="image" src="https://github.com/user-attachments/assets/570d6335-f7e0-49a1-bcb3-cd1916998b1d" />