### PR TITLE
remove canHold check.

### DIFF
--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -1648,6 +1648,7 @@ pub const Command = struct { // MARK: Command
 			for(self.dest._items, 0..) |*destStack, destSlot| {
 				if(std.meta.eql(destStack.item, sourceStack.item) or destStack.item == null) {
 					const amount = @min(sourceStack.item.?.stackSize() - destStack.amount, remainingAmount);
+					if(amount == 0) continue;
 					cmd.executeBaseOperation(allocator, .{.move = .{
 						.dest = .{.inv = self.dest, .slot = @intCast(destSlot)},
 						.source = self.source,


### PR DESCRIPTION
Fixes: #1881

just a little change that makes the amount requirement of shifting to an inventory not be the stack size