### PR TITLE
Allow placing on and breaking of fluid & gas blocks when holding their items

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -1058,7 +1058,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 			}
 			const block = mesh_storage.getBlockFromRenderThread(selectedPos[0], selectedPos[1], selectedPos[2]) orelse return;
 			const holdingTargetedBlock = stack.item != null and stack.item.? == .baseItem and stack.item.?.baseItem.block() == block.typ;
-			if((block.hasTag(.fluid) or block.hasTag(.air)) and !(holdingTargetedBlock and game.Player.isCreative())) return;
+			if((block.hasTag(.fluid) or block.hasTag(.air)) and !holdingTargetedBlock) return;
 
 			const relPos: Vec3f = @floatCast(lastPos - @as(Vec3d, @floatFromInt(selectedPos)));
 


### PR DESCRIPTION
Makes building with liquids and gasses behave the same as normal blocks when their corresponding item is held. Applies to all `.fluid` and `.air` tagged blocks. I disabled breaking in survival because digging a hole in a lake with a water block seemed weird.

https://github.com/user-attachments/assets/5c06ede1-6ff5-4820-b2f0-3bb23e3b9ad3