### PR TITLE
Make the Seed Configurable

### DIFF
--- a/src/gui/windows/save_creation.zig
+++ b/src/gui/windows/save_creation.zig
@@ -141,7 +141,6 @@ fn flawedCreateWorld() !void {
 		defer main.stackAllocator.free(assetsPath);
 		try main.files.cubyzDir().makePath(assetsPath);
 	}
-	// TODO: Make the seed configurable
 	gui.closeWindowFromRef(&window);
 	gui.windowlist.save_selection.needsUpdate = true;
 	gui.openWindow("save_selection");


### PR DESCRIPTION
This PR adds an input field to the world creation GUI that allows the user to input a seed. If the user leaves this field blank, then the password is randomly generated.

<img width="455" height="768" alt="Screenshot_20251025_230211" src="https://github.com/user-attachments/assets/d5bfa26c-89fa-43d4-8174-eba940c9fcad" />