### PR TITLE
Refactor ItemSlot interaction

### DIFF
--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -660,9 +660,9 @@ pub const inventory = struct { // MARK: inventory
 		const secondaryGuiButton = main.KeyBoard.key("secondaryGuiButton");
 
 		if(itemSlot.inventory.type == .crafting and itemSlot.mode == .takeOnly and mainGuiButton.pressed and (recipeItem != null or itemSlot.pressed)) {
-			const slot = itemSlot.inventory.getItem(itemSlot.itemSlot);
-			if(recipeItem == null and slot != null) recipeItem = slot.?.clone();
-			if(!std.meta.eql(slot, recipeItem)) return;
+			const item = itemSlot.inventory.getItem(itemSlot.itemSlot);
+			if(recipeItem == null and item != null) recipeItem = item.?.clone();
+			if(!std.meta.eql(item, recipeItem)) return;
 			const time = std.time.milliTimestamp();
 			if(!isCrafting) {
 				isCrafting = true;


### PR DESCRIPTION
I went in with the intention to figure out a fix to https://github.com/PixelGuys/Cubyz/issues/1880 among other inventory issues but ended up finding a lot of bugs that didn't seam cleanly resolvable without rewriting the whole thing.

Issues that this PR fixes
- Holding left click to craft quickly, then moving the mouse over inventory slots, releasing left click (nothing should happen), then holding left click and moving over inventory slots, then releasing left click will cause both the previously selected slots and the currently selected slots to get items
- Holding left click to craft quickly then moving mouse off doesn't reset craft speed, waiting a second and moving the mouse back on will craft at an extremely fast rate
- Holding left or right click and then moving your mouse over a crafting item instantly crafts one. This has been very frustrating when trying to scroll, I've miscrafted things so many times in survival
- Items can be crafted with right click (Unsure, was this is intentional?)
- Holding shift and left click to craft quickly into the inventory, then while still holding shift releasing click, move the mouse over a different item, and hold click again will not craft any items

Fixing https://github.com/PixelGuys/Cubyz/issues/1880 should be a single line but I wasn't sure if it should be included in this so I left it out. I can add it if wanted.
