### PR TITLE
Add clickThrough property to GuiWindow

### DIFF
--- a/src/gui/GuiWindow.zig
+++ b/src/gui/GuiWindow.zig
@@ -64,6 +64,7 @@ closeable: bool = true,
 isHud: bool = false,
 
 shiftClickableInventory: ?main.items.Inventory = null,
+clickThrough: bool = false,
 
 /// Called every frame.
 renderFn: *const fn() void = &defaultFunction,

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -476,7 +476,7 @@ pub fn mainButtonPressed() void {
 	for(openWindows.items, 0..) |window, i| {
 		var mousePosition = main.Window.getMousePosition()/@as(Vec2f, @splat(scale));
 		mousePosition -= window.pos;
-		if(@reduce(.And, mousePosition >= Vec2f{0, 0}) and @reduce(.And, mousePosition < window.size)) {
+		if(@reduce(.And, mousePosition >= Vec2f{0, 0}) and @reduce(.And, mousePosition < window.size) and (!window.clickThrough or reorderWindows)) {
 			selectedWindow = window;
 			selectedI = i;
 		}
@@ -547,7 +547,7 @@ pub fn updateAndRenderGui() void {
 		while(i != 0) {
 			i -= 1;
 			const window: *GuiWindow = openWindows.items[i];
-			if(GuiComponent.contains(window.pos, window.size, mousePos)) {
+			if(GuiComponent.contains(window.pos, window.size, mousePos) and !window.clickThrough) {
 				window.updateHovered(mousePos);
 				hoveredAWindow = true;
 				break;

--- a/src/gui/windows/crosshair.zig
+++ b/src/gui/windows/crosshair.zig
@@ -19,6 +19,7 @@ pub var window = GuiWindow{
 	.isHud = true,
 	.hideIfMouseIsGrabbed = false,
 	.closeable = false,
+	.clickThrough = true,
 };
 
 var texture: Texture = undefined;


### PR DESCRIPTION
Allows windows to not sink clicks, fixes https://github.com/PixelGuys/Cubyz/issues/2162
Should this also apply to the chat window?