### PR TITLE
Properly hide all hud elements when creating a background image

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -310,7 +310,7 @@ fn openCommand() void {
 }
 fn takeBackgroundImageFn() void {
 	if(game.world == null) return;
-	
+
 	const oldHideGui = gui.hideGui;
 	gui.hideGui = true;
 	const oldShowItem = itemdrop.ItemDisplayManager.showItem;


### PR DESCRIPTION
This hides the outline of the block you're pointing at when taking a background image.