### PR TITLE
Fill partial stacks before placing in an empty slot

### DIFF
--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -1644,7 +1644,7 @@ pub const Command = struct { // MARK: Command
 			if(self.amount > sourceStack.amount) return;
 
 			var remainingAmount = self.amount;
-			var selectedEmptySlot: ?i32 = null;
+			var selectedEmptySlot: ?u32 = null;
 			for(self.dest._items, 0..) |*destStack, destSlot| {
 				if(destStack.item == null and selectedEmptySlot == null) {
 					selectedEmptySlot = @intCast(destSlot);
@@ -1663,7 +1663,7 @@ pub const Command = struct { // MARK: Command
 			}
 			if(remainingAmount > 0 and selectedEmptySlot != null) {
 				cmd.executeBaseOperation(allocator, .{.move = .{
-					.dest = .{.inv = self.dest, .slot = @intCast(selectedEmptySlot.?)},
+					.dest = .{.inv = self.dest, .slot = selectedEmptySlot.?},
 					.source = self.source,
 					.amount = remainingAmount,
 				}}, side);


### PR DESCRIPTION
Fixes #2120

The approach is to first loop the inventory only for slots with at least some of source item to attempt filling those slots first.

~~Then, if remainingAmount > 0, do the same loop again but to find an empty slot to place the remainder into.~~
EDIT:
I found a more efficient way. During the existing loop, find the first empty slot and mark that as the `selectedEmptySlot`.

Then, distribute the blocks into all slots with some of the item in it.

Then, after the loop, place the remaining amount (if any) in the `selectedEmptySlot` from earlier.