### PR TITLE
Halfopen connection timeout

### DIFF
--- a/src/network.zig
+++ b/src/network.zig
@@ -625,7 +625,6 @@ pub const ConnectionManager = struct { // MARK: ConnectionManager
 				defer self.mutex.unlock();
 				while(i < self.connections.items.len) {
 					var conn = self.connections.items[i];
-					// if(range.timestamp +% retransmissionTimeout -% time >= 0)
 					if(conn.hasRttEstimate and networkTimestamp() -% conn.lastConnection > Connection.timeoutMicroseconds) {
 						self.mutex.unlock();
 						conn.disconnect();


### PR DESCRIPTION
Fixes #1876

The approach is quite simple.

I assumed if an RTT estimate is available, we must have received at least one packet from the user.
Perhaps there is a better way.

Regardless, I reutilized the existing send packets loop to disconnect connections that have not sent the server packets in at least 5 seconds (5 million microseconds).

~~I know right now the timeout period is a magic number. I could make that a const somewhere instead. (conn.timeoutPeriod?)~~ It's conn.timeoutMicroseconds now - which is hardcoded to `5_000_000`