### PR TITLE
fix issue with verticle list relative positions

### DIFF
--- a/src/gui/components/VerticalList.zig
+++ b/src/gui/components/VerticalList.zig
@@ -139,7 +139,7 @@ pub fn render(self: *VerticalList, mousePosition: Vec2f) void {
 		const itemYPos = child.pos()[1];
 		const adjustedYPos = itemYPos + shiftedPos[1] - self.pos[1];
 
-		if(adjustedYPos + child.size()[1] < 0 or adjustedYPos > self.maxHeight) {
+		if(adjustedYPos + 2*child.size()[1] < 0 or adjustedYPos - child.size()[1] > self.maxHeight) {
 			continue;
 		}
 		child.render(mousePosition - shiftedPos);


### PR DESCRIPTION
While implement culling in VerticalList.render #2024 the culling was only tested on the chat from what I know.

While making a example for #2065 I noticed a bug while showing the list.
Problem was `shiftedPos` is relative to the parent component, different than all other variables used in the if.
I did not create an issue because I knew the problematic code and was able to make a quick fix. I can also make an issue if wanted.