### PR TITLE
Press C to open creative inventory without toggling menu first

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -283,7 +283,6 @@ fn ungrabMouse(_: Window.Key.Modifiers) void {
 		gui.toggleGameMenu();
 	}
 }
-
 fn openCreativeInventory(mods: Window.Key.Modifiers) void {
 	if(game.world == null) return;
 	if(!game.Player.isCreative()) return;


### PR DESCRIPTION
Fixes #401 
There could be a simpler way to achieve this, but for now to avoid having to set a bool every time this specific window closes, it loops when you press the `openCreativeInventory` keybind over the open windows and if the id matches, it sets the bool to true.

Then if the window is opened, it will toggle the menu without opening the window.
If the window is not opened, it will open the window but only toggle the menu if the mouse is currently grabbed (and hud would be hidden in that case)