### PR TITLE
Add usage hint to /help output

### DIFF
--- a/src/server/command/help.zig
+++ b/src/server/command/help.zig
@@ -15,11 +15,11 @@ pub fn execute(args: []const u8, source: *User) void {
 	if(args.len == 0) {
 		var iterator = command.commands.valueIterator();
 		while(iterator.next()) |cmd| {
-				msg.append('/');
-				msg.appendSlice(cmd.name);
-				msg.appendSlice(": ");
-				msg.appendSlice(cmd.description);
-				msg.append('\n');
+			msg.append('/');
+			msg.appendSlice(cmd.name);
+			msg.appendSlice(": ");
+			msg.appendSlice(cmd.description);
+			msg.append('\n');
 		}
 		msg.appendSlice("\nUse /help <command> for usage of a specific command.\n");
 	} else {


### PR DESCRIPTION
Closes #2193
- - -
<img width="415" height="435" alt="image" src="https://github.com/user-attachments/assets/74f136a0-c999-4c4c-9c44-1d5b82ba0ff7" />
