### PR TITLE
Halfopen connection timeout

### DIFF
--- a/src/settings.zig
+++ b/src/settings.zig
@@ -8,7 +8,7 @@ const Window = @import("graphics/Window.zig");
 pub const version = @import("utils/version.zig");
 
 pub const defaultPort: u16 = 47649;
-pub const connectionTimeout = 5_000_000;
+pub const connectionTimeout = 60_000_000;
 
 pub const entityLookback: i16 = 100;
 


### PR DESCRIPTION
Fixes #1876 

Revised Approach:

During `ConnectionManager.run`, if the connection's handShakeState is > `.start`, that indicates the client has at least sent the `.userData` handshake step.

So we time out in this function if the above is true and the timeout has elapsed. This will throw out half open connections that won't reach the existing timeout check.