### PR TITLE
Add silly new generator mode enum value `floor_above_water`

### DIFF
--- a/src/server/terrain/biomes.zig
+++ b/src/server/terrain/biomes.zig
@@ -15,6 +15,7 @@ pub const SimpleStructureModel = struct { // MARK: SimpleStructureModel
 		floor,
 		ceiling,
 		floor_and_ceiling,
+		floor_above_water,
 		air,
 		underground,
 		water_surface,

--- a/src/server/terrain/simple_structures/SbbGen.zig
+++ b/src/server/terrain/simple_structures/SbbGen.zig
@@ -14,7 +14,7 @@ const ServerChunk = main.chunk.ServerChunk;
 const NeverFailingAllocator = main.heap.NeverFailingAllocator;
 
 pub const id = "cubyz:sbb";
-pub const generationMode = .floor;
+pub const generationMode = .floor_above_water;
 
 const SbbGen = @This();
 

--- a/src/server/terrain/structuremapgen/SimpleStructureGen.zig
+++ b/src/server/terrain/structuremapgen/SimpleStructureGen.zig
@@ -169,6 +169,15 @@ const SimpleStructure = struct {
 				}
 				if(relZ & ~@as(i32, 31) != self.wz -% chunk.super.pos.wz & ~@as(i32, 31)) return; // Too far from the surface.
 			},
+			.floor_above_water => {
+				if(biomeMap.getSurfaceHeight(self.wx, self.wy) <= 0) return;
+				if(caveMap.isSolid(px, py, relZ)) {
+					relZ = caveMap.findTerrainChangeAbove(px, py, relZ);
+				} else {
+					relZ = caveMap.findTerrainChangeBelow(px, py, relZ) + chunk.super.pos.voxelSize;
+				}
+				if(relZ & ~@as(i32, 31) != self.wz -% chunk.super.pos.wz & ~@as(i32, 31)) return; // Too far from the surface.
+			},
 			.air => {
 				relZ += -16 + random.nextIntBounded(i32, &seed, 32);
 				if(caveMap.isSolid(px, py, relZ)) return;


### PR DESCRIPTION
As in the title, likely a more robust solution would be required, unless we want follow up PRs 
> Add silly new generator mode enum value `floor_above_25`
> Add silly new generator mode enum value `floor_above_50`
> Add silly new generator mode enum value `floor_above_75`