### PR TITLE
Allow pressing ESC once to exit chat fully

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -274,10 +274,7 @@ fn logToStdErr(comptime format: []const u8, args: anytype) void {
 
 // MARK: Callbacks
 fn escape(_: Window.Key.Modifiers) void {
-	if(gui.selectedTextInput != null) {
-		gui.setSelectedTextInput(null);
-		return;
-	}
+	if(gui.selectedTextInput != null) gui.setSelectedTextInput(null);
 	if(game.world == null) return;
 	gui.toggleGameMenu();
 }


### PR DESCRIPTION
Removed the return that cancels GUI closing if there is a focused text box. This also applies to searching in the creative inventory and editing signs but I think its positive change in those cases too

fixes #709 