### PR TITLE
Add shift-click from creative inventory

### DIFF
--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -1631,7 +1631,7 @@ pub const Command = struct { // MARK: Command
 		source: InventoryAndSlot,
 		amount: u16,
 
-		fn run(self: DepositToAny, allocator: NeverFailingAllocator, cmd: *Command, side: Side, user: ?*main.server.User, _: Gamemode) error{serverFailure}!void {
+		fn run(self: DepositToAny, allocator: NeverFailingAllocator, cmd: *Command, side: Side, user: ?*main.server.User, gamemode: Gamemode) error{serverFailure}!void {
 			if(self.dest.type == .creative) return;
 			if(self.dest.type == .crafting) return;
 			if(self.dest.type == .workbench) return;
@@ -1641,7 +1641,7 @@ pub const Command = struct { // MARK: Command
 			}
 			const sourceStack = self.source.ref();
 			if(sourceStack.item == null) return;
-			if(self.amount > sourceStack.amount) return;
+			if(self.amount > sourceStack.amount and self.source.inv.type != .creative) return;
 
 			var remainingAmount = self.amount;
 			var selectedEmptySlot: ?u32 = null;
@@ -1652,21 +1652,29 @@ pub const Command = struct { // MARK: Command
 				if(std.meta.eql(destStack.item, sourceStack.item)) {
 					const amount = @min(sourceStack.item.?.stackSize() - destStack.amount, remainingAmount);
 					if(amount == 0) continue;
-					cmd.executeBaseOperation(allocator, .{.move = .{
-						.dest = .{.inv = self.dest, .slot = @intCast(destSlot)},
-						.source = self.source,
-						.amount = amount,
-					}}, side);
+					if(self.source.inv.type == .creative) {
+						try FillFromCreative.run(.{.dest = .{.inv = self.dest, .slot = @intCast(destSlot)}, .item = self.source.ref().item, .amount = amount + destStack.amount}, allocator, cmd, side, user, gamemode);
+					} else {
+						cmd.executeBaseOperation(allocator, .{.move = .{
+							.dest = .{.inv = self.dest, .slot = @intCast(destSlot)},
+							.source = self.source,
+							.amount = amount,
+						}}, side);
+					}
 					remainingAmount -= amount;
 					if(remainingAmount == 0) break;
 				}
 			}
 			if(remainingAmount > 0 and selectedEmptySlot != null) {
-				cmd.executeBaseOperation(allocator, .{.move = .{
-					.dest = .{.inv = self.dest, .slot = selectedEmptySlot.?},
-					.source = self.source,
-					.amount = remainingAmount,
-				}}, side);
+				if(self.source.inv.type == .creative) {
+					try FillFromCreative.run(.{.dest = .{.inv = self.dest, .slot = selectedEmptySlot.?}, .item = self.source.ref().item, .amount = remainingAmount}, allocator, cmd, side, user, gamemode);
+				} else {
+					cmd.executeBaseOperation(allocator, .{.move = .{
+						.dest = .{.inv = self.dest, .slot = selectedEmptySlot.?},
+						.source = self.source,
+						.amount = remainingAmount,
+					}}, side);
+				}
 			}
 		}
 

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -739,7 +739,13 @@ pub const inventory = struct { // MARK: inventory
 				carried.distribute(targetInventories, targetSlots);
 				leftClickSlots.clearRetainingCapacity();
 			} else if(hoveredItemSlot) |hovered| {
-				hovered.inventory.depositOrSwap(hovered.itemSlot, carried);
+				if(hovered.inventory.type == .creative and main.KeyBoard.key("mainGuiButton").modsOnPress.shift) {
+					if(hovered.inventory.getItem(hovered.itemSlot)) |item| {
+						hovered.inventory.depositToAny(hovered.itemSlot, main.game.Player.inventory, item.stackSize());
+					}
+				} else {
+					hovered.inventory.depositOrSwap(hovered.itemSlot, carried);
+				}
 			} else if(!hoveredAWindow) {
 				carried.dropStack(0);
 			}


### PR DESCRIPTION
Modifies the behavior of `DepositToAny.run` when the source inventory is the creative inventory, calling `FillFromCreative.run`. Makes shift-clicking an item in the creative inventory call `depositToAny` once per click.

Resolves #2201.