### PR TITLE
Implemented Mat3f in some scenarios where a 4D matrix is inefficient and unneeded

### DIFF
--- a/mods/cubyz/rotation/branch.zig
+++ b/mods/cubyz/rotation/branch.zig
@@ -9,7 +9,6 @@ const rotation = main.rotation;
 const Degrees = rotation.Degrees;
 const RotationMode = rotation.RotationMode;
 const vec = main.vec;
-const Mat4f = vec.Mat4f;
 const Vec2f = vec.Vec2f;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;

--- a/mods/cubyz/rotation/carpet.zig
+++ b/mods/cubyz/rotation/carpet.zig
@@ -10,7 +10,7 @@ const Degrees = rotation.Degrees;
 const RayIntersectionResult = rotation.RayIntersectionResult;
 const RotationMode = rotation.RotationMode;
 const vec = main.vec;
-const Mat4f = vec.Mat4f;
+const Mat3f = vec.Mat3f;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
 const ZonElement = main.ZonElement;
@@ -79,12 +79,12 @@ pub fn createBlockModel(_: Block, _: *u16, zon: ZonElement) ModelIndex {
 	for(1..64) |i| {
 		const carpetData: CarpetData = @bitCast(@as(u6, @intCast(i)));
 		if(i & i - 1 == 0) {
-			if(carpetData.negX) negXModel = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(-std.math.pi/2.0).mul(Mat4f.rotationX(-std.math.pi/2.0))});
-			if(carpetData.posX) posXModel = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(std.math.pi/2.0).mul(Mat4f.rotationX(-std.math.pi/2.0))});
-			if(carpetData.negY) negYModel = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationX(-std.math.pi/2.0)});
-			if(carpetData.posY) posYModel = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(std.math.pi).mul(Mat4f.rotationX(-std.math.pi/2.0))});
-			if(carpetData.negZ) negZModel = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.identity()});
-			if(carpetData.posZ) posZModel = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationY(std.math.pi)});
+			if(carpetData.negX) negXModel = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(-std.math.pi/2.0).mul(Mat3f.rotationX(-std.math.pi/2.0))});
+			if(carpetData.posX) posXModel = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(std.math.pi/2.0).mul(Mat3f.rotationX(-std.math.pi/2.0))});
+			if(carpetData.negY) negYModel = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationX(-std.math.pi/2.0)});
+			if(carpetData.posY) posYModel = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(std.math.pi).mul(Mat3f.rotationX(-std.math.pi/2.0))});
+			if(carpetData.negZ) negZModel = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.identity()});
+			if(carpetData.posZ) posZModel = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationY(std.math.pi)});
 		} else {
 			var models: [6]ModelIndex = undefined;
 			var amount: usize = 0;

--- a/mods/cubyz/rotation/direction.zig
+++ b/mods/cubyz/rotation/direction.zig
@@ -8,7 +8,7 @@ const ModelIndex = main.models.ModelIndex;
 const rotation = main.rotation;
 const Degrees = rotation.Degrees;
 const vec = main.vec;
-const Mat4f = vec.Mat4f;
+const Mat3f = vec.Mat3f;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
 const ZonElement = main.ZonElement;
@@ -33,12 +33,12 @@ pub fn createBlockModel(_: Block, _: *u16, zon: ZonElement) ModelIndex {
 
 	const baseModel = main.models.getModelIndex(modelId).model();
 	// Rotate the model:
-	const modelIndex = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.identity()});
-	_ = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationY(std.math.pi)});
-	_ = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(-std.math.pi/2.0).mul(Mat4f.rotationX(-std.math.pi/2.0))});
-	_ = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(std.math.pi/2.0).mul(Mat4f.rotationX(-std.math.pi/2.0))});
-	_ = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationX(-std.math.pi/2.0)});
-	_ = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(std.math.pi).mul(Mat4f.rotationX(-std.math.pi/2.0))});
+	const modelIndex = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.identity()});
+	_ = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationY(std.math.pi)});
+	_ = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(-std.math.pi/2.0).mul(Mat3f.rotationX(-std.math.pi/2.0))});
+	_ = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(std.math.pi/2.0).mul(Mat3f.rotationX(-std.math.pi/2.0))});
+	_ = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationX(-std.math.pi/2.0)});
+	_ = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(std.math.pi).mul(Mat3f.rotationX(-std.math.pi/2.0))});
 	rotatedModels.put(modelId, modelIndex) catch unreachable;
 	return modelIndex;
 }

--- a/mods/cubyz/rotation/fence.zig
+++ b/mods/cubyz/rotation/fence.zig
@@ -8,7 +8,6 @@ const ModelIndex = main.models.ModelIndex;
 const rotation = main.rotation;
 const Degrees = rotation.Degrees;
 const vec = main.vec;
-const Mat4f = vec.Mat4f;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
 const ZonElement = main.ZonElement;

--- a/mods/cubyz/rotation/log.zig
+++ b/mods/cubyz/rotation/log.zig
@@ -9,7 +9,6 @@ const rotation = main.rotation;
 const Degrees = rotation.Degrees;
 const RotationMode = rotation.RotationMode;
 const vec = main.vec;
-const Mat4f = vec.Mat4f;
 const Vec2f = vec.Vec2f;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;

--- a/mods/cubyz/rotation/ore.zig
+++ b/mods/cubyz/rotation/ore.zig
@@ -10,7 +10,6 @@ const Degrees = rotation.Degrees;
 const RayIntersectionResult = rotation.RayIntersectionResult;
 const RotationMode = rotation.RotationMode;
 const vec = main.vec;
-const Mat4f = vec.Mat4f;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
 const ZonElement = main.ZonElement;

--- a/mods/cubyz/rotation/planar.zig
+++ b/mods/cubyz/rotation/planar.zig
@@ -9,7 +9,6 @@ const rotation = main.rotation;
 const Degrees = rotation.Degrees;
 const vec = main.vec;
 const Mat3f = vec.Mat3f;
-const Mat4f = vec.Mat4f;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
 const ZonElement = main.ZonElement;

--- a/mods/cubyz/rotation/planar.zig
+++ b/mods/cubyz/rotation/planar.zig
@@ -8,6 +8,7 @@ const ModelIndex = main.models.ModelIndex;
 const rotation = main.rotation;
 const Degrees = rotation.Degrees;
 const vec = main.vec;
+const Mat3f = vec.Mat3f;
 const Mat4f = vec.Mat4f;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
@@ -33,10 +34,10 @@ pub fn createBlockModel(_: Block, _: *u16, zon: ZonElement) ModelIndex {
 
 	const baseModel = main.models.getModelIndex(modelId).model();
 	// Rotate the model:
-	const modelIndex: ModelIndex = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(std.math.pi/2.0)});
-	_ = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(-std.math.pi/2.0)});
-	_ = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(std.math.pi)});
-	_ = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.identity()});
+	const modelIndex: ModelIndex = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(std.math.pi/2.0)});
+	_ = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(-std.math.pi/2.0)});
+	_ = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(std.math.pi)});
+	_ = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.identity()});
 	rotatedModels.put(modelId, modelIndex) catch unreachable;
 	return modelIndex;
 }

--- a/mods/cubyz/rotation/sign.zig
+++ b/mods/cubyz/rotation/sign.zig
@@ -10,7 +10,7 @@ const Degrees = rotation.Degrees;
 const RayIntersectionResult = rotation.RayIntersectionResult;
 const RotationMode = rotation.RotationMode;
 const vec = main.vec;
-const Mat4f = vec.Mat4f;
+const Mat3f = vec.Mat3f;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
 const ZonElement = main.ZonElement;
@@ -48,14 +48,14 @@ pub fn createBlockModel(_: Block, _: *u16, zon: ZonElement) ModelIndex {
 	var modelIndex: ModelIndex = undefined;
 	// Rotate the model:
 	for(0..centerRotations) |i| {
-		const index = floorModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(@as(f32, @floatFromInt(i))*2.0*std.math.pi/centerRotations)});
+		const index = floorModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(@as(f32, @floatFromInt(i))*2.0*std.math.pi/centerRotations)});
 		if(i == 0) modelIndex = index;
 	}
 	for(0..centerRotations) |i| {
-		_ = ceilingModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(@as(f32, @floatFromInt(i))*2.0*std.math.pi/centerRotations)});
+		_ = ceilingModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(@as(f32, @floatFromInt(i))*2.0*std.math.pi/centerRotations)});
 	}
 	for(0..sideRotations) |i| {
-		_ = sideModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(@as(f32, @floatFromInt(i))*2.0*std.math.pi/sideRotations)});
+		_ = sideModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(@as(f32, @floatFromInt(i))*2.0*std.math.pi/sideRotations)});
 	}
 	rotatedModels.put(key, modelIndex) catch unreachable;
 	return modelIndex;

--- a/mods/cubyz/rotation/stairs.zig
+++ b/mods/cubyz/rotation/stairs.zig
@@ -10,7 +10,6 @@ const Degrees = rotation.Degrees;
 const RayIntersectionResult = rotation.RayIntersectionResult;
 const RotationMode = rotation.RotationMode;
 const vec = main.vec;
-const Mat4f = vec.Mat4f;
 const Tag = main.Tag;
 const Vec2f = vec.Vec2f;
 const Vec3f = vec.Vec3f;

--- a/mods/cubyz/rotation/torch.zig
+++ b/mods/cubyz/rotation/torch.zig
@@ -10,7 +10,7 @@ const Degrees = rotation.Degrees;
 const RayIntersectionResult = rotation.RayIntersectionResult;
 const RotationMode = rotation.RotationMode;
 const vec = main.vec;
-const Mat4f = vec.Mat4f;
+const Mat3f = vec.Mat3f;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
 const ZonElement = main.ZonElement;
@@ -57,11 +57,11 @@ pub fn createBlockModel(_: Block, _: *u16, zon: ZonElement) ModelIndex {
 	for(1..32) |i| {
 		const torchData: TorchData = @bitCast(@as(u5, @intCast(i)));
 		if(i & i - 1 == 0) {
-			if(torchData.center) centerModel = baseModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.identity()});
-			if(torchData.negX) negXModel = sideModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(0)});
-			if(torchData.posX) posXModel = sideModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(std.math.pi)});
-			if(torchData.negY) negYModel = sideModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(std.math.pi/2.0)});
-			if(torchData.posY) posYModel = sideModel.transformModel(rotation.rotationMatrixTransform, .{Mat4f.rotationZ(-std.math.pi/2.0)});
+			if(torchData.center) centerModel = baseModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.identity()});
+			if(torchData.negX) negXModel = sideModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(0)});
+			if(torchData.posX) posXModel = sideModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(std.math.pi)});
+			if(torchData.negY) negYModel = sideModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(std.math.pi/2.0)});
+			if(torchData.posY) posYModel = sideModel.transformModel(rotation.rotationMatrixTransform3D, .{Mat3f.rotationZ(-std.math.pi/2.0)});
 		} else {
 			var models: [5]ModelIndex = undefined;
 			var amount: usize = 0;

--- a/src/items.zig
+++ b/src/items.zig
@@ -14,7 +14,6 @@ const NeverFailingAllocator = main.heap.NeverFailingAllocator;
 const chunk = main.chunk;
 const random = @import("random.zig");
 const vec = @import("vec.zig");
-const Mat4f = vec.Mat4f;
 const Vec2f = vec.Vec2f;
 const Vec2i = vec.Vec2i;
 const Vec3i = vec.Vec3i;

--- a/src/models.zig
+++ b/src/models.zig
@@ -9,7 +9,6 @@ const Vec3i = vec.Vec3i;
 const Vec3f = vec.Vec3f;
 const Vec3d = vec.Vec3d;
 const Vec2f = vec.Vec2f;
-const Mat4f = vec.Mat4f;
 
 const FaceData = main.renderer.chunk_meshing.FaceData;
 const NeverFailingAllocator = main.heap.NeverFailingAllocator;

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -467,7 +467,7 @@ const Bloom = struct { // MARK: Bloom
 	}
 };
 
-pub const MenuBackGround = struct { // Mark: MenuBackground
+pub const MenuBackGround = struct { // MARK: MenuBackground
 	var pipeline: graphics.Pipeline = undefined;
 	var uniforms: struct {
 		viewMatrix: c_int,
@@ -667,7 +667,7 @@ pub const MenuBackGround = struct { // Mark: MenuBackground
 	}
 };
 
-pub const Skybox = struct { // Mark: Skybox
+pub const Skybox = struct { // MARK: Skybox
 	var starPipeline: graphics.Pipeline = undefined;
 	var starUniforms: struct {
 		mvp: c_int,

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -60,7 +60,7 @@ pub var activeFrameBuffer: c_uint = 0;
 pub const reflectionCubeMapSize = 64;
 var reflectionCubeMap: graphics.CubeMapTexture = undefined;
 
-pub fn init() void {
+pub fn init() void { // MARK: init()
 	deferredRenderPassPipeline = graphics.Pipeline.init(
 		"assets/cubyz/shaders/deferred_render_pass.vert",
 		"assets/cubyz/shaders/deferred_render_pass.frag",
@@ -92,7 +92,7 @@ pub fn init() void {
 	initReflectionCubeMap();
 }
 
-pub fn deinit() void {
+pub fn deinit() void { // MARK: deinit()
 	deferredRenderPassPipeline.deinit();
 	fakeReflectionPipeline.deinit();
 	worldFrameBuffer.deinit();
@@ -105,7 +105,7 @@ pub fn deinit() void {
 	reflectionCubeMap.deinit();
 }
 
-fn initReflectionCubeMap() void {
+fn initReflectionCubeMap() void { // MARK: initReflectionCubeMap()
 	c.glViewport(0, 0, reflectionCubeMapSize, reflectionCubeMapSize);
 	var framebuffer: graphics.FrameBuffer = undefined;
 	framebuffer.init(false, c.GL_LINEAR, c.GL_CLAMP_TO_EDGE);
@@ -129,7 +129,7 @@ var worldFrameBuffer: graphics.FrameBuffer = undefined;
 pub var lastWidth: u31 = 0;
 pub var lastHeight: u31 = 0;
 var lastFov: f32 = 0;
-pub fn updateFov(fov: f32) void {
+pub fn updateFov(fov: f32) void { // MARK: updateFov() & updateViewport()
 	if(lastFov != fov) {
 		lastFov = fov;
 		game.projectionMatrix = Mat4f.perspective(std.math.degreesToRadians(fov), @as(f32, @floatFromInt(lastWidth))/@as(f32, @floatFromInt(lastHeight)), zNear, zFar);
@@ -142,7 +142,7 @@ pub fn updateViewport(width: u31, height: u31) void {
 	worldFrameBuffer.unbind();
 }
 
-pub fn render(playerPosition: Vec3d, deltaTime: f64) void {
+pub fn render(playerPosition: Vec3d, deltaTime: f64) void { // MARK: render()
 	// TODO: player bobbing
 	// TODO: Handle colors and sun position in the world.
 	std.debug.assert(game.world != null);
@@ -157,7 +157,7 @@ pub fn render(playerPosition: Vec3d, deltaTime: f64) void {
 	mesh_storage.updateMeshes(startTime + maximumMeshTime);
 }
 
-pub fn crosshairDirection(rotationMatrix: Mat4f, fovY: f32, width: u31, height: u31) Vec3f {
+pub fn crosshairDirection(rotationMatrix: Mat4f, fovY: f32, width: u31, height: u31) Vec3f { // MARK: crosshairDirection()
 	// stolen code from Frustum.init
 	const invRotationMatrix = rotationMatrix.transpose();
 	const cameraDir = vec.xyz(invRotationMatrix.mulVec(Vec4f{0, 1, 0, 1}));
@@ -466,7 +466,7 @@ const Bloom = struct { // MARK: Bloom
 	}
 };
 
-pub const MenuBackGround = struct {
+pub const MenuBackGround = struct { // Mark: MenuBackground
 	var pipeline: graphics.Pipeline = undefined;
 	var uniforms: struct {
 		viewMatrix: c_int,
@@ -666,7 +666,7 @@ pub const MenuBackGround = struct {
 	}
 };
 
-pub const Skybox = struct {
+pub const Skybox = struct { // Mark: Skybox
 	var starPipeline: graphics.Pipeline = undefined;
 	var starUniforms: struct {
 		mvp: c_int,

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -23,6 +23,7 @@ const Vec3i = vec.Vec3i;
 const Vec3f = vec.Vec3f;
 const Vec3d = vec.Vec3d;
 const Vec4f = vec.Vec4f;
+const Mat3f = vec.Mat3f;
 const Mat4f = vec.Mat4f;
 
 pub const chunk_meshing = @import("renderer/chunk_meshing.zig");
@@ -769,11 +770,11 @@ pub const Skybox = struct { // Mark: Skybox
 			const latitude: f32 = @floatCast(std.math.asin(normPos[2]));
 			const longitude: f32 = @floatCast(std.math.atan2(-normPos[0], normPos[1]));
 
-			const mat = Mat4f.rotationZ(longitude).mul(Mat4f.rotationX(latitude));
+			const mat = Mat3f.rotationZ(longitude).mul(Mat3f.rotationX(latitude));
 
-			const posA = vec.xyz(mat.mulVec(.{triVertA[0], triVertA[1], triVertA[2], 1.0}));
-			const posB = vec.xyz(mat.mulVec(.{triVertB[0], triVertB[1], triVertB[2], 1.0}));
-			const posC = vec.xyz(mat.mulVec(.{triVertC[0], triVertC[1], triVertC[2], 1.0}));
+			const posA = mat.mulVec(triVertA);
+			const posB = mat.mulVec(triVertB);
+			const posC = mat.mulVec(triVertC);
 
 			starData[i*20 ..][0..3].* = posA;
 			starData[i*20 + 4 ..][0..3].* = posB;

--- a/src/renderer/mesh_storage.zig
+++ b/src/renderer/mesh_storage.zig
@@ -15,7 +15,6 @@ const Vec3i = vec.Vec3i;
 const Vec3f = vec.Vec3f;
 const Vec3d = vec.Vec3d;
 const Vec4f = vec.Vec4f;
-const Mat4f = vec.Mat4f;
 const EventStatus = main.block_entity.EventStatus;
 
 const chunk_meshing = @import("chunk_meshing.zig");

--- a/src/rotation.zig
+++ b/src/rotation.zig
@@ -10,6 +10,7 @@ const Tag = main.Tag;
 const vec = main.vec;
 const Vec3i = vec.Vec3i;
 const Vec3f = vec.Vec3f;
+const Mat3f = vec.Mat3f;
 const Mat4f = vec.Mat4f;
 const ZonElement = main.ZonElement;
 
@@ -175,6 +176,13 @@ pub fn rotationMatrixTransform(quad: *main.models.QuadInfo, transformMatrix: Mat
 	quad.normal = vec.xyz(Mat4f.mulVec(transformMatrix, vec.combine(quad.normal, 0)));
 	for(&quad.corners) |*corner| {
 		corner.* = vec.xyz(Mat4f.mulVec(transformMatrix, vec.combine(corner.* - Vec3f{0.5, 0.5, 0.5}, 1))) + Vec3f{0.5, 0.5, 0.5};
+	}
+}
+
+pub fn rotationMatrixTransform3D(quad: *main.models.QuadInfo, transformMatrix: Mat3f) void {
+	quad.normal = Mat3f.mulVec(transformMatrix, quad.normal);
+	for(&quad.corners) |*corner| {
+		corner.* = Mat3f.mulVec(transformMatrix, corner.* - Vec3f{0.5, 0.5, 0.5}) + Vec3f{0.5, 0.5, 0.5};
 	}
 }
 

--- a/src/vec.zig
+++ b/src/vec.zig
@@ -161,7 +161,7 @@ pub const Mat3f = struct { // MARK: Mat3f
 
 	pub fn transpose(self: Mat3f) Mat3f {
 		return Mat3f{
-			.rows = [4]Vec3f{
+			.rows = [3]Vec3f{
 				Vec3f{self.rows[0][0], self.rows[1][0], self.rows[2][0]},
 				Vec3f{self.rows[0][1], self.rows[1][1], self.rows[2][1]},
 				Vec3f{self.rows[0][2], self.rows[1][2], self.rows[2][2]},

--- a/src/vec.zig
+++ b/src/vec.zig
@@ -172,7 +172,7 @@ pub const Mat3f = struct { // MARK: Mat3f
 	pub fn mul(self: Mat3f, other: Mat3f) Mat3f {
 		const transposeOther = other.transpose();
 		var result: Mat3f = undefined;
-		for (&result.rows, self.rows) |*resRow, selfRow| {
+		for(&result.rows, self.rows) |*resRow, selfRow| {
 			resRow.* = .{
 				dot(selfRow, transposeOther.rows[0]),
 				dot(selfRow, transposeOther.rows[1]),

--- a/src/vec.zig
+++ b/src/vec.zig
@@ -101,6 +101,96 @@ pub fn rotate2d(self: anytype, angle: @typeInfo(@TypeOf(self)).vector.child, cen
 	} + center;
 }
 
+pub const Mat3f = struct { // MARK: Mat3f
+	rows: [3]Vec3f,
+	pub fn identity() Mat3f {
+		return Mat3f{
+			.rows = [3]Vec3f{
+				Vec3f{1, 0, 0},
+				Vec3f{0, 1, 0},
+				Vec3f{0, 0, 1},
+			},
+		};
+	}
+
+	pub fn scale(vector: Vec3f) Mat3f { // zig fmt: off
+		return Mat3f{
+			.rows = [3]Vec3f{
+				Vec3f{vector[0], 0,         0,       },
+				Vec3f{0,         vector[1], 0,       },
+				Vec3f{0,         0,         vector[2]},
+			},
+		};
+	} // zig fmt: on
+
+	pub fn rotationX(rad: f32) Mat3f {
+		const s = @sin(rad);
+		const c = @cos(rad);
+		return Mat3f{
+			.rows = [3]Vec3f{
+				Vec3f{1, 0, 0},
+				Vec3f{0, c, -s},
+				Vec3f{0, s, c},
+			},
+		};
+	}
+
+	pub fn rotationY(rad: f32) Mat3f {
+		const s = @sin(rad);
+		const c = @cos(rad);
+		return Mat3f{
+			.rows = [3]Vec3f{
+				Vec3f{c, 0, s},
+				Vec3f{0, 1, 0},
+				Vec3f{-s, 0, c},
+			},
+		};
+	}
+
+	pub fn rotationZ(rad: f32) Mat3f {
+		const s = @sin(rad);
+		const c = @cos(rad);
+		return Mat3f{
+			.rows = [3]Vec3f{
+				Vec3f{c, -s, 0},
+				Vec3f{s, c, 0},
+				Vec3f{0, 0, 1},
+			},
+		};
+	}
+
+	pub fn transpose(self: Mat3f) Mat3f {
+		return Mat3f{
+			.rows = [4]Vec3f{
+				Vec3f{self.rows[0][0], self.rows[1][0], self.rows[2][0]},
+				Vec3f{self.rows[0][1], self.rows[1][1], self.rows[2][1]},
+				Vec3f{self.rows[0][2], self.rows[1][2], self.rows[2][2]},
+			},
+		};
+	}
+
+	pub fn mul(self: Mat3f, other: Mat3f) Mat3f {
+		const transposeOther = other.transpose();
+		var result: Mat3f = undefined;
+		for (&result.rows, self.rows) |*resRow, selfRow| {
+			resRow.* = .{
+				dot(selfRow, transposeOther.rows[0]),
+				dot(selfRow, transposeOther.rows[1]),
+				dot(selfRow, transposeOther.rows[2]),
+			};
+		}
+		return result;
+	}
+
+	pub fn mulVec(self: Mat3f, vec: Vec3f) Vec3f {
+		return Vec3f{
+			dot(self.rows[0], vec),
+			dot(self.rows[1], vec),
+			dot(self.rows[2], vec),
+		};
+	}
+};
+
 pub const Mat4f = struct { // MARK: Mat4f
 	rows: [4]Vec4f,
 	pub fn identity() Mat4f {


### PR DESCRIPTION
These changes server not only to improve performance but also readability, making it clearer what certain sections of code do by reducing the need to convert between 4d and 3d vectors in calculations.

Additionally added markers within the renderer to make it easier to find certain sections of code. Markers were already present but only on *some* of the structs.

My motivations for doing this were when I was reading through the code to try to understand how portions of it worked, the 4D matrices at times impacted readability and made it less clear what was happening, especially with an abundance of `vec.xyz()`. I feel as though this is a necessary change to work towards a more maintainable code base that is easier for other people to understand and adapt in future.