### PR TITLE
Show the actual error message in the error popup

### DIFF
--- a/src/gui/windows/error_prompt.zig
+++ b/src/gui/windows/error_prompt.zig
@@ -63,7 +63,7 @@ pub fn update() void {
 
 const plainErrorText = "#ffff00The game encountered errors.\nCheck the logs for details.";
 const singleErrorFmtText = "#ff0000{s}";
-const multipleErrorFmtText =  "#ff0000{s}\n#ffff00And {d} more...\nCheck the logs for details.";
+const multipleErrorFmtText = "#ff0000{s}\n#ffff00And {d} more...\nCheck the logs for details.";
 
 pub fn onOpen() void {
 	isOpen = true;

--- a/src/gui/windows/error_prompt.zig
+++ b/src/gui/windows/error_prompt.zig
@@ -63,7 +63,6 @@ pub fn update() void {
 	}
 }
 
-const plainErrorText = "#ffff00The game encountered errors.\nCheck the logs for details.";
 const singleErrorFmtText = "#ff0000{s}";
 const multipleErrorFmtText = "#ff0000{s}\n#ffff00And {d} more...\nCheck the logs for details.";
 

--- a/src/gui/windows/error_prompt.zig
+++ b/src/gui/windows/error_prompt.zig
@@ -13,6 +13,9 @@ const VerticalList = @import("../components/VerticalList.zig");
 const Button = @import("../components/Button.zig");
 
 var fileExplorerIcon: Texture = undefined;
+var errorText: []const u8 = "";
+var isOpen: bool = false;
+var errorCount: u32 = 0;
 
 pub var window = GuiWindow{
 	.contentSize = Vec2f{128, 64},
@@ -26,14 +29,30 @@ pub var window = GuiWindow{
 
 pub fn init() void {
 	fileExplorerIcon = Texture.initFromFile("assets/cubyz/ui/file_explorer_icon.png");
+	errorText = main.globalAllocator.dupe(u8, "");
 }
 
 pub fn deinit() void {
 	fileExplorerIcon.deinit();
+	main.globalAllocator.free(errorText);
 }
 
 fn openLog() void {
 	main.files.openDirInWindow("logs");
+}
+
+pub fn raiseError(newText: []const u8) void {
+	if(isOpen) {
+		gui.closeWindow("error_prompt");
+		errorCount += 1;
+		gui.openWindow("error_prompt");
+	} else {
+		// openWindow can take time
+		main.globalAllocator.free(errorText);
+		errorText = main.globalAllocator.dupe(u8, newText);
+		errorCount = 0;
+		gui.openWindow("error_prompt");
+	}
 }
 
 const padding: f32 = 8;
@@ -43,9 +62,17 @@ pub fn update() void {
 	}
 }
 
+const plainErrorText = "#ffff00The game encountered errors.\nCheck the logs for details.";
+const singleErrorFmtText = "#ff0000{s}";
+const multipleErrorFmtText =  "#ff0000{s}\n#ffff00And {d} more...\nCheck the logs for details.";
+
 pub fn onOpen() void {
+	isOpen = true;
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
-	list.add(Label.init(.{padding, 16 + padding}, 128, "#ffff00The game encountered errors. Check the logs for details", .center));
+	var buf: [256]u8 = undefined;
+	const str = if(errorCount == 0) std.fmt.bufPrint(&buf, singleErrorFmtText, .{errorText}) catch plainErrorText
+		else std.fmt.bufPrint(&buf, multipleErrorFmtText, .{errorText, errorCount}) catch plainErrorText;
+	list.add(Label.init(.{padding, 16 + padding}, 256, str, .center));
 	list.add(Button.initIcon(.{0, 0}, .{16, 16}, fileExplorerIcon, false, .init(openLog)));
 	list.finish(.center);
 	window.rootComponent = list.toComponent();
@@ -54,6 +81,7 @@ pub fn onOpen() void {
 }
 
 pub fn onClose() void {
+	isOpen = false;
 	if (window.rootComponent) |*comp| {
 		comp.deinit();
 	}

--- a/src/gui/windows/error_prompt.zig
+++ b/src/gui/windows/error_prompt.zig
@@ -33,8 +33,8 @@ pub fn init() void {
 
 pub fn deinit() void {
 	fileExplorerIcon.deinit();
-	if (errorText != null) {
-		main.globalAllocator.free(errorText.?);
+	if (errorText) |text| {
+		main.globalAllocator.free(text);
 		errorText = null;
 	}
 }
@@ -49,7 +49,7 @@ pub fn raiseError(newText: []const u8) void {
 		onClose();
 		onOpen();
 	} else {
-		if (errorText != null) main.globalAllocator.free(errorText.?);
+		if (errorText) |text| main.globalAllocator.free(text);
 		errorText = main.globalAllocator.dupe(u8, newText);
 		errorCount = 0;
 		gui.openWindowFromRef(&window);

--- a/src/gui/windows/error_prompt.zig
+++ b/src/gui/windows/error_prompt.zig
@@ -12,10 +12,10 @@ const Label = @import("../components/Label.zig");
 const VerticalList = @import("../components/VerticalList.zig");
 const Button = @import("../components/Button.zig");
 
-var fileExplorerIcon: Texture = undefined;
-var errorText: []const u8 = "";
-var isOpen: bool = false;
 var errorCount: u32 = 0;
+var errorText: []const u8 = "";
+var fileExplorerIcon: Texture = undefined;
+var isOpen: bool = false;
 
 pub var window = GuiWindow{
 	.contentSize = Vec2f{128, 64},
@@ -43,15 +43,14 @@ fn openLog() void {
 
 pub fn raiseError(newText: []const u8) void {
 	if(isOpen) {
-		gui.closeWindow("error_prompt");
 		errorCount += 1;
-		gui.openWindow("error_prompt");
+		onClose();
+		onOpen();
 	} else {
-		// openWindow can take time
 		main.globalAllocator.free(errorText);
 		errorText = main.globalAllocator.dupe(u8, newText);
 		errorCount = 0;
-		gui.openWindow("error_prompt");
+		gui.openWindowFromRef(&window);
 	}
 }
 

--- a/src/gui/windows/error_prompt.zig
+++ b/src/gui/windows/error_prompt.zig
@@ -13,7 +13,7 @@ const VerticalList = @import("../components/VerticalList.zig");
 const Button = @import("../components/Button.zig");
 
 var errorCount: u32 = 0;
-var errorText: []const u8 = "";
+var errorText: ?[]const u8 = null;
 var fileExplorerIcon: Texture = undefined;
 var isOpen: bool = false;
 
@@ -29,12 +29,14 @@ pub var window = GuiWindow{
 
 pub fn init() void {
 	fileExplorerIcon = Texture.initFromFile("assets/cubyz/ui/file_explorer_icon.png");
-	errorText = main.globalAllocator.dupe(u8, "");
 }
 
 pub fn deinit() void {
 	fileExplorerIcon.deinit();
-	main.globalAllocator.free(errorText);
+	if(errorText != null) {
+		main.globalAllocator.free(errorText.?);
+		errorText = null;
+	}
 }
 
 fn openLog() void {
@@ -47,7 +49,7 @@ pub fn raiseError(newText: []const u8) void {
 		onClose();
 		onOpen();
 	} else {
-		main.globalAllocator.free(errorText);
+		if(errorText != null) main.globalAllocator.free(errorText.?);
 		errorText = main.globalAllocator.dupe(u8, newText);
 		errorCount = 0;
 		gui.openWindowFromRef(&window);
@@ -70,9 +72,9 @@ pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
 	var str: []const u8 = undefined;
 	if(errorCount == 0) {
-		str = std.fmt.allocPrint(main.stackAllocator.allocator, singleErrorFmtText, .{errorText}) catch unreachable;
+		str = std.fmt.allocPrint(main.stackAllocator.allocator, singleErrorFmtText, .{errorText.?}) catch unreachable;
 	} else {
-		str = std.fmt.allocPrint(main.stackAllocator.allocator, multipleErrorFmtText, .{errorText, errorCount}) catch unreachable;
+		str = std.fmt.allocPrint(main.stackAllocator.allocator, multipleErrorFmtText, .{errorText.?, errorCount}) catch unreachable;
 	}
 	defer main.stackAllocator.free(str);
 	list.add(Label.init(.{padding, 16 + padding}, 256, str, .center));

--- a/src/gui/windows/error_prompt.zig
+++ b/src/gui/windows/error_prompt.zig
@@ -33,7 +33,7 @@ pub fn init() void {
 
 pub fn deinit() void {
 	fileExplorerIcon.deinit();
-	if(errorText != null) {
+	if (errorText != null) {
 		main.globalAllocator.free(errorText.?);
 		errorText = null;
 	}
@@ -44,12 +44,12 @@ fn openLog() void {
 }
 
 pub fn raiseError(newText: []const u8) void {
-	if(isOpen) {
+	if (isOpen) {
 		errorCount += 1;
 		onClose();
 		onOpen();
 	} else {
-		if(errorText != null) main.globalAllocator.free(errorText.?);
+		if (errorText != null) main.globalAllocator.free(errorText.?);
 		errorText = main.globalAllocator.dupe(u8, newText);
 		errorCount = 0;
 		gui.openWindowFromRef(&window);
@@ -71,7 +71,7 @@ pub fn onOpen() void {
 	isOpen = true;
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
 	var str: []const u8 = undefined;
-	if(errorCount == 0) {
+	if (errorCount == 0) {
 		str = std.fmt.allocPrint(main.stackAllocator.allocator, singleErrorFmtText, .{errorText.?}) catch unreachable;
 	} else {
 		str = std.fmt.allocPrint(main.stackAllocator.allocator, multipleErrorFmtText, .{errorText.?, errorCount}) catch unreachable;

--- a/src/gui/windows/error_prompt.zig
+++ b/src/gui/windows/error_prompt.zig
@@ -68,9 +68,13 @@ const multipleErrorFmtText = "#ff0000{s}\n#ffff00And {d} more...\nCheck the logs
 pub fn onOpen() void {
 	isOpen = true;
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
-	var buf: [256]u8 = undefined;
-	const str = if(errorCount == 0) std.fmt.bufPrint(&buf, singleErrorFmtText, .{errorText}) catch plainErrorText
-		else std.fmt.bufPrint(&buf, multipleErrorFmtText, .{errorText, errorCount}) catch plainErrorText;
+	var str: []const u8 = undefined;
+	if(errorCount == 0) {
+		str = std.fmt.allocPrint(main.stackAllocator.allocator, singleErrorFmtText, .{errorText}) catch unreachable;
+	} else {
+		str = std.fmt.allocPrint(main.stackAllocator.allocator, multipleErrorFmtText, .{errorText, errorCount}) catch unreachable;
+	}
+	defer main.stackAllocator.free(str);
 	list.add(Label.init(.{padding, 16 + padding}, 256, str, .center));
 	list.add(Button.initIcon(.{0, 0}, .{16, 16}, fileExplorerIcon, false, .init(openLog)));
 	list.finish(.center);

--- a/src/gui/windows/error_prompt.zig
+++ b/src/gui/windows/error_prompt.zig
@@ -12,7 +12,7 @@ const Label = @import("../components/Label.zig");
 const VerticalList = @import("../components/VerticalList.zig");
 const Button = @import("../components/Button.zig");
 
-var errorCount: u32 = 0;
+var overflowErrorCount: u32 = 0;
 var errorText: ?[]const u8 = null;
 var fileExplorerIcon: Texture = undefined;
 var isOpen: bool = false;
@@ -45,13 +45,13 @@ fn openLog() void {
 
 pub fn raiseError(newText: []const u8) void {
 	if (isOpen) {
-		errorCount += 1;
+		overflowErrorCount += 1;
 		onClose();
 		onOpen();
 	} else {
 		if (errorText) |text| main.globalAllocator.free(text);
 		errorText = main.globalAllocator.dupe(u8, newText);
-		errorCount = 0;
+		overflowErrorCount = 0;
 		gui.openWindowFromRef(&window);
 	}
 }
@@ -65,10 +65,10 @@ pub fn onOpen() void {
 	isOpen = true;
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
 	var str: []const u8 = undefined;
-	if (errorCount == 0) {
+	if (overflowErrorCount == 0) {
 		str = std.fmt.allocPrint(main.stackAllocator.allocator, singleErrorFmtText, .{errorText.?}) catch unreachable;
 	} else {
-		str = std.fmt.allocPrint(main.stackAllocator.allocator, multipleErrorFmtText, .{errorText.?, errorCount}) catch unreachable;
+		str = std.fmt.allocPrint(main.stackAllocator.allocator, multipleErrorFmtText, .{errorText.?, overflowErrorCount}) catch unreachable;
 	}
 	defer main.stackAllocator.free(str);
 	list.add(Label.init(.{padding, 16 + padding}, 256, str, .center));

--- a/src/gui/windows/error_prompt.zig
+++ b/src/gui/windows/error_prompt.zig
@@ -57,11 +57,6 @@ pub fn raiseError(newText: []const u8) void {
 }
 
 const padding: f32 = 8;
-pub fn update() void {
-	if (main.Window.Gamepad.wereControllerMappingsDownloaded()) {
-		gui.closeWindowFromRef(&window);
-	}
-}
 
 const singleErrorFmtText = "#ff0000{s}";
 const multipleErrorFmtText = "#ff0000{s}\n#ffff00And {d} more...\nCheck the logs for details.";

--- a/src/main.zig
+++ b/src/main.zig
@@ -87,7 +87,6 @@ fn cacheString(comptime str: []const u8) []const u8 {
 var logFile: ?std.Io.File = undefined;
 var logFileTs: ?std.Io.File = undefined;
 var supportsANSIColors: bool = undefined;
-var openingErrorWindow: bool = false;
 // overwrite the log function:
 pub const std_options: std.Options = .{ // MARK: std_options
 	.log_level = .debug,
@@ -136,10 +135,8 @@ noinline fn runtimeLogFn(level: std.log.Level, format: []const u8, args: []const
 		logToStdErr("[{s}]: {s}{s}", .{filePrefix, writer.buffered(), fileSuffix});
 	}
 
-	if (level == .err and !openingErrorWindow and !settings.launchConfig.headlessServer) {
-		openingErrorWindow = true;
-		gui.openWindow("error_prompt");
-		openingErrorWindow = false;
+	if (level == .err and !settings.launchConfig.headlessServer) {
+		gui.windowlist.error_prompt.raiseError(writer.buffered());
 	}
 }
 


### PR DESCRIPTION
Adds `raiseError` function to the `error_prompt` window that
- If the window is closed, opens it and shows the error
- If the window is open, increments the error count

Fixes https://github.com/PixelGuys/Cubyz/issues/1554

<img width="460" height="228" alt="image" src="https://github.com/user-attachments/assets/8b8f30c6-50a6-4d36-b444-21d8924fecf0" />

<img width="442" height="261" alt="image" src="https://github.com/user-attachments/assets/41fc3def-03b5-453f-82d8-346fb6ebd641" />

<img width="440" height="215" alt="image" src="https://github.com/user-attachments/assets/f8b808e1-85aa-44b1-9725-d66bab901994" />

<img width="441" height="260" alt="image" src="https://github.com/user-attachments/assets/be302169-d264-4999-8813-68033368b1d6" />
