### PR TITLE
switch to globalArena for autoEnterWorld

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -499,7 +499,6 @@ pub fn main() void { // MARK: main()
 	std.log.info("Starting game with version {s}", .{settings.version.version});
 
 	settings.launchConfig.init();
-	defer settings.launchConfig.deinit();
 
 	const headless = settings.launchConfig.headlessServer;
 

--- a/src/settings.zig
+++ b/src/settings.zig
@@ -198,12 +198,8 @@ pub const launchConfig = struct {
 		};
 		defer zon.deinit(main.stackAllocator);
 
-		cubyzDir = main.globalAllocator.dupe(u8, zon.get([]const u8, "cubyzDir", cubyzDir));
+		cubyzDir = main.globalArena.dupe(u8, zon.get([]const u8, "cubyzDir", cubyzDir));
 		headlessServer = zon.get(bool, "headlessServer", headlessServer);
 		autoEnterWorld = main.globalArena.dupe(u8, zon.get([]const u8, "autoEnterWorld", autoEnterWorld));
-	}
-
-	pub fn deinit() void {
-		main.globalAllocator.free(cubyzDir);
 	}
 };


### PR DESCRIPTION
Fixes: #2284 

Could someone maybe explain to me why we should use the globalarena?
`cubyzDir` is also created here and in the deinit deallocated.
When we click on touch grass while autEnterWorld is set we also close the game so just putting free for autoEnterWorld in deinit should be ok right?