### PR TITLE
Fix parseNumber and related functions

### DIFF
--- a/src/zon.zig
+++ b/src/zon.zig
@@ -893,6 +893,12 @@ test "number parsing" {
 	try std.testing.expectApproxEqAbs(Parser.parseNumber("1.234589e10", &index).float, 1.234589e10, 1.0);
 	index = 5;
 	try std.testing.expectApproxEqAbs(Parser.parseNumber("_____0.0000000000234589e10abcdfe", &index).float, 0.234589, 1e-10);
+	index = 0;
+	try std.testing.expectEqual(Parser.parseNumber("9223372036854775807", &index), ZonElement{.int = 9223372036854775807});
+	index = 0;
+	try std.testing.expectEqual(Parser.parseNumber("18446744073709551615", &index), ZonElement{.uint = 18446744073709551615});
+	index = 0;
+	try std.testing.expectEqual(Parser.parseNumber("-9223372036854775808", &index), ZonElement{.int = -9223372036854775808});
 }
 
 test "element parsing" {


### PR DESCRIPTION
Fixes #2290 
If given values greater than an i64 can handle, the parseNumber function and the createElementFromRandomType function both could not handle that.

I added a new `.uint` property on ZonElement and it'll use `.uint` when the value is too large for a i64 (detected by checking if `std.math.cast` will cast it to a i64 for createElementFromRandomType)