### PR TITLE
Indentation change

### DIFF
--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -652,9 +652,7 @@ pub const inventory = struct { // MARK: inventory
 
 	fn update() void {
 		if(!initialized) return;
-		const itemSlot = hoveredItemSlot orelse {
-			return;
-		};
+		const itemSlot = hoveredItemSlot orelse return;
 		const mainGuiButton = main.KeyBoard.key("mainGuiButton");
 		const secondaryGuiButton = main.KeyBoard.key("secondaryGuiButton");
 


### PR DESCRIPTION
Large indentation change from switching to a gaurd clause. Requested by quantum to make reviewing https://github.com/PixelGuys/Cubyz/pull/2150 easier.
I don't know why the diff looks so weird (I hope I didn't do something wrong). Diffing with `--ignore-space-change` makes it look correct though.