### PR TITLE
Hide usernames when GUI is hidden

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -323,7 +323,7 @@ pub fn renderWorld(world: *World, ambientLight: Vec3f, skyColor: Vec3f, playerPo
 
 	c.glBindFramebuffer(c.GL_FRAMEBUFFER, 0);
 
-	entity.ClientEntityManager.renderNames(game.projectionMatrix, playerPos);
+	if(!main.gui.hideGui) entity.ClientEntityManager.renderNames(game.projectionMatrix, playerPos);
 	gpu_performance_measuring.stopQuery();
 }
 


### PR DESCRIPTION
I think this change is beneficial because GUI is most often hidden for screenshots/panoramas and usernames look bad in those

Before change:
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/f736c967-3544-4824-9474-680e28583f23" />

After change:
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/8b89ab83-10ad-4fd3-9d47-267c81d06849" />