### PR TITLE
Round up hp when displaying it

### DIFF
--- a/src/gui/windows/healthbar.zig
+++ b/src/gui/windows/healthbar.zig
@@ -52,8 +52,7 @@ pub fn render() void {
 
 	var x: f32 = 0;
 	var y: f32 = 0;
-	var i: usize = 0;
-	while(i < totalHearts) : (i += 1) {
+	for(0..totalHearts) |i| {
 		if(x >= window.contentSize[0]) {
 			x = 0;
 			y += 20;


### PR DESCRIPTION
Fixes #2308.
The healthbar now displays the health rounded up, which prevents it from displaying as 0 when the player's health is above 0.