### PR TITLE
Change the only instance of 3.14 to std.math.pi

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -932,7 +932,7 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 		const newPos = Vec2f{
 			@floatCast(main.KeyBoard.key("cameraRight").value - main.KeyBoard.key("cameraLeft").value),
 			@floatCast(main.KeyBoard.key("cameraDown").value - main.KeyBoard.key("cameraUp").value),
-		}*@as(Vec2f, @splat(3.14*settings.controllerSensitivity));
+		}*@as(Vec2f, @splat(std.math.pi*settings.controllerSensitivity));
 		main.game.camera.moveRotation(newPos[0]/64.0, newPos[1]/64.0);
 	}
 


### PR DESCRIPTION
It's overkill for the use-case but it bothers me that it's the only place 3.14 is used instead of std.math.pi. If there's a reason, let me know.