### PR TITLE
fix projection matrix not updating on window resize

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -132,12 +132,13 @@ var lastFov: f32 = 0;
 pub fn updateFov(fov: f32) void {
 	if(lastFov != fov) {
 		lastFov = fov;
+		game.projectionMatrix = Mat4f.perspective(std.math.degreesToRadians(fov), @as(f32, @floatFromInt(lastWidth))/@as(f32, @floatFromInt(lastHeight)), zNear, zFar);
 	}
-	game.projectionMatrix = Mat4f.perspective(std.math.degreesToRadians(fov), @as(f32, @floatFromInt(lastWidth))/@as(f32, @floatFromInt(lastHeight)), zNear, zFar);
 }
 pub fn updateViewport(width: u31, height: u31) void {
 	lastWidth = @intFromFloat(@as(f32, @floatFromInt(width))*main.settings.resolutionScale);
 	lastHeight = @intFromFloat(@as(f32, @floatFromInt(height))*main.settings.resolutionScale);
+	game.projectionMatrix = Mat4f.perspective(std.math.degreesToRadians(lastFov), @as(f32, @floatFromInt(lastWidth))/@as(f32, @floatFromInt(lastHeight)), zNear, zFar);
 	worldFrameBuffer.updateSize(lastWidth, lastHeight, c.GL_RGB16F);
 	worldFrameBuffer.unbind();
 }


### PR DESCRIPTION
projection matrix was not updated on window resize leading to stretched rendering in the main menu and the game world. example:

this: 

https://github.com/user-attachments/assets/2ded6189-da88-44d3-a616-e39b201168d3

is now fixed as:

https://github.com/user-attachments/assets/5e163657-4f47-4db6-8dae-62f9461b7bae

including the menu and all.
i checked logically and via debug prints that it only updates if the window resizes or user updates the fov in the graphic settings