### PR TITLE
fix: Item drop/throw physics

### DIFF
--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -1475,7 +1475,8 @@ pub const Command = struct { // MARK: Command
 				if(_items[0].item != null) {
 					if(side == .server) {
 						const direction = vec.rotateZ(vec.rotateX(Vec3f{0, 1, 0}, -user.?.player.rot[0]), -user.?.player.rot[2]);
-						main.server.world.?.dropWithCooldown(_items[0], user.?.player.pos, direction, 20, main.server.updatesPerSec*2);
+						const throwPos = user.?.player.pos + main.game.Player.eye.desiredPos;
+						main.server.world.?.dropWithCooldown(_items[0], throwPos, direction, 8, main.server.updatesPerSec*2);
 					}
 				}
 				return;
@@ -1487,7 +1488,8 @@ pub const Command = struct { // MARK: Command
 			const amount = @min(self.source.ref().amount, self.desiredAmount);
 			if(side == .server) {
 				const direction = vec.rotateZ(vec.rotateX(Vec3f{0, 1, 0}, -user.?.player.rot[0]), -user.?.player.rot[2]);
-				main.server.world.?.dropWithCooldown(.{.item = self.source.ref().item.?.clone(), .amount = amount}, user.?.player.pos, direction, 20, main.server.updatesPerSec*2);
+				const throwPos = user.?.player.pos + main.game.Player.eye.desiredPos;
+				main.server.world.?.dropWithCooldown(.{.item = self.source.ref().item.?.clone(), .amount = amount}, throwPos, direction, 8, main.server.updatesPerSec*2);
 			}
 			cmd.executeBaseOperation(allocator, .{.delete = .{
 				.source = self.source,
@@ -1602,7 +1604,7 @@ pub const Command = struct { // MARK: Command
 				}
 				if(side == .server) {
 					const direction = if(user) |_user| vec.rotateZ(vec.rotateX(Vec3f{0, 1, 0}, -_user.player.rot[0]), -_user.player.rot[2]) else Vec3f{0, 0, 0};
-					main.server.world.?.drop(sourceStack.clone(), self.dropLocation, direction, 20);
+					main.server.world.?.drop(sourceStack.clone(), self.dropLocation, direction, 8);
 				}
 				cmd.executeBaseOperation(allocator, .{.delete = .{
 					.source = .{.inv = self.source, .slot = @intCast(sourceSlot)},

--- a/src/vec.zig
+++ b/src/vec.zig
@@ -10,6 +10,10 @@ pub const Vec4i = @Vector(4, i32);
 pub const Vec4f = @Vector(4, f32);
 pub const Vec4d = @Vector(4, f64);
 
+pub const X: u8 = 0;
+pub const Y: u8 = 1;
+pub const Z: u8 = 2;
+
 pub inline fn combine(pos: Vec3f, w: f32) Vec4f {
 	return .{pos[0], pos[1], pos[2], w};
 }


### PR DESCRIPTION
Some small tweaks to fix the item drop/throw physics

- tweak: Changed throw vertical position to Player eye position
- tweak: Added const to represent X, Y and Z values when accessing vector positions.
- tweak: Item velocity
- fix: Ground detection for friction application
- fix: Item collision with blocks

Velocity was tuned down.
Attempted to apply same strategy to detect when item is onGround and apply proper friction.
src/itemdrop.zig:371 seemed to be improperly using max value of the bounding box which seems to be the cause of items clipping passing through blocks when dropped.

As as small suggestion, added 3 constants to represent X, Y, Z to vec.zig. The intention is to improve code redeability. This obviously is optional and i'll revert it if this is not something you with to pursue. The purpose is not to push toward an immediate change but to introduce the ideia in order to be adopted as the code changes.