### PR TITLE
Split Hotbar from Inventory

### DIFF
--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -130,8 +130,8 @@ pub const ServerSide = struct { // MARK: ServerSide
 				if(self.managed == .internallyManaged) {
 					if(self.inv.type.shouldDepositToUserOnClose()) {
 						const playerMainInventory = getInventoryFromSource(.{.playerMainInventory = user.id}) orelse @panic("Could not find player main inventory");
-						sync.ServerSide.executeCommand(.{.depositOrDrop = .{.dest = playerMainInventory, .source = self.inv, .dropLocation = user.player.pos}}, null);
-						// TODO: add Hotbar after depositOrDrop is updated to slice
+						const playerHotbar = getInventoryFromSource(.{.playerHotbar = user.id}) orelse @panic("Could not find player hotbar");
+						sync.ServerSide.executeCommand(.{.depositOrDrop = .init(&.{playerHotbar, playerMainInventory}, self.inv, user.player.pos)}, null);
 					}
 					inventoryCreationMutex.lock();
 					defer inventoryCreationMutex.unlock();
@@ -514,8 +514,8 @@ pub fn distribute(carried: Inventory, destinationInventories: []const Inventory,
 	}
 }
 
-pub fn depositOrDrop(dest: Inventory, source: Inventory) void {
-	main.sync.ClientSide.executeCommand(.{.depositOrDrop = .{.dest = dest, .source = source, .dropLocation = undefined}});
+pub fn depositOrDrop(source: Inventory, destinations: []const Inventory) void {
+	main.sync.ClientSide.executeCommand(.{.depositOrDrop = .init(destinations, source, undefined)});
 }
 
 pub fn depositToAny(source: Inventory, sourceSlot: u32, destinations: []const Inventory, amount: u16) void {

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -131,7 +131,7 @@ pub const ServerSide = struct { // MARK: ServerSide
 					if(self.inv.type.shouldDepositToUserOnClose()) {
 						const playerMainInventory = getInventoryFromSource(.{.playerMainInventory = user.id}) orelse @panic("Could not find player main inventory");
 						sync.ServerSide.executeCommand(.{.depositOrDrop = .{.dest = playerMainInventory, .source = self.inv, .dropLocation = user.player.pos}}, null);
-						//TODO add Hotbar after depositOrDrop is updated to slice
+						//TODO: add Hotbar after depositOrDrop is updated to slice
 					}
 					inventoryCreationMutex.lock();
 					defer inventoryCreationMutex.unlock();

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -129,8 +129,9 @@ pub const ServerSide = struct { // MARK: ServerSide
 				}
 				if(self.managed == .internallyManaged) {
 					if(self.inv.type.shouldDepositToUserOnClose()) {
-						const playerInventory = getInventoryFromSource(.{.playerInventory = user.id}) orelse @panic("Could not find player inventory");
-						sync.ServerSide.executeCommand(.{.depositOrDrop = .{.dest = playerInventory, .source = self.inv, .dropLocation = user.player.pos}}, null);
+						const playerMainInventory = getInventoryFromSource(.{.playerMainInventory = user.id}) orelse @panic("Could not find player main inventory");
+						sync.ServerSide.executeCommand(.{.depositOrDrop = .{.dest = playerMainInventory, .source = self.inv, .dropLocation = user.player.pos}}, null);
+						//TODO add Hotbar after depositOrDrop is updated to slice
 					}
 					inventoryCreationMutex.lock();
 					defer inventoryCreationMutex.unlock();
@@ -231,9 +232,9 @@ pub const ServerSide = struct { // MARK: ServerSide
 	pub fn createInventory(user: *main.server.User, clientId: InventoryId, len: usize, typ: Inventory.Type, source: Source) !void {
 		sync.threadContext.assertCorrectContext(.server);
 		switch(source) {
-			.recipe, .blockInventory, .playerInventory, .hand => {
+			.recipe, .blockInventory, .playerMainInventory, .playerHotbar, .hand => {
 				switch(source) {
-					.playerInventory, .hand => |id| {
+					.playerMainInventory, .playerHotbar, .hand => |id| {
 						if(id != user.id) {
 							std.log.err("Player {s} tried to access the inventory of another player.", .{user.name});
 							return error.Invalid;
@@ -264,7 +265,7 @@ pub const ServerSide = struct { // MARK: ServerSide
 
 		switch(source) {
 			.blockInventory => unreachable, // Should be loaded by the block entity
-			.playerInventory, .hand => unreachable, // Should be loaded on player creation
+			.playerMainInventory, .playerHotbar, .hand => unreachable, // Should be loaded on player creation
 			.recipe => |recipe| {
 				for(0..recipe.sourceAmounts.len) |i| {
 					inventory.inv._items[i].amount = recipe.sourceAmounts[i];
@@ -316,7 +317,7 @@ pub const ServerSide = struct { // MARK: ServerSide
 		sync.threadContext.assertCorrectContext(.server);
 		var inventoryIdIterator = user.inventoryClientToServerIdMap.valueIterator();
 		while(inventoryIdIterator.next()) |inventoryId| {
-			if(inventories.items()[@intFromEnum(inventoryId.*)].source == .playerInventory) {
+			if(inventories.items()[@intFromEnum(inventoryId.*)].source == .playerMainInventory or inventories.items()[@intFromEnum(inventoryId.*)].source == .playerHotbar) {
 				sync.ServerSide.executeCommand(.{.clear = .{.inv = inventories.items()[@intFromEnum(inventoryId.*)].inv}}, null);
 			}
 		}
@@ -326,23 +327,32 @@ pub const ServerSide = struct { // MARK: ServerSide
 		if(itemStack.item == .null) return;
 		sync.threadContext.assertCorrectContext(.server);
 		var inventoryIdIterator = user.inventoryClientToServerIdMap.valueIterator();
+		var mainInventory: ?Inventory = null;
+		var hotbar: ?Inventory = null;
 		outer: while(inventoryIdIterator.next()) |inventoryId| {
-			if(inventories.items()[@intFromEnum(inventoryId.*)].source == .playerInventory) {
-				const inv = inventories.items()[@intFromEnum(inventoryId.*)].inv;
-				for(inv._items, 0..) |invStack, slot| {
-					if(std.meta.eql(invStack.item, itemStack.item)) {
-						const amount = @min(itemStack.item.stackSize() - invStack.amount, itemStack.amount);
-						if(amount == 0) continue;
-						sync.ServerSide.executeCommand(.{.fillFromCreative = .{.dest = .{.inv = inv, .slot = @intCast(slot)}, .item = itemStack.item, .amount = invStack.amount + amount}}, null);
-						itemStack.amount -= amount;
-						if(itemStack.amount == 0) break :outer;
+			if(mainInventory == null and inventories.items()[@intFromEnum(inventoryId.*)].source == .playerMainInventory)
+				mainInventory = inventories.items()[@intFromEnum(inventoryId.*)].inv;
+			if(hotbar == null and inventories.items()[@intFromEnum(inventoryId.*)].source == .playerHotbar)
+				hotbar = inventories.items()[@intFromEnum(inventoryId.*)].inv;
+			if(hotbar != null and mainInventory != null) {
+				inline for(.{hotbar.?, mainInventory.?}) |inv| {
+					for(inv._items, 0..) |invStack, slot| {
+						if(std.meta.eql(invStack.item, itemStack.item)) {
+							const amount = @min(itemStack.item.stackSize() - invStack.amount, itemStack.amount);
+							if(amount == 0) continue;
+							sync.ServerSide.executeCommand(.{.fillFromCreative = .{.dest = .{.inv = inv, .slot = @intCast(slot)}, .item = itemStack.item, .amount = invStack.amount + amount}}, null);
+							itemStack.amount -= amount;
+							if(itemStack.amount == 0) break :outer;
+						}
 					}
 				}
-				for(inv._items, 0..) |invStack, slot| {
-					if(invStack.item == .null) {
-						sync.ServerSide.executeCommand(.{.fillFromCreative = .{.dest = .{.inv = inv, .slot = @intCast(slot)}, .item = itemStack.item, .amount = itemStack.amount}}, null);
-						itemStack.amount = 0;
-						break :outer;
+				inline for(.{hotbar.?, mainInventory.?}) |inv| {
+					for(inv._items, 0..) |invStack, slot| {
+						if(invStack.item == .null) {
+							sync.ServerSide.executeCommand(.{.fillFromCreative = .{.dest = .{.inv = inv, .slot = @intCast(slot)}, .item = itemStack.item, .amount = itemStack.amount}}, null);
+							itemStack.amount = 0;
+							break :outer;
+						}
 					}
 				}
 			}
@@ -367,7 +377,8 @@ pub const Callbacks = struct {
 
 pub const SourceType = enum(u8) {
 	alreadyFreed = 0,
-	playerInventory = 1,
+	playerMainInventory = 1,
+	playerHotbar = 2,
 	hand = 3,
 	recipe = 4,
 	blockInventory = 5,
@@ -375,7 +386,8 @@ pub const SourceType = enum(u8) {
 };
 pub const Source = union(SourceType) {
 	alreadyFreed: void,
-	playerInventory: u32,
+	playerMainInventory: u32,
+	playerHotbar: u32,
 	hand: u32,
 	recipe: *const main.items.Recipe,
 	blockInventory: Vec3i,

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -131,7 +131,7 @@ pub const ServerSide = struct { // MARK: ServerSide
 					if(self.inv.type.shouldDepositToUserOnClose()) {
 						const playerMainInventory = getInventoryFromSource(.{.playerMainInventory = user.id}) orelse @panic("Could not find player main inventory");
 						sync.ServerSide.executeCommand(.{.depositOrDrop = .{.dest = playerMainInventory, .source = self.inv, .dropLocation = user.player.pos}}, null);
-						//TODO: add Hotbar after depositOrDrop is updated to slice
+						// TODO: add Hotbar after depositOrDrop is updated to slice
 					}
 					inventoryCreationMutex.lock();
 					defer inventoryCreationMutex.unlock();

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -572,7 +572,7 @@ pub fn toggleGameMenu() void {
 	if(!main.Window.grabbed) {
 		hideGui = false;
 	} else { // Take of the currently held item stack and close some windows
-		main.game.Player.inventory.depositOrDrop(inventory.carried);
+		main.game.Player.hotbar.depositOrDrop(inventory.carried);
 		hoveredItemSlot = null;
 		var i: usize = 0;
 		while(i < openWindows.items.len) {
@@ -665,7 +665,7 @@ pub const inventory = struct { // MARK: inventory
 				nextCraftingAction = nextCraftingAction.addDuration(craftingCooldown);
 				craftingCooldown.nanoseconds -= @divTrunc((craftingCooldown.nanoseconds -% minCraftingCooldown.nanoseconds)*craftingCooldown.nanoseconds, std.time.ns_per_s);
 				if(mainGuiButton.modsOnPress.shift) {
-					itemSlot.inventory.depositToAny(itemSlot.itemSlot, &.{main.game.Player.inventory}, itemSlot.inventory.getAmount(itemSlot.itemSlot));
+					itemSlot.inventory.depositToAny(itemSlot.itemSlot, &.{main.game.Player.hotbar, main.game.Player.mainInventory}, itemSlot.inventory.getAmount(itemSlot.itemSlot));
 				} else {
 					itemSlot.inventory.depositOrSwap(itemSlot.itemSlot, carried);
 				}
@@ -679,7 +679,7 @@ pub const inventory = struct { // MARK: inventory
 		if(itemSlot.mode != .normal) return;
 
 		if(mainGuiButton.pressed and mainGuiButton.modsOnPress.shift) {
-			if(itemSlot.inventory.id == main.game.Player.inventory.id) {
+			if(itemSlot.inventory.id == main.game.Player.mainInventory.id or itemSlot.inventory.id == main.game.Player.hotbar.id) {
 				var iterator = std.mem.reverseIterator(openWindows.items);
 				while(iterator.next()) |window| {
 					if(window.shiftClickableInventory) |inv| {
@@ -688,7 +688,7 @@ pub const inventory = struct { // MARK: inventory
 					}
 				}
 			} else {
-				itemSlot.inventory.depositToAny(itemSlot.itemSlot, &.{main.game.Player.inventory}, itemSlot.inventory.getAmount(itemSlot.itemSlot));
+				itemSlot.inventory.depositToAny(itemSlot.itemSlot, &.{main.game.Player.hotbar, main.game.Player.mainInventory}, itemSlot.inventory.getAmount(itemSlot.itemSlot));
 			}
 			return;
 		}

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -572,7 +572,7 @@ pub fn toggleGameMenu() void {
 	if(!main.Window.grabbed) {
 		hideGui = false;
 	} else { // Take of the currently held item stack and close some windows
-		main.game.Player.hotbar.depositOrDrop(inventory.carried);
+		inventory.carried.depositOrDrop(&.{main.game.Player.hotbar, main.game.Player.mainInventory});
 		hoveredItemSlot = null;
 		var i: usize = 0;
 		while(i < openWindows.items.len) {

--- a/src/gui/windows/hotbar.zig
+++ b/src/gui/windows/hotbar.zig
@@ -42,7 +42,7 @@ var itemSlots: [12]*ItemSlot = undefined;
 pub fn onOpen() void {
 	const list = HorizontalList.init();
 	for(0..12) |i| {
-		itemSlots[i] = ItemSlot.init(.{0, 0}, Player.inventory, @intCast(i), .{.custom = hotbarSlotTexture}, .normal);
+		itemSlots[i] = ItemSlot.init(.{0, 0}, Player.hotbar, @intCast(i), .{.custom = hotbarSlotTexture}, .normal);
 		list.add(itemSlots[i]);
 	}
 	list.finish(.{0, 0}, .center);

--- a/src/gui/windows/inventory.zig
+++ b/src/gui/windows/inventory.zig
@@ -53,9 +53,9 @@ pub fn onOpen() void {
 	for(0..2) |y| {
 		const row = HorizontalList.init();
 		for(0..10) |x| {
-			const index: usize = 12 + y*10 + x;
-			const slot = ItemSlot.init(.{0, 0}, Player.inventory, @intCast(index), .default, .normal);
-			itemSlots[index - 12] = slot;
+			const index: usize = y*10 + x;
+			const slot = ItemSlot.init(.{0, 0}, Player.mainInventory, @intCast(index), .default, .normal);
+			itemSlots[index] = slot;
 			row.add(slot);
 		}
 		list.add(row);

--- a/src/gui/windows/inventory_crafting.zig
+++ b/src/gui/windows/inventory_crafting.zig
@@ -67,8 +67,10 @@ fn findAvailableRecipes(list: *VerticalList) bool {
 		amount.* = 0;
 	}
 	// Figure out what items are available in the inventory:
-	for(0..main.game.Player.inventory.size()) |i| {
-		addItemStackToAvailable(main.game.Player.inventory.getStack(i));
+	inline for(.{main.game.Player.hotbar, main.game.Player.mainInventory}) |inv| {
+		for(0..inv.size()) |i| {
+			addItemStackToAvailable(inv.getStack(i));
+		}
 	}
 	if(std.mem.eql(u32, oldAmounts, itemAmount.items)) return false;
 	// Remove no longer present items:

--- a/src/itemdrop.zig
+++ b/src/itemdrop.zig
@@ -795,7 +795,7 @@ pub const ItemDropRenderer = struct { // MARK: ItemDropRenderer
 		const viewMatrix = Mat4f.identity();
 		bindCommonUniforms(projMatrix, viewMatrix, ambientLight);
 
-		const item = game.Player.inventory.getItem(game.Player.selectedSlot);
+		const item = game.Player.hotbar.getItem(game.Player.selectedSlot);
 		if(item != .null) {
 			var pos: Vec3d = Vec3d{0, 0, 0};
 			const rot: Vec3f = ItemDisplayManager.cameraFollow;

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -220,7 +220,7 @@ pub fn renderWorld(world: *World, ambientLight: Vec3f, skyColor: Vec3f, playerPo
 
 	gpu_performance_measuring.startQuery(.chunk_rendering_preparation);
 	const direction = crosshairDirection(game.camera.viewMatrix, lastFov, lastWidth, lastHeight);
-	MeshSelection.select(playerPos, direction, game.Player.inventory.getItem(game.Player.selectedSlot));
+	MeshSelection.select(playerPos, direction, game.Player.hotbar.getItem(game.Player.selectedSlot));
 
 	chunk_meshing.beginRender();
 

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -118,7 +118,8 @@ pub const User = struct { // MARK: User
 	lastSentBiomeId: u32 = 0xffffffff,
 
 	inventoryClientToServerIdMap: std.AutoHashMap(InventoryId, InventoryId) = undefined,
-	inventory: ?InventoryId = null,
+	mainInventory: ?InventoryId = null,
+	hotbar: ?InventoryId = null,
 	handInventory: ?InventoryId = null,
 
 	connected: Atomic(bool) = .init(true),
@@ -148,13 +149,14 @@ pub const User = struct { // MARK: User
 		std.debug.assert(self.inventoryClientToServerIdMap.count() == 0); // leak
 		self.inventoryClientToServerIdMap.deinit();
 
-		if(self.inventory != null) {
+		if(self.mainInventory != null) {
 			world.?.savePlayer(self) catch |err| {
 				std.log.err("Failed to save player: {s}", .{@errorName(err)});
 				return;
 			};
 
-			main.items.Inventory.ServerSide.destroyExternallyManagedInventory(self.inventory.?);
+			main.items.Inventory.ServerSide.destroyExternallyManagedInventory(self.mainInventory.?);
+			main.items.Inventory.ServerSide.destroyExternallyManagedInventory(self.hotbar.?);
 			main.items.Inventory.ServerSide.destroyExternallyManagedInventory(self.handInventory.?);
 		}
 

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -860,7 +860,8 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 
 			main.sync.setGamemode(user, std.meta.stringToEnum(main.game.Gamemode, playerData.get([]const u8, "gamemode", @tagName(self.defaultGamemode))) orelse self.defaultGamemode);
 		}
-		user.inventory = loadPlayerInventory(main.game.Player.inventorySize, playerData.get([]const u8, "playerInventory", ""), .{.playerInventory = user.id}, path);
+		user.mainInventory = loadPlayerInventory(main.game.Player.mainInventorySize, playerData.get([]const u8, "playerMainInventory", ""), .{.playerMainInventory = user.id}, path);
+		user.hotbar = loadPlayerInventory(main.game.Player.hotbarSize, playerData.get([]const u8, "playerHotbar", ""), .{.playerHotbar = user.id}, path);
 		user.handInventory = loadPlayerInventory(1, playerData.get([]const u8, "hand", ""), .{.hand = user.id}, path);
 
 		user.spawnPos = playerData.get(Vec3d, "playerSpawnPos", @as(Vec3d, @floatFromInt(self.spawn)));
@@ -918,8 +919,12 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 
 		{
 			main.sync.threadContext.assertCorrectContext(.server);
-			if(main.items.Inventory.ServerSide.getInventoryFromSource(.{.playerInventory = user.id})) |inv| {
-				playerZon.put("playerInventory", ZonElement{.stringOwned = savePlayerInventory(main.stackAllocator, inv)});
+			if(main.items.Inventory.ServerSide.getInventoryFromSource(.{.playerMainInventory = user.id})) |inv| {
+				playerZon.put("playerMainInventory", ZonElement{.stringOwned = savePlayerInventory(main.stackAllocator, inv)});
+			} else @panic("The player inventory wasn't found. Cannot save player data.");
+
+			if(main.items.Inventory.ServerSide.getInventoryFromSource(.{.playerHotbar = user.id})) |inv| {
+				playerZon.put("playerHotbar", ZonElement{.stringOwned = savePlayerInventory(main.stackAllocator, inv)});
 			} else @panic("The player inventory wasn't found. Cannot save player data.");
 
 			if(main.items.Inventory.ServerSide.getInventoryFromSource(.{.hand = user.id})) |inv| {

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1332,39 +1332,71 @@ pub const Command = struct { // MARK: Command
 	};
 
 	const DepositOrDrop = struct { // MARK: DepositOrDrop
-		dest: Inventory,
+		destinations: []const Inventory,
 		source: Inventory,
 		dropLocation: Vec3d,
 
+		pub fn init(destinations: []const Inventory, source: Inventory, dropLocation: Vec3d) DepositOrDrop {
+			return .{
+				.destinations = main.globalAllocator.dupe(Inventory, destinations),
+				.source = source,
+				.dropLocation = dropLocation,
+			};
+		}
+
+		fn finalize(self: DepositOrDrop, _: Side, _: *BinaryReader) !void {
+			main.globalAllocator.free(self.destinations);
+		}
+
 		pub fn run(self: DepositOrDrop, ctx: Context) error{serverFailure}!void {
-			std.debug.assert(self.dest.type == .normal);
+			for(self.destinations) |dest| {
+				std.debug.assert(dest.type == .normal);
+			}
 			if(self.source.type == .creative) return;
 			if(self.source.type == .crafting) return;
 			var sourceItems = self.source._items;
 			if(self.source.type == .workbench) sourceItems = self.source._items[0..25];
 			outer: for(sourceItems, 0..) |*sourceStack, sourceSlot| {
 				if(sourceStack.item == .null) continue;
-				for(self.dest._items, 0..) |*destStack, destSlot| {
-					if(std.meta.eql(destStack.item, sourceStack.item)) {
-						const amount = @min(destStack.item.stackSize() - destStack.amount, sourceStack.amount);
-						ctx.execute(.{.move = .{
-							.dest = .{.inv = self.dest, .slot = @intCast(destSlot)},
-							.source = .{.inv = self.source, .slot = @intCast(sourceSlot)},
-							.amount = amount,
-						}});
-						if(sourceStack.amount == 0) {
-							continue :outer;
+				var selectedEmptySlot: ?u32 = null;
+				var selectedEmptyInv: ?Inventory = null;
+				for(self.destinations) |dest| {
+					var emptySlot: ?u32 = null;
+					var hasItem = false;
+					for(dest._items, 0..) |*destStack, destSlot| {
+						if(destStack.item == .null and emptySlot == null) {
+							emptySlot = @intCast(destSlot);
+							if(selectedEmptySlot == null) {
+								selectedEmptySlot = emptySlot;
+								selectedEmptyInv = dest;
+							}
+						}
+						if(std.meta.eql(destStack.item, sourceStack.item)) {
+							hasItem = true;
+							const amount = @min(sourceStack.item.stackSize() - destStack.amount, sourceStack.amount);
+							if(amount == 0) continue;
+							ctx.execute(.{.move = .{
+								.dest = .{.inv = dest, .slot = @intCast(destSlot)},
+								.source = .{.inv = self.source, .slot = @intCast(sourceSlot)},
+								.amount = amount,
+							}});
+							if(sourceStack.amount == 0) continue :outer;
 						}
 					}
-				}
-				for(self.dest._items, 0..) |*destStack, destSlot| {
-					if(destStack.item == .null) {
+					if(emptySlot != null and hasItem) {
 						ctx.execute(.{.swap = .{
-							.dest = .{.inv = self.dest, .slot = @intCast(destSlot)},
+							.dest = .{.inv = dest, .slot = emptySlot.?},
 							.source = .{.inv = self.source, .slot = @intCast(sourceSlot)},
 						}});
 						continue :outer;
 					}
+				}
+				if(selectedEmptySlot != null) {
+					ctx.execute(.{.swap = .{
+						.dest = .{.inv = selectedEmptyInv.?, .slot = selectedEmptySlot.?},
+						.source = .{.inv = self.source, .slot = @intCast(sourceSlot)},
+					}});
+					continue :outer;
 				}
 				if(ctx.side == .server) {
 					const direction = if(ctx.user) |_user| vec.rotateZ(vec.rotateX(Vec3f{0, 1, 0}, -_user.player.rot[0]), -_user.player.rot[2]) else Vec3f{0, 0, 0};
@@ -1378,15 +1410,28 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn serialize(self: DepositOrDrop, writer: *BinaryWriter) void {
-			writer.writeEnum(InventoryId, self.dest.id);
+			writer.writeVarInt(usize, self.destinations.len);
+			for(self.destinations) |dest| {
+				writer.writeEnum(InventoryId, dest.id);
+			}
 			writer.writeEnum(InventoryId, self.source.id);
 		}
 
 		fn deserialize(reader: *BinaryReader, side: Side, user: ?*main.server.User) !DepositOrDrop {
-			const destId = try reader.readEnum(InventoryId);
+			const destinationsSize = try reader.readVarInt(usize);
+			if(destinationsSize == 0) return error.Invalid;
+			if(destinationsSize*@sizeOf(InventoryId) >= reader.remaining.len) return error.Invalid;
+
+			const destinations = main.globalAllocator.alloc(Inventory, destinationsSize);
+			errdefer main.globalAllocator.free(destinations);
+
+			for(destinations) |*dest| {
+				const invId = try reader.readEnum(InventoryId);
+				dest.* = Inventory.getInventory(invId, side, user) orelse return error.InventoryNotFound;
+			}
 			const sourceId = try reader.readEnum(InventoryId);
 			return .{
-				.dest = Inventory.getInventory(destId, side, user) orelse return error.InventoryNotFound,
+				.destinations = destinations[0..],
 				.source = Inventory.getInventory(sourceId, side, user) orelse return error.InventoryNotFound,
 				.dropLocation = (user orelse return error.Invalid).player.pos,
 			};

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -781,15 +781,15 @@ pub const Command = struct { // MARK: Command
 
 	fn tryCraftingTo(self: *Command, allocator: NeverFailingAllocator, destinations: []const Inventory, source: InventoryAndSlot, side: Side, user: ?*main.server.User) void { // MARK: tryCraftingTo()
 		std.debug.assert(source.inv.type == .crafting);
-                for(destinations) |dest| std.debug.assert(dest.type == .normal);
+		for(destinations) |dest| std.debug.assert(dest.type == .normal);
 		if(source.slot != source.inv._items.len - 1) return;
 		const destinationsCanHold = blk: {
-                    for(destinations) |dest| {
-                        if(dest.canHold(source.ref().*)) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if(!destinationsCanHold) return;
+			for(destinations) |dest| {
+				if(dest.canHold(source.ref().*)) break :blk true;
+			}
+			break :blk false;
+		};
+		if(!destinationsCanHold) return;
 		if(source.ref().item == .null) return; // Can happen if the we didn't receive the inventory information from the server yet.
 
 		const playerInventory: Inventory = switch(side) {


### PR DESCRIPTION
Closes: #2311 

I have renamed the inventory to mainInventory and added hotbar and am now just going error by error to get this to work.
I started this in a draft to get a little bit of input how this can be done good.

While we can make somethings work with just getting the mainInventory and hotbar, the Inventory based instructions like depositToAny or depositOrDrop are things were I would like some input. Currently I have done an optional fallback parameter but maybe there are better ways?
Maybe this system should be first done good in a different PR
(I have not yet implemented the fallback only added the parameter)

If we do the parameter there is the question of how should we best serialize this?
I am currently just exploiting that the fallback should not be the same as the dest Inventory.

There is also the Question of how the priority system should work. 
Example if I shift click item A into my inventory from a chest:
We now search the hotbar. If we find A the item from the chest goes also there.
But what if we don't find A or there is not enough space for the items from the chest. 
Should the mainInventory be searched first for A or should we fill empty spaces inside the hotbar first?
So either:
search(hotbar), search(mainInv), emptySpaces(hotbar), emptySpaces(mainInv)
or
search(hotbar), emptySpaces(hotbar), search(mainInv), emptySpaces(mainInv)

In my opinion the first option is better but maybe others have different opinions.