### PR TITLE
Fix server thread sleeping for too long

### DIFF
--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -457,7 +457,7 @@ pub fn startFromExistingThread(name: []const u8, port: ?u16) void {
 		main.heap.GarbageCollection.syncPoint();
 		const newTime = main.timestamp();
 		if(lastTime.durationTo(newTime).nanoseconds < updateTime.nanoseconds) {
-			main.io.sleep(lastTime.durationTo(newTime.addDuration(updateTime)), .awake) catch {};
+			main.io.sleep(newTime.durationTo(lastTime.addDuration(updateTime)), .awake) catch {};
 			lastTime = lastTime.addDuration(updateTime);
 		} else {
 			std.log.warn("The server is lagging behind by {d:.1} ms", .{@as(f32, @floatFromInt(newTime.nanoseconds -% lastTime.nanoseconds -% updateTime.nanoseconds))/1000000.0});


### PR DESCRIPTION
The calculation for how long the server thread should sleep was broken by #2009. This fixes it.