### PR TITLE
Consistent rare biome chance

### DIFF
--- a/assets/cubyz/biomes/rare/knitted/forest.zig.zon
+++ b/assets/cubyz/biomes/rare/knitted/forest.zig.zon
@@ -9,7 +9,7 @@
 	.maxRadius = 320,
 	.roughness = 1,
 	.hills = 8,
-	.chance = 0.02,
+	.chance = 0.01,
 	.validPlayerSpawn = false,
 	.stoneBlock = "cubyz:cloth/block/grey",
 	.ground_structure = .{

--- a/assets/cubyz/biomes/rare/tuften/fields.zig.zon
+++ b/assets/cubyz/biomes/rare/tuften/fields.zig.zon
@@ -9,7 +9,7 @@
 	.maxRadius = 320,
 	.roughness = 1,
 	.hills = 15,
-	.chance = 0.02,
+	.chance = 0.01,
 	.music = "cubyz:sunrise",
 	.validPlayerSpawn = true,
 	.ground_structure = .{


### PR DESCRIPTION
Gives tuften fields and knitted forest a `chance` of 0.01 (same as all other rare biomes)