### PR TITLE
Significantly slow down the fog and sky color transition effect

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -987,7 +987,7 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 
 	const biome = world.?.playerBiome.load(.monotonic);
 
-	const t = 1 - @as(f32, @floatCast(@exp(-2*deltaTime)));
+	const t = 1 - @as(f32, @floatCast(@exp(-0.1*deltaTime)));
 
 	biomeFog.fogColor = (biome.fogColor - biomeFog.fogColor)*@as(Vec3f, @splat(t)) + biomeFog.fogColor;
 	biomeFog.skyColor = (biome.skyColor - biomeFog.skyColor)*@as(Vec3f, @splat(t)) + biomeFog.skyColor;


### PR DESCRIPTION
I slowed it down by 20× which makes it really hard to notice the transition (if it weren't for the color banding, but that's a different issue).
I looked around a bit, and I can only find one problem: if you move out of a cave too fast the sky is grey (depending on what cave you come from), but I think that shouldn't be too noticable in survival.

fixes #2096

@ikabod-kee please check if this is good.