### PR TITLE
Hide Energy- and Healthbar in Creative

### DIFF
--- a/src/gui/windows/energybar.zig
+++ b/src/gui/windows/energybar.zig
@@ -43,6 +43,9 @@ pub fn deinit() void {
 }
 
 pub fn render() void {
+	if(main.game.Player.isCreative())
+		return;
+
 	draw.setColor(0xffffffff);
 	var y: f32 = 0;
 	var x: f32 = 0;

--- a/src/gui/windows/healthbar.zig
+++ b/src/gui/windows/healthbar.zig
@@ -43,6 +43,9 @@ pub fn deinit() void {
 }
 
 pub fn render() void {
+	if(main.game.Player.isCreative())
+		return;
+
 	draw.setColor(0xffffffff);
 	const displayHealth = @max(0, main.game.Player.super.health);
 	const halfHeartUnits: usize = @intFromFloat(@ceil(displayHealth*2));


### PR DESCRIPTION
Not only do you see instantly which gamemode you are in right now, but it also feels more responsive when you type the command, and see survival HUD change. 
<img width="1280" height="752" alt="grafik" src="https://github.com/user-attachments/assets/42b37774-d7b0-4e8d-9b88-520d1cd5f1c9" />
