### PR TITLE
Introduce a per-tick arena for the server side

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -65,6 +65,7 @@ Cubyz has four main allocators, choose them based on lifetime:
 - global lifetime, things that are used until the end of the game (e.g. mod registry data) → `main.globalArena`
 - world lifetime, things that are used until the player exits the world (e.g. assets/addons) → `main.worldArena`
 - local lifetime, things that are freed at the end of the scope (including local data structures such as lists) → `main.stackAllocator`
+- server tick lifetime, things that are used until the end of the next tick (e.g. block updates and similar short-lived events) → `main.server.tickArena`
 - other lifetime → `main.globalAllocator`
 
 Sometimes it might also make sense to use another arena allocator `allocator.create-/destroyArena()` (when you have many small allocations that share the same lifetime, e.g. dynamic structure data in the structure map), or a `MemoryPool` (if you have many items of the same type that get freed and allocated many times throughout the game).

--- a/src/server/BlockUpdateSystem.zig
+++ b/src/server/BlockUpdateSystem.zig
@@ -15,18 +15,16 @@ pub fn init() @This() {
 }
 pub fn deinit(self: *@This()) void {
 	self.mutex = undefined;
-	self.list.deinit(main.globalAllocator);
 }
 pub fn add(self: *@This(), position: BlockPos) void {
 	self.mutex.lock();
 	defer self.mutex.unlock();
-	self.list.append(main.globalAllocator, position);
+	self.list.append(main.server.tickArena, position);
 }
 pub fn update(self: *@This(), ch: *main.chunk.ServerChunk) void {
 	// swap
 	self.mutex.lock();
 	const list = self.list;
-	defer list.deinit(main.globalAllocator);
 	self.list = .{};
 	self.mutex.unlock();
 

--- a/src/utils/heap.zig
+++ b/src/utils/heap.zig
@@ -15,6 +15,8 @@ pub const allocators = struct { // MARK: allocators
 	pub var worldArenaAllocator: ThreadSafeAllocator(NeverFailingArenaAllocator) = undefined;
 	var worldArenaOpenCount: usize = 0;
 	var worldArenaMutex: std.Thread.Mutex = .{};
+	var serverTickArenas: [2]ThreadSafeAllocator(NeverFailingArenaAllocator) = undefined;
+	var activeTickArena: usize = 0;
 
 	pub fn deinit() void {
 		std.log.info("Clearing global arena with {} MiB", .{globalArenaAllocator.child.arena.queryCapacity() >> 20});
@@ -44,6 +46,28 @@ pub const allocators = struct { // MARK: allocators
 			worldArenaAllocator.deinit();
 			worldArenaAllocator = undefined;
 		}
+	}
+
+	pub fn createServerTickArenas() void {
+		for(0..serverTickArenas.len) |i| {
+			serverTickArenas[i] = .init(.init(handledGpa.allocator()));
+		}
+	}
+
+	pub fn destroyServerTickArenas() void {
+		for(0..serverTickArenas.len) |i| {
+			serverTickArenas[i].deinit();
+			serverTickArenas[i] = undefined;
+		}
+	}
+
+	pub fn swapServerTickArenas() NeverFailingAllocator {
+		activeTickArena += 1;
+		if(activeTickArena >= serverTickArenas.len) {
+			activeTickArena = 0;
+		}
+		_ = serverTickArenas[activeTickArena].child.reset(.free_all);
+		return serverTickArenas[activeTickArena].allocator();
 	}
 };
 


### PR DESCRIPTION
It feels weird to introduce yet another allocator, but I think this is the right choice for events which are only persistent for a single frame. Everything would require more bookkeeping. For now I only implemented this for the block update list, but in the future we will need to run more complex events with manual allocations.

- [ ] The allocator swapping is not thread safe
- [ ] Use the garbage collector to free the arenas to make sure it is safe to use when another thread gets suspended for a long time
- [ ] What happens to the list when the chunk hasn't been loaded yet and doesn't do events?