### PR TITLE
Have Better FPS Presets

### DIFF
--- a/src/gui/windows/graphics.zig
+++ b/src/gui/windows/graphics.zig
@@ -39,7 +39,7 @@ const fpsPresetsText = blk: {
 };
 
 fn fpsCapGetIndex(fpsOptional: ?u32) u16 {
-	const fps:u16 = @truncate(fpsOptional orelse return fpsPresetsValue.len);
+	const fps: u16 = @truncate(fpsOptional orelse return fpsPresetsValue.len);
 	return @intCast(std.sort.lowerBound(u16, &fpsPresetsValue, fps, struct {
 		fn order(a: u16, b: u16) std.math.Order {
 			return std.math.order(a, b);
@@ -136,7 +136,7 @@ fn vulkanTestingWindowCallback(newValue: bool) void {
 
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
-	list.add(DiscreteSlider.init(.{0, 0}, 128, "#ffffffFPS Limit:\n", "{s}", &fpsPresetsText,  fpsCapGetIndex(settings.fpsCap), &fpsCapCallback));
+	list.add(DiscreteSlider.init(.{0, 0}, 128, "#ffffffFPS Limit:\n", "{s}", &fpsPresetsText, fpsCapGetIndex(settings.fpsCap), &fpsCapCallback));
 	list.add(DiscreteSlider.init(.{0, 0}, 128, "#ffffffLOD1 Distance: ", "{} chunks", &renderDistances, @min(@max(settings.renderDistance, renderDistances[0]) - renderDistances[0], renderDistances.len - 1), &renderDistanceCallback));
 	if (main.game.world == null) {
 		list.add(DiscreteSlider.init(.{0, 0}, 128, "#ffffffHighest LOD: ", "{s}", &lodValues, @min(settings.highestLod, settings.highestSupportedLod), &highestLodCallback));


### PR DESCRIPTION
Most Monitors can display more FPS then 144Hz.
This make the FPS Slider pick one of the values from this Preset instead:

5, 10, 15, 30, 50, 60, 75, 90, 100, 120, 144, 165, 170, 180, 200, 240, 260, 280, 300, 360, 480, unlimited


Credit: Mischol (@thcae) idea and request