### PR TITLE
Add vine decay

### DIFF
--- a/assets/cubyz/blocks/vine/_defaults.zig.zon
+++ b/assets/cubyz/blocks/vine/_defaults.zig.zon
@@ -1,6 +1,10 @@
 .{
 	.tags = .{.cuttable},
 	.blockHealth = 0.3,
+	.onUpdate = .{
+		.type = .decay,
+		.prevention = .{.leaf, .log, .branch},
+	},
 	.drops = .{
 		.{.items = .{.auto}},
 	},

--- a/src/callbacks/block/server/decay.zig
+++ b/src/callbacks/block/server/decay.zig
@@ -121,7 +121,7 @@ pub fn run(self: *@This(), params: main.callbacks.ServerBlockCallback.Params) ma
 		const bd = Branch.BranchData.init(params.block.data);
 		if(bd.placedByHuman)
 			return .ignored;
-	} else {
+	} else if(params.block.mode() == main.rotation.getByID("cubyz:hanging")) {} else {
 		std.log.err("Expected {s} to have cubyz:decayable or cubyz:branch as rotation", .{params.block.id()});
 	}
 


### PR DESCRIPTION
Adds makeshift vine decay to avoid having flying vines after #1930 pull request is merged.

Related-to: #1930 