### PR TITLE
Fixed flying break Animation

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -785,6 +785,7 @@ pub fn pressBreak(_: main.Window.Key.Modifiers) void {
 }
 
 pub fn releaseBreak(_: main.Window.Key.Modifiers) void {
+	main.renderer.MeshSelection.stopBreakBlock(main.renderer.MeshSelection.lastSelectedBlockPos);
 	nextBlockBreakTime = null;
 }
 

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -891,7 +891,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 	var posBeforeBlock: Vec3i = undefined;
 	var neighborOfSelection: chunk.Neighbor = undefined;
 	pub var selectedBlockPos: ?Vec3i = null;
-	var lastSelectedBlockPos: Vec3i = undefined;
+	pub var lastSelectedBlockPos: Vec3i = undefined;
 	var currentBlockProgress: f32 = 0;
 	var currentSwingProgress: f32 = 0;
 	var currentSwingTime: f32 = 0;
@@ -1036,7 +1036,12 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 			}
 		}
 	}
-
+	pub fn stopBreakBlock(pos: Vec3i) void {
+		if(@reduce(.And, lastSelectedBlockPos == pos)) {
+			mesh_storage.removeBreakingAnimation(lastSelectedBlockPos);
+			currentBlockProgress = 0;
+		}
+	}
 	pub fn breakBlock(inventory: main.items.Inventory, slot: u32, deltaTime: f64) void {
 		if(selectedBlockPos) |selectedPos| {
 			const stack = inventory.getStack(slot);

--- a/src/renderer/mesh_storage.zig
+++ b/src/renderer/mesh_storage.zig
@@ -903,6 +903,7 @@ pub const MeshGenerationTask = struct { // MARK: MeshGenerationTask
 // MARK: updaters
 
 pub fn updateBlock(update: BlockUpdate) void {
+	main.renderer.MeshSelection.stopBreakBlock(.{update.x, update.y, update.z});
 	blockUpdateList.pushBack(BlockUpdate.initManaged(main.globalAllocator, update));
 }
 


### PR DESCRIPTION
If someone else breaks the block you already broke, the animations just stays there in there in the Air.
(Like in this picture)

<img width="1282" height="752" alt="grafik" src="https://github.com/user-attachments/assets/6fc6251e-a4d0-45c2-9b3a-33fe7744afaa" />


This PR does only partly solves: https://github.com/PixelGuys/Cubyz/issues/1048
There is still the problem that if you chisel and someone else breaks the block, you still see your animation in the air.

Thanks for Mischol (@thcae) for Play testing.