### PR TITLE
Add an action for closing stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,6 @@
 name: "Close stale issues and PRs"
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *" # Runs daily at 00:00
 


### PR DESCRIPTION
This pull request adds a github action configuration which utilized [existing implementation of stale bot](https://github.com/marketplace/actions/close-stale-issues).

Bot will check all exsiting PRs and will leave a comment and a `stale` label (please add) with warning on those with no action for at least 28 days. After another 7 days, pull request will be closed and branch will be removed (hopefully latter applies only to branches in this repo).
Issues has been explicitly excluded from that system.
Bot has been configured to run daily at 00:00

For now, submitted configuration has a `debug-only: true` entry for safety.