### PR TITLE
Add a night brightness slider and make night light slightly blue

### DIFF
--- a/src/gui/windows/graphics.zig
+++ b/src/gui/windows/graphics.zig
@@ -92,6 +92,14 @@ fn contrastCallback(newValue: f32) void {
 	settings.save();
 }
 
+fn nightBrightnessCallback(newValue: f32) void {
+	settings.nightBrightness = newValue;
+	settings.save();
+}
+fn nightBrightnessFormatter(allocator: main.heap.NeverFailingAllocator, _: f32) []const u8 {
+	return std.fmt.allocPrint(allocator.allocator, "Night Brightness", .{}) catch unreachable;
+}
+
 fn bloomCallback(newValue: bool) void {
 	settings.bloom = newValue;
 	settings.save();
@@ -133,6 +141,7 @@ pub fn onOpen() void {
 	list.add(DiscreteSlider.init(.{0, 0}, 128, "#ffffffLeaves Quality (TODO: requires reload): ", "{}", &leavesQualities, settings.leavesQuality - leavesQualities[0], &leavesQualityCallback));
 	list.add(ContinuousSlider.init(.{0, 0}, 128, 50.0, 400.0, settings.@"lod0.5Distance", &lodDistanceCallback, &lodDistanceFormatter));
 	list.add(ContinuousSlider.init(.{0, 0}, 128, 0.0, 0.5, settings.blockContrast, &contrastCallback, &contrastFormatter));
+	list.add(ContinuousSlider.init(.{0, 0}, 128, 0.0, 1.0, settings.nightBrightness, &nightBrightnessCallback, &nightBrightnessFormatter));
 	list.add(ContinuousSlider.init(.{0, 0}, 128, 40.0, 120.0, settings.fov, &fovCallback, &fovFormatter));
 	list.add(CheckBox.init(.{0, 0}, 128, "Bloom", settings.bloom, &bloomCallback));
 	list.add(CheckBox.init(.{0, 0}, 128, "Vertical Synchronization", settings.vsync, &vsyncCallback));

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -147,10 +147,9 @@ pub fn render(playerPosition: Vec3d, deltaTime: f64) void {
 	// TODO: player bobbing
 	// TODO: Handle colors and sun position in the world.
 	std.debug.assert(game.world != null);
-	var ambient: Vec3f = undefined;
-	ambient[0] = @max(0.1, game.world.?.ambientLight);
-	ambient[1] = @max(0.1, game.world.?.ambientLight);
-	ambient[2] = @max(0.1, game.world.?.ambientLight);
+
+	const nightColor: Vec3f = .{0.3, 0.4, 0.5};
+	const ambient = @max(nightColor*@as(Vec3f, @splat(settings.nightBrightness)), @as(Vec3f, @splat(game.world.?.ambientLight)));
 
 	itemdrop.ItemDisplayManager.update(deltaTime);
 	renderWorld(game.world.?, ambient, game.fog.skyColor, playerPosition);

--- a/src/settings.zig
+++ b/src/settings.zig
@@ -59,6 +59,8 @@ pub var @"lod0.5Distance": f32 = 200;
 
 pub var blockContrast: f32 = 0;
 
+pub var nightBrightness: f32 = 0.5;
+
 pub var storageTime: std.Io.Duration = .fromSeconds(5);
 
 pub var updateRepeatSpeed: std.Io.Duration = .fromMilliseconds(200);


### PR DESCRIPTION
Another solution to the night darkness problem #2363 using a simple brightness slider.

As you can see it does still desaturate dim light sources, but at the default brightness it is not overpowering it.

New default:
<img width="2560" height="1413" alt="Screenshot at 2025-12-30 13-18-15" src="https://github.com/user-attachments/assets/55fff85b-a421-4a7d-924d-bcca60120af5" />
brightest:
<img width="2560" height="1413" alt="Screenshot at 2025-12-30 13-18-24" src="https://github.com/user-attachments/assets/2bec9d6f-41c8-4cda-85f7-11e219ae4847" />
darkest:
<img width="2560" height="1413" alt="Screenshot at 2025-12-30 13-18-32" src="https://github.com/user-attachments/assets/bafbff89-be87-4999-9095-47021016675c" />