### PR TITLE
Ruby rebalance

### DIFF
--- a/assets/cubyz/blocks/ruby_ore.zig.zon
+++ b/assets/cubyz/blocks/ruby_ore.zig.zon
@@ -24,7 +24,7 @@
 					.restriction = .{
 						.id = .encased,
 						.tag = .precious,
-						.amount = 3,
+						.amount = 2,
 					},
 				},
 			},


### PR DESCRIPTION
Changes the ruby to have more of a purpose; A early game gem

it has easier requirements and a permanent debuff to durability but it only needs 2 precious to activate its 25% damage buff a cheap requirement when players will have less precious resources.
It also now spawns in the gold/silver layers (under -500) higher than diamond to be more easily gained as a early game ore

<img width="673" height="140" alt="image" src="https://github.com/user-attachments/assets/fd12cd8b-ae28-49b7-a70e-db0349bb7713" />

also its old stats are the same eg; durability