### PR TITLE
Add enum for representing LOD values

### DIFF
--- a/src/chunk.zig
+++ b/src/chunk.zig
@@ -234,7 +234,7 @@ pub const Lod = enum(u5) {
 	}
 
 	test "Lod.localMask() max" {
-		try std.testing.expectEqual(Lod.max.localMask(), ~@as(i32, 1023));
+		try std.testing.expectEqual(~@as(i32, 1023), Lod.max.localMask());
 	}
 };
 


### PR DESCRIPTION
This is an intermediate step PR;

Long term goal is to use Lod enum instead of `ChunkPosition.voxelSize`, `Chunk.width`, `Chunk.voxelSizeShift`, `Chunk.voxelSizeMask` and possibly other values with similar meaning scattered around codebase.

Even long-er term goal is to standardize how we pass around chunk positions, local and global block positions and whatever is passed as random i32/Vec3i coordinates in different contexts. A lot of bit masking is done in various contexts and it is really hard to determine which type of coordinate we are looking at in some random part of the code, without reading long long before and after.