### PR TITLE
Introduce the perfect-time prototype

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -1077,19 +1077,15 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 						const swings = @ceil(block.blockHealth()/damage);
 						const damagePerSwing = block.blockHealth()/swings;
 						currentSwingTime = damagePerSwing/damage*swingTime;
-						std.log.info("hit {} {} {} {} {} {}", .{currentSwingTime, currentSwingProgress, damagePerSwing, swings, damage, swingTime});
 					}
-					std.log.info("no hit {} {}", .{currentSwingTime, currentSwingProgress});
 					currentSwingProgress += @floatCast(deltaTime);
 					while (currentSwingProgress > currentSwingTime) {
 						currentSwingProgress -= currentSwingTime;
 						currentBlockProgress += damage*currentSwingTime/swingTime/block.blockHealth();
-						std.log.info("hit {}", .{damage*currentSwingTime/swingTime/block.blockHealth()});
 						if (currentBlockProgress > 0.9999) break;
 						const swings = @ceil(block.blockHealth()/damage);
 						const damagePerSwing = block.blockHealth()/swings;
 						currentSwingTime = damagePerSwing/damage*swingTime;
-						std.log.info("hit {} {} {} {} {} {}", .{currentSwingTime, currentSwingProgress, damagePerSwing, swings, damage, swingTime});
 					}
 					if (currentBlockProgress < 0.9999) {
 						mesh_storage.removeBreakingAnimation(lastSelectedBlockPos);


### PR DESCRIPTION
After seeing the problems of over-damage #1657 and under-time #1658 (currently in the game, see #1683 and #1643 for the problems), I present to you the perfect-time model:

Snale isn't dumb, instead of blindly hitting the block with high force and then accidentally breaking blocks behind it faster (both under-time and over-damage fall in that category), Snale can see how hard a block is just by looking at it, and calculate the exact force (and thus swing time) needed to break the block.
With this model the exact swing speed is much more consistent, which should make it easier to animate as well.

@ikabod-kee @careeoki I would like your opinions here.

- [x] Remove leftover debug code

fixes #1683 