### PR TITLE
Inventories wrapper

### DIFF
--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -671,10 +671,6 @@ pub const Inventories = struct { // MARK: Inventories
 		alloctor.free(self.inventories);
 	}
 
-	pub fn getInventories(self: Inventories) []const Inventory {
-		return self.inventories;
-	}
-
 	pub fn canHold(self: Inventories, itemStack: ItemStack) Inventory.CanHoldReturn {
 		var remainingAmount = itemStack.amount;
 		for (self.inventories) |dest| {

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -722,11 +722,10 @@ pub const Inventories = struct { // MARK: Inventories
 	pub fn canHold(self: Inventories, itemStack: ItemStack) Inventory.CanHoldReturn {
 		var remainingAmount = itemStack.amount;
 		for (self.inventories) |dest| {
-			remainingAmount -|= switch (dest.canHold(itemStack)) {
+			remainingAmount = switch (dest.canHold(.{.item = itemStack.item, .amount = remainingAmount})) {
 				.yes => return .yes,
-				.remainingAmount => |amount| (itemStack.amount - amount),
+				.remainingAmount => |amount| amount,
 			};
-			if (remainingAmount == 0) return .yes;
 		}
 		return .{.remainingAmount = remainingAmount};
 	}

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -773,38 +773,4 @@ pub const Inventories = struct { // MARK: Inventories
 		return remainingAmount;
 	}
 
-	pub fn removeItems(self: Inventories, ctx: sync.Command.Context, itemAmount: u16, baseItem: main.items.BaseItemIndex) void {
-		var fullSlot: ?u32 = null;
-		var fullInv: ?Inventory = null;
-		var remainingAmount: usize = itemAmount;
-		for (self.inventories) |source| {
-			for (0..source._items.len) |reverseIndex| {
-				const i: usize = source._items.len - reverseIndex - 1;
-				const otherStack: *ItemStack = &source._items[i];
-				if (otherStack.item != .null and baseItem == otherStack.item.baseItem) {
-					if (otherStack.amount == otherStack.item.stackSize()) {
-						if (fullSlot == null) {
-							fullSlot = @intCast(i);
-							fullInv = source;
-						}
-						continue;
-					}
-					const amount = @min(remainingAmount, otherStack.amount);
-					ctx.execute(.{.delete = .{
-						.source = .{.inv = source, .slot = @intCast(i)},
-						.amount = amount,
-					}});
-					remainingAmount -= amount;
-					if (remainingAmount == 0) return;
-				}
-			}
-		}
-		if (remainingAmount > 0 and fullSlot != null) {
-			ctx.execute(.{.delete = .{
-				.source = .{.inv = fullInv.?, .slot = fullSlot.?},
-				.amount = @min(remainingAmount, baseItem.stackSize()),
-			}});
-		}
-	}
-
 };

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -772,5 +772,4 @@ pub const Inventories = struct { // MARK: Inventories
 		}
 		return remainingAmount;
 	}
-
 };

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -601,18 +601,23 @@ pub fn getAmount(self: Inventory, slot: usize) u16 {
 	return self._items[slot].amount;
 }
 
-pub fn canHold(self: Inventory, sourceStack: ItemStack) bool {
-	if (sourceStack.amount == 0) return true;
+pub const CanHoldReturn = union(enum) {
+	yes: void,
+	remainingAmount: u16,
+};
+
+pub fn canHold(self: Inventory, sourceStack: ItemStack) CanHoldReturn {
+	if (sourceStack.amount == 0) return .yes;
 
 	var remainingAmount = sourceStack.amount;
 	for (self._items) |*destStack| {
 		if (std.meta.eql(destStack.item, sourceStack.item) or destStack.item == .null) {
 			const amount = @min(sourceStack.item.stackSize() - destStack.amount, remainingAmount);
 			remainingAmount -= amount;
-			if (remainingAmount == 0) return true;
+			if (remainingAmount == 0) return .yes;
 		}
 	}
-	return false;
+	return .{.remainingAmount = remainingAmount};
 }
 
 pub fn toBytes(self: Inventory, writer: *BinaryWriter) void {
@@ -644,3 +649,165 @@ pub fn fromBytes(self: Inventory, reader: *BinaryReader) void {
 		stack.deinit();
 	}
 }
+
+pub const Inventories = struct { // MARK: Inventories
+	inventories: []const Inventory,
+
+	pub fn init(alloctor: NeverFailingAllocator, inventories: []const Inventory) Inventories {
+		return .{
+			.inventories = alloctor.dupe(Inventory, inventories),
+		};
+	}
+
+	pub fn initWithClientInventories(alloctor: NeverFailingAllocator, clientInventories: []const Inventory.ClientInventory) Inventories {
+		const copy = alloctor.alloc(Inventory, clientInventories.len);
+		for (copy, clientInventories) |*d, s| d.* = s.super;
+		return .{
+			.inventories = copy,
+		};
+	}
+
+	pub fn deinit(self: Inventories, alloctor: NeverFailingAllocator) void {
+		alloctor.free(self.inventories);
+	}
+
+	pub fn getInventories(self: Inventories) []const Inventory {
+		return self.inventories;
+	}
+
+	pub fn canHold(self: Inventories, itemStack: ItemStack) Inventory.CanHoldReturn {
+		var remainingAmount = itemStack.amount;
+		for (self.inventories) |dest| {
+			remainingAmount -|= switch (dest.canHold(itemStack)) {
+				.yes => return .yes,
+				.remainingAmount => |amount| (itemStack.amount - amount),
+			};
+			if (remainingAmount == 0) return .yes;
+		}
+		return .{.remainingAmount = remainingAmount};
+	}
+
+	const Provider = union(enum) {
+		move: sync.Command.InventoryAndSlot,
+		create: Item,
+
+		pub fn getBaseOperation(provider: Provider, dest: sync.Command.InventoryAndSlot, amount: u16) sync.Command.BaseOperation {
+			return switch (provider) {
+				.move => |slot| .{.move = .{
+					.dest = dest,
+					.amount = amount,
+					.source = slot,
+				}},
+				.create => |item| .{.create = .{
+					.dest = dest,
+					.amount = amount,
+					.item = item,
+				}},
+			};
+		}
+
+		pub fn getItem(provider: Provider) Item {
+			return switch (provider) {
+				.move => |slot| slot.ref().item,
+				.create => |item| item,
+			};
+		}
+	};
+
+	pub fn putItemsInto(self: Inventories, ctx: sync.Command.Context, itemAmount: u16, provider: Provider) u16 {
+		const item = provider.getItem();
+		var remainingAmount = itemAmount;
+		var selectedEmptySlot: ?u32 = null;
+		var selectedEmptyInv: ?Inventory = null;
+
+		outer: for (self.inventories) |dest| {
+			var emptySlot: ?u32 = null;
+			var hasItem = false;
+			for (dest._items, 0..) |*destStack, destSlot| {
+				if (destStack.item == .null and emptySlot == null) {
+					emptySlot = @intCast(destSlot);
+					if (selectedEmptySlot == null) {
+						selectedEmptySlot = emptySlot;
+						selectedEmptyInv = dest;
+					}
+				}
+				if (std.meta.eql(destStack.item, item)) {
+					hasItem = true;
+					const amount = @min(item.stackSize() - destStack.amount, remainingAmount);
+					if (amount == 0) continue;
+					ctx.execute(provider.getBaseOperation(.{.inv = dest, .slot = @intCast(destSlot)}, amount));
+					remainingAmount -= amount;
+					if (remainingAmount == 0) break :outer;
+				}
+			}
+			if (emptySlot != null and hasItem) {
+				ctx.execute(provider.getBaseOperation(.{.inv = dest, .slot = emptySlot.?}, remainingAmount));
+				remainingAmount = 0;
+				break :outer;
+			}
+		}
+		if (remainingAmount > 0 and selectedEmptySlot != null) {
+			ctx.execute(provider.getBaseOperation(.{.inv = selectedEmptyInv.?, .slot = selectedEmptySlot.?}, remainingAmount));
+			remainingAmount = 0;
+		}
+		return remainingAmount;
+	}
+
+	pub fn removeItems(self: Inventories, ctx: sync.Command.Context, itemAmount: u16, baseItem: main.items.BaseItemIndex) void {
+		var fullSlot: ?u32 = null;
+		var fullInv: ?Inventory = null;
+		var remainingAmount: usize = itemAmount;
+		for (self.inventories) |source| {
+			for (0..source._items.len) |reverseIndex| {
+				const i: usize = source._items.len - reverseIndex - 1;
+				const otherStack: *ItemStack = &source._items[i];
+				if (otherStack.item != .null and baseItem == otherStack.item.baseItem) {
+					if (otherStack.amount == otherStack.item.stackSize()) {
+						if (fullSlot == null) {
+							fullSlot = @intCast(i);
+							fullInv = source;
+						}
+						continue;
+					}
+					const amount = @min(remainingAmount, otherStack.amount);
+					ctx.execute(.{.delete = .{
+						.source = .{.inv = source, .slot = @intCast(i)},
+						.amount = amount,
+					}});
+					remainingAmount -= amount;
+					if (remainingAmount == 0) return;
+				}
+			}
+		}
+		if (remainingAmount > 0 and fullSlot != null) {
+			ctx.execute(.{.delete = .{
+				.source = .{.inv = fullInv.?, .slot = fullSlot.?},
+				.amount = @min(remainingAmount, baseItem.stackSize()),
+			}});
+		}
+	}
+
+	pub fn toBytes(self: Inventories, writer: *BinaryWriter) void {
+		writer.writeVarInt(usize, self.inventories.len);
+		for (self.inventories) |inv| {
+			writer.writeEnum(InventoryId, inv.id);
+		}
+	}
+
+	pub fn fromBytes(allocator: NeverFailingAllocator, reader: *BinaryReader, side: sync.Side, user: ?*main.server.User) !Inventories {
+		const inventoryCount = try reader.readVarInt(usize);
+		if (inventoryCount == 0) return error.Invalid;
+		if (inventoryCount*@sizeOf(InventoryId) >= reader.remaining.len) return error.Invalid;
+
+		const inventories = allocator.alloc(Inventory, inventoryCount);
+		errdefer allocator.free(inventories);
+
+		for (inventories) |*inv| {
+			const invId = try reader.readEnum(InventoryId);
+			inv.* = Inventory.getInventory(invId, side, user) orelse return error.InventoryNotFound;
+		}
+		return .{
+			.inventories = inventories,
+		};
+	}
+};

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -651,27 +651,27 @@ pub fn fromBytes(self: Inventory, reader: *BinaryReader) void {
 }
 
 pub const InventoryAndSlot = struct {
-        inv: Inventory,
-        slot: u32,
+	inv: Inventory,
+	slot: u32,
 
-        pub fn ref(self: InventoryAndSlot) *ItemStack {
-                return &self.inv._items[self.slot];
-        }
+	pub fn ref(self: InventoryAndSlot) *ItemStack {
+		return &self.inv._items[self.slot];
+	}
 
-        pub fn write(self: InventoryAndSlot, writer: *BinaryWriter) void {
-                writer.writeEnum(InventoryId, self.inv.id);
-                writer.writeInt(u32, self.slot);
-        }
+	pub fn write(self: InventoryAndSlot, writer: *BinaryWriter) void {
+		writer.writeEnum(InventoryId, self.inv.id);
+		writer.writeInt(u32, self.slot);
+	}
 
-        pub fn read(reader: *BinaryReader, side: sync.Side, user: ?*main.server.User) !InventoryAndSlot {
-                const id = try reader.readEnum(InventoryId);
-                const result: InventoryAndSlot = .{
-                        .inv = Inventory.getInventory(id, side, user) orelse return error.InventoryNotFound,
-                        .slot = try reader.readInt(u32),
-                };
-                if (result.slot >= result.inv._items.len) return error.Invalid;
-                return result;
-        }
+	pub fn read(reader: *BinaryReader, side: sync.Side, user: ?*main.server.User) !InventoryAndSlot {
+		const id = try reader.readEnum(InventoryId);
+		const result: InventoryAndSlot = .{
+			.inv = Inventory.getInventory(id, side, user) orelse return error.InventoryNotFound,
+			.slot = try reader.readInt(u32),
+		};
+		if (result.slot >= result.inv._items.len) return error.Invalid;
+		return result;
+	}
 };
 
 pub const Inventories = struct { // MARK: Inventories

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -7,6 +7,7 @@ const Gamemode = main.game.Gamemode;
 const NeverFailingAllocator = main.heap.NeverFailingAllocator;
 const Inventory = main.items.Inventory;
 const InventoryId = Inventory.InventoryId;
+const InventoryAndSlot = Inventory.InventoryAndSlot;
 const Item = main.items.Item;
 const ItemStack = main.items.ItemStack;
 const utils = main.utils;
@@ -258,30 +259,6 @@ pub const Command = struct { // MARK: Command
 		useDurability = 4,
 		addHealth = 5,
 		addEnergy = 6,
-	};
-
-	pub const InventoryAndSlot = struct {
-		inv: Inventory,
-		slot: u32,
-
-		pub fn ref(self: InventoryAndSlot) *ItemStack {
-			return &self.inv._items[self.slot];
-		}
-
-		fn write(self: InventoryAndSlot, writer: *BinaryWriter) void {
-			writer.writeEnum(InventoryId, self.inv.id);
-			writer.writeInt(u32, self.slot);
-		}
-
-		fn read(reader: *BinaryReader, side: Side, user: ?*main.server.User) !InventoryAndSlot {
-			const id = try reader.readEnum(InventoryId);
-			const result: InventoryAndSlot = .{
-				.inv = Inventory.getInventory(id, side, user) orelse return error.InventoryNotFound,
-				.slot = try reader.readInt(u32),
-			};
-			if (result.slot >= result.inv._items.len) return error.Invalid;
-			return result;
-		}
 	};
 
 	pub const BaseOperation = union(BaseOperationType) {

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1289,7 +1289,7 @@ pub const Command = struct { // MARK: Command
 		}
 
 		pub fn run(self: DepositOrDrop, ctx: Context) error{serverFailure}!void {
-			for (self.destinations.getInventories()) |dest| {
+			for (self.destinations.inventories) |dest| {
 				std.debug.assert(dest.type == .normal);
 			}
 			if (self.source.type == .crafting) return;
@@ -1344,11 +1344,11 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn run(self: DepositToAny, ctx: Context) error{serverFailure}!void {
-			for (self.destinations.getInventories()) |dest| {
+			for (self.destinations.inventories) |dest| {
 				if (dest.type != .normal) return;
 			}
 			if (self.source.inv.type == .crafting) {
-				ctx.cmd.tryCraftingTo(ctx.allocator, self.destinations.getInventories()[0], self.source, ctx.side, ctx.user);
+				ctx.cmd.tryCraftingTo(ctx.allocator, self.destinations.inventories[0], self.source, ctx.side, ctx.user);
 				return;
 			}
 			const sourceStack = self.source.ref();

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1316,7 +1316,7 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn deserialize(reader: *BinaryReader, side: Side, user: ?*main.server.User) !DepositOrDrop {
-			const destinations = try Inventory.Inventories.fromBytes(main.globalAllocator, reader, side, user);
+			const destinations: Inventory.Inventories = try .fromBytes(main.globalAllocator, reader, side, user);
 			const sourceId = try reader.readEnum(InventoryId);
 			return .{
 				.destinations = destinations,

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -260,11 +260,11 @@ pub const Command = struct { // MARK: Command
 		addEnergy = 6,
 	};
 
-	const InventoryAndSlot = struct {
+	pub const InventoryAndSlot = struct {
 		inv: Inventory,
 		slot: u32,
 
-		fn ref(self: InventoryAndSlot) *ItemStack {
+		pub fn ref(self: InventoryAndSlot) *ItemStack {
 			return &self.inv._items[self.slot];
 		}
 
@@ -284,7 +284,7 @@ pub const Command = struct { // MARK: Command
 		}
 	};
 
-	const BaseOperation = union(BaseOperationType) {
+	pub const BaseOperation = union(BaseOperationType) {
 		move: struct {
 			dest: InventoryAndSlot,
 			source: InventoryAndSlot,
@@ -779,77 +779,11 @@ pub const Command = struct { // MARK: Command
 		};
 	}
 
-	const put_items_into = struct {
-		const Provider = union(enum) {
-			move: InventoryAndSlot,
-			create: Item,
-
-			pub fn getBaseOperation(provider: Provider, dest: InventoryAndSlot, amount: u16) BaseOperation {
-				return switch (provider) {
-					.move => |slot| .{.move = .{
-						.dest = dest,
-						.amount = amount,
-						.source = slot,
-					}},
-					.create => |item| .{.create = .{
-						.dest = dest,
-						.amount = amount,
-						.item = item,
-					}},
-				};
-			}
-
-			pub fn getItem(provider: Provider) Item {
-				return switch (provider) {
-					.move => |slot| slot.ref().item,
-					.create => |item| item,
-				};
-			}
-		};
-
-		pub fn do(ctx: Context, destinations: []const Inventory, itemAmount: u16, provider: Provider) void {
-			const item = provider.getItem();
-			var remainingAmount = itemAmount;
-			var selectedEmptySlot: ?u32 = null;
-			var selectedEmptyInv: ?Inventory = null;
-
-			outer: for (destinations) |dest| {
-				var emptySlot: ?u32 = null;
-				var hasItem = false;
-				for (dest._items, 0..) |*destStack, destSlot| {
-					if (destStack.item == .null and emptySlot == null) {
-						emptySlot = @intCast(destSlot);
-						if (selectedEmptySlot == null) {
-							selectedEmptySlot = emptySlot;
-							selectedEmptyInv = dest;
-						}
-					}
-					if (std.meta.eql(destStack.item, item)) {
-						hasItem = true;
-						const amount = @min(item.stackSize() - destStack.amount, remainingAmount);
-						if (amount == 0) continue;
-						ctx.execute(provider.getBaseOperation(.{.inv = dest, .slot = @intCast(destSlot)}, amount));
-						remainingAmount -= amount;
-						if (remainingAmount == 0) break :outer;
-					}
-				}
-				if (emptySlot != null and hasItem) {
-					ctx.execute(provider.getBaseOperation(.{.inv = dest, .slot = emptySlot.?}, remainingAmount));
-					remainingAmount = 0;
-					break :outer;
-				}
-			}
-			if (remainingAmount > 0 and selectedEmptySlot != null) {
-				ctx.execute(provider.getBaseOperation(.{.inv = selectedEmptyInv.?, .slot = selectedEmptySlot.?}, remainingAmount));
-			}
-		}
-	};
-
 	fn tryCraftingTo(self: *Command, allocator: NeverFailingAllocator, dest: Inventory, source: InventoryAndSlot, side: Side, user: ?*main.server.User) void { // MARK: tryCraftingTo()
 		std.debug.assert(source.inv.type == .crafting);
 		std.debug.assert(dest.type == .normal);
 		if (source.slot != source.inv._items.len - 1) return;
-		if (!dest.canHold(source.ref().*)) return;
+		if (dest.canHold(source.ref().*) != .yes) return;
 		if (source.ref().item == .null) return; // Can happen if the we didn't receive the inventory information from the server yet.
 
 		const playerInventory: Inventory = switch (side) {
@@ -917,14 +851,14 @@ pub const Command = struct { // MARK: Command
 		std.debug.assert(remainingAmount == 0);
 	}
 
-	const Context = struct {
+	pub const Context = struct {
 		allocator: NeverFailingAllocator,
 		cmd: *Command,
 		side: Side,
 		user: ?*main.server.User,
 		gamemode: Gamemode,
 
-		fn execute(self: Context, _op: BaseOperation) void {
+		pub fn execute(self: Context, _op: BaseOperation) void {
 			return self.cmd.executeBaseOperation(self.allocator, _op, self.side);
 		}
 	};
@@ -1330,15 +1264,13 @@ pub const Command = struct { // MARK: Command
 	};
 
 	const DepositOrDrop = struct { // MARK: DepositOrDrop
-		destinations: []const Inventory,
+		destinations: Inventory.Inventories,
 		source: Inventory,
 		dropLocation: Vec3d,
 
 		pub fn init(destinations: []const Inventory.ClientInventory, source: Inventory, dropLocation: Vec3d) DepositOrDrop {
-			const copy = main.globalAllocator.alloc(Inventory, destinations.len);
-			for (copy, destinations) |*d, s| d.* = s.super;
 			return .{
-				.destinations = copy,
+				.destinations = .initWithClientInventories(main.globalAllocator, destinations),
 				.source = source,
 				.dropLocation = dropLocation,
 			};
@@ -1346,18 +1278,18 @@ pub const Command = struct { // MARK: Command
 
 		pub fn initWithInventories(destinations: []const Inventory, source: Inventory, dropLocation: Vec3d) DepositOrDrop {
 			return .{
-				.destinations = main.globalAllocator.dupe(Inventory, destinations),
+				.destinations = .init(main.globalAllocator, destinations),
 				.source = source,
 				.dropLocation = dropLocation,
 			};
 		}
 
 		fn finalize(self: DepositOrDrop, _: Side, _: *BinaryReader) !void {
-			main.globalAllocator.free(self.destinations);
+			self.destinations.deinit(main.globalAllocator);
 		}
 
 		pub fn run(self: DepositOrDrop, ctx: Context) error{serverFailure}!void {
-			for (self.destinations) |dest| {
+			for (self.destinations.getInventories()) |dest| {
 				std.debug.assert(dest.type == .normal);
 			}
 			if (self.source.type == .crafting) return;
@@ -1365,8 +1297,8 @@ pub const Command = struct { // MARK: Command
 			if (self.source.type == .workbench) sourceItems = self.source._items[0..25];
 			for (sourceItems, 0..) |*sourceStack, sourceSlot| {
 				if (sourceStack.item == .null) continue;
-				put_items_into.do(ctx, self.destinations, sourceStack.amount, .{.move = .{.inv = self.source, .slot = @intCast(sourceSlot)}});
-				if (sourceStack.amount == 0) continue;
+				const remainingAmount = self.destinations.putItemsInto(ctx, sourceStack.amount, .{.move = .{.inv = self.source, .slot = @intCast(sourceSlot)}});
+				if (remainingAmount == 0) continue;
 				if (ctx.side == .server) {
 					const direction = if (ctx.user) |_user| vec.rotateZ(vec.rotateX(Vec3f{0, 1, 0}, -_user.player.rot[0]), -_user.player.rot[2]) else Vec3f{0, 0, 0};
 					main.server.world.?.drop(sourceStack.clone(), self.dropLocation, direction, 20);
@@ -1379,28 +1311,15 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn serialize(self: DepositOrDrop, writer: *BinaryWriter) void {
-			writer.writeVarInt(usize, self.destinations.len);
-			for (self.destinations) |dest| {
-				writer.writeEnum(InventoryId, dest.id);
-			}
+			self.destinations.toBytes(writer);
 			writer.writeEnum(InventoryId, self.source.id);
 		}
 
 		fn deserialize(reader: *BinaryReader, side: Side, user: ?*main.server.User) !DepositOrDrop {
-			const destinationsSize = try reader.readVarInt(usize);
-			if (destinationsSize == 0) return error.Invalid;
-			if (destinationsSize*@sizeOf(InventoryId) >= reader.remaining.len) return error.Invalid;
-
-			const destinations = main.globalAllocator.alloc(Inventory, destinationsSize);
-			errdefer main.globalAllocator.free(destinations);
-
-			for (destinations) |*dest| {
-				const invId = try reader.readEnum(InventoryId);
-				dest.* = Inventory.getInventory(invId, side, user) orelse return error.InventoryNotFound;
-			}
+			const destinations = try Inventory.Inventories.fromBytes(main.globalAllocator, reader, side, user);
 			const sourceId = try reader.readEnum(InventoryId);
 			return .{
-				.destinations = destinations[0..],
+				.destinations = destinations,
 				.source = Inventory.getInventory(sourceId, side, user) orelse return error.InventoryNotFound,
 				.dropLocation = (user orelse return error.Invalid).player.pos,
 			};
@@ -1408,63 +1327,46 @@ pub const Command = struct { // MARK: Command
 	};
 
 	const DepositToAny = struct { // MARK: DepositToAny
-		destinations: []const Inventory,
+		destinations: Inventory.Inventories,
 		source: InventoryAndSlot,
 		amount: u16,
 
 		pub fn init(destinations: []const Inventory.ClientInventory, source: InventoryAndSlot, amount: u16) DepositToAny {
-			const copy = main.globalAllocator.alloc(Inventory, destinations.len);
-			for (copy, destinations) |*d, s| d.* = s.super;
 			return .{
-				.destinations = copy,
+				.destinations = .initWithClientInventories(main.globalAllocator, destinations),
 				.source = source,
 				.amount = amount,
 			};
 		}
 
 		fn finalize(self: DepositToAny, _: Side, _: *BinaryReader) !void {
-			main.globalAllocator.free(self.destinations);
+			self.destinations.deinit(main.globalAllocator);
 		}
 
 		fn run(self: DepositToAny, ctx: Context) error{serverFailure}!void {
-			for (self.destinations) |dest| {
+			for (self.destinations.getInventories()) |dest| {
 				if (dest.type != .normal) return;
 			}
 			if (self.source.inv.type == .crafting) {
-				ctx.cmd.tryCraftingTo(ctx.allocator, self.destinations[0], self.source, ctx.side, ctx.user);
+				ctx.cmd.tryCraftingTo(ctx.allocator, self.destinations.getInventories()[0], self.source, ctx.side, ctx.user);
 				return;
 			}
 			const sourceStack = self.source.ref();
 			if (sourceStack.item == .null) return;
 			if (self.amount > sourceStack.amount) return;
 
-			put_items_into.do(ctx, self.destinations, self.amount, .{.move = self.source});
+			_ = self.destinations.putItemsInto(ctx, self.amount, .{.move = self.source});
 		}
 
 		fn serialize(self: DepositToAny, writer: *BinaryWriter) void {
-			writer.writeVarInt(usize, self.destinations.len);
-			for (self.destinations) |dest| {
-				writer.writeEnum(InventoryId, dest.id);
-			}
+			self.destinations.toBytes(writer);
 			self.source.write(writer);
 			writer.writeInt(u16, self.amount);
 		}
 
 		fn deserialize(reader: *BinaryReader, side: Side, user: ?*main.server.User) !DepositToAny {
-			const destinationsSize = try reader.readVarInt(usize);
-			if (destinationsSize == 0) return error.Invalid;
-			if (destinationsSize*@sizeOf(InventoryId) >= reader.remaining.len) return error.Invalid;
-
-			const destinations = main.globalAllocator.alloc(Inventory, destinationsSize);
-			errdefer main.globalAllocator.free(destinations);
-
-			for (destinations) |*dest| {
-				const invId = try reader.readEnum(InventoryId);
-				dest.* = Inventory.getInventory(invId, side, user) orelse return error.InventoryNotFound;
-			}
-
 			return .{
-				.destinations = destinations[0..],
+				.destinations = try .fromBytes(main.globalAllocator, reader, side, user),
 				.source = try InventoryAndSlot.read(reader, side, user),
 				.amount = try reader.readInt(u16),
 			};

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1270,7 +1270,7 @@ pub const Command = struct { // MARK: Command
 
 		pub fn init(destinations: []const Inventory.ClientInventory, source: Inventory, dropLocation: Vec3d) DepositOrDrop {
 			return .{
-				.destinations = .initWithClientInventories(main.globalAllocator, destinations),
+				.destinations = .initFromClientInventories(main.globalAllocator, destinations),
 				.source = source,
 				.dropLocation = dropLocation,
 			};
@@ -1333,7 +1333,7 @@ pub const Command = struct { // MARK: Command
 
 		pub fn init(destinations: []const Inventory.ClientInventory, source: InventoryAndSlot, amount: u16) DepositToAny {
 			return .{
-				.destinations = .initWithClientInventories(main.globalAllocator, destinations),
+				.destinations = .initFromClientInventories(main.globalAllocator, destinations),
 				.source = source,
 				.amount = amount,
 			};

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1294,6 +1294,7 @@ pub const Command = struct { // MARK: Command
 
 		fn deserialize(reader: *BinaryReader, side: Side, user: ?*main.server.User) !DepositOrDrop {
 			const destinations: Inventory.Inventories = try .fromBytes(main.globalAllocator, reader, side, user);
+			errdefer destinations.deinit(main.globalAllocator);
 			const sourceId = try reader.readEnum(InventoryId);
 			return .{
 				.destinations = destinations,
@@ -1342,8 +1343,10 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn deserialize(reader: *BinaryReader, side: Side, user: ?*main.server.User) !DepositToAny {
+			const destinations: Inventory.Inventories = try .fromBytes(main.globalAllocator, reader, side, user);
+			errdefer destinations.deinit(main.globalAllocator);
 			return .{
-				.destinations = try .fromBytes(main.globalAllocator, reader, side, user),
+				.destinations = destinations,
 				.source = try InventoryAndSlot.read(reader, side, user),
 				.amount = try reader.readInt(u16),
 			};


### PR DESCRIPTION
While working on #2506, it became apparent that handling multiple inventories was becoming repetitive and that more functions required their own `[]const Inventory` implementations.

This PR introduces a wrapper for handling multiple Inventories and migrates the existing Sync Commands that operate on them to use it.

It also changes the behavior of `canHold`. Before it just returned if the Inventory can hold the `ItemStack` but now it either returns `yes` for it can hold or the `remainingAmount` it can not hold.

`removeItems` is currently unused, but will be used by #2506.

