### PR TITLE
Change block interaction override to crouch keybind instead of shift

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -529,14 +529,14 @@ pub const Player = struct { // MARK: Player
 		}
 	}
 
-	pub fn placeBlock(mods: main.Window.Key.Modifiers) void {
+	pub fn placeBlock() void {
 		if (main.renderer.MeshSelection.selectedBlockPos) |blockPos| {
-			if (!mods.shift) {
+			if (!KeyBoard.key("crouch").pressed) {
 				if (main.renderer.mesh_storage.triggerOnInteractBlockFromRenderThread(blockPos[0], blockPos[1], blockPos[2]) == .handled) return;
 			}
 			const block = main.renderer.mesh_storage.getBlockFromRenderThread(blockPos[0], blockPos[1], blockPos[2]) orelse main.blocks.Block{.typ = 0, .data = 0};
 			const onInteract = block.onInteract();
-			if (!mods.shift) {
+			if (!KeyBoard.key("crouch").pressed) {
 				if (onInteract.run(.{.blockPos = blockPos, .block = block}) == .handled) return;
 			}
 		}
@@ -767,10 +767,10 @@ pub var fog = Fog{.skyColor = .{0.8, 0.8, 1}, .fogColor = .{0.8, 0.8, 1}, .densi
 var nextBlockPlaceTime: ?std.Io.Timestamp = null;
 var nextBlockBreakTime: ?std.Io.Timestamp = null;
 
-pub fn pressPlace(mods: main.Window.Key.Modifiers) void {
+pub fn pressPlace(_: main.Window.Key.Modifiers) void {
 	const time = main.timestamp();
 	nextBlockPlaceTime = time.addDuration(main.settings.updateRepeatDelay);
-	Player.placeBlock(mods);
+	Player.placeBlock();
 }
 
 pub fn releasePlace(_: main.Window.Key.Modifiers) void {
@@ -972,7 +972,7 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 	if (nextBlockPlaceTime) |*placeTime| {
 		if (placeTime.durationTo(time).nanoseconds >= 0) {
 			placeTime.* = placeTime.addDuration(main.settings.updateRepeatSpeed);
-			Player.placeBlock(main.KeyBoard.key("placeBlock").modsOnPress);
+			Player.placeBlock();
 		}
 	}
 	if (nextBlockBreakTime) |*breakTime| {


### PR DESCRIPTION
"Block interaction override" being the key you hold to place a block while looking at something that would normally do something else, currently it is always `mods.shift` which can be problematic. For example I use shift for sprint and toggle sprint, meaning whenever I want to use this I toggle whether I am running, which is bothersome (additionally, some people might not have `mods.shift` bound for anything else, which would make this very unnatural). I don't think it is necessary to add a special keybind for this, and changing it to `"crouch"` will be familiar for people coming from Minecraft.

I did notice however there is `dropFromHand` which also checks `mods.shift` to decide whether to drop a whole stack or not, currently I have not changed this as I checked in Minecraft and for some reason this is always shift unlike block interaction overriding, I do feel this is an inconsistency and I obviously don't think Cubyz should seek to be inconsistent just because Minecraft is, but I am unsure whether it would be better to add a new keybind for this or make it `"crouch"`