### PR TITLE
Add advanced controls setting creativeReach

### DIFF
--- a/src/gui/windows/advanced_controls.zig
+++ b/src/gui/windows/advanced_controls.zig
@@ -38,10 +38,20 @@ fn speedFormatter(allocator: main.heap.NeverFailingAllocator, value: f32) []cons
 	return std.fmt.allocPrint(allocator.allocator, "#ffffffPlace/Break Speed: {d:.0} ms", .{value/1.0e6}) catch unreachable;
 }
 
+fn reachCallback(newValue: f32) void {
+	settings.creativeReach = @min(@max(1, @round(newValue/6)), 40)*6;
+	settings.save();
+}
+
+fn reachFormatter(allocator: main.heap.NeverFailingAllocator, value: f32) []const u8 {
+	return std.fmt.allocPrint(allocator.allocator, "#ffffffCreative Reach: {d:.0} blocks", .{@round(value/6)*6}) catch unreachable;
+}
+
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
 	list.add(ContinuousSlider.init(.{0, 0}, 128, 1.0e6, 1.0e9, @floatFromInt(settings.updateRepeatDelay.nanoseconds), &delayCallback, &delayFormatter));
 	list.add(ContinuousSlider.init(.{0, 0}, 128, 1.0e6, 0.5e9, @floatFromInt(settings.updateRepeatSpeed.nanoseconds), &speedCallback, &speedFormatter));
+	list.add(ContinuousSlider.init(.{0, 0}, 128, 6.0, 240.0, settings.creativeReach, &reachCallback, &reachFormatter));
 	list.finish(.center);
 	window.rootComponent = list.toComponent();
 	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -905,7 +905,10 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 		lastDir = _dir;
 
 		// Test blocks:
-		const closestDistance: f64 = 6.0; // selection now limited
+		var closestDistance: f64 = 6.0; // selection now limited
+		if (game.Player.isCreative()) {
+			closestDistance = @as(f64, settings.creativeReach);
+		}
 		// Implementation of "A Fast Voxel Traversal Algorithm for Ray Tracing"  http://www.cse.yorku.ca/~amana/research/grid.pdf
 		const step: Vec3i = @intFromFloat(std.math.sign(dir));
 		const invDir = @as(Vec3d, @splat(1))/dir;

--- a/src/settings.zig
+++ b/src/settings.zig
@@ -67,6 +67,8 @@ pub var updateRepeatSpeed: std.Io.Duration = .fromMilliseconds(200);
 
 pub var updateRepeatDelay: std.Io.Duration = .fromMilliseconds(500);
 
+pub var creativeReach: f32 = 6.0;
+
 pub var controllerAxisDeadzone: f32 = 0.2;
 
 const settingsFile = if (builtin.mode == .Debug) "debug_settings.zig.zon" else "settings.zig.zon";


### PR DESCRIPTION
Adds creativeReach setting which modifies the players block selection range if they are in creative mode. Ranges from 6 to 240 moving by increments of 6. I put it in advanced controls because it seems pretty similar to block place/break speed/delay to me.

~~Also I accidentally added `Merge branch 'PixelGuys:master' into creativereach_setting` to this branch and as I'm inexperienced with git I'm worried about messing things up if I try to remove it, but it doesn't seem to actually change anything? So I think it is fine..~~ Edit: I think I fixed it 