### PR TITLE
Experimental mesh light sampling improvements by caching the samples

### DIFF
--- a/src/block_entity.zig
+++ b/src/block_entity.zig
@@ -529,7 +529,8 @@ pub const BlockEntityTypes = struct {
 
 				c.glUniform1i(uniforms.quadIndex, @intFromEnum(quad));
 				const mesh = main.renderer.mesh_storage.getMesh(main.chunk.ChunkPosition.initFromWorldPos(signData.blockPos, 1)) orelse continue :outer;
-				const light: [4]u32 = main.renderer.chunk_meshing.PrimitiveMesh.getLight(mesh, signData.blockPos -% Vec3i{mesh.pos.wx, mesh.pos.wy, mesh.pos.wz}, 0, quad);
+				_ = mesh;
+				const light: [4]u32 = @splat(0); // TODO: main.renderer.chunk_meshing.PrimitiveMesh.getLight(mesh, signData.blockPos -% Vec3i{mesh.pos.wx, mesh.pos.wy, mesh.pos.wz}, 0, quad, true);
 				c.glUniform4ui(uniforms.lightData, light[0], light[1], light[2], light[3]);
 				c.glUniform3i(uniforms.chunkPos, signData.blockPos[0] & ~main.chunk.chunkMask, signData.blockPos[1] & ~main.chunk.chunkMask, signData.blockPos[2] & ~main.chunk.chunkMask);
 				c.glUniform3i(uniforms.blockPos, signData.blockPos[0] & main.chunk.chunkMask, signData.blockPos[1] & main.chunk.chunkMask, signData.blockPos[2] & main.chunk.chunkMask);


### PR DESCRIPTION
While it does reduce block placement lag significantly (9 ms → 7.5 ms) to the point where it only takes 20% of the remaining latency on the render thread (most of the work is distributed). The main bottleneck (when placing white glowcrystals) is now light propagation with around ²⁄₃ of the latency.

However this comes at a cost of increased complexity and decreased generation throughput.
- [ ] It might make sense to switch between the old and new implementation based on the cache size to face count ratio to improve performance on LOD chunks.
- [ ] Cleanup the code, use enum instead of bool for the light parameter, pass it in from further up to reduce code duplication.
- [ ] Move the LOD switch to a separate PR, so we can check its impact independently of the cache changes.
- [ ] Make a throughput (chunk generation) and latency (placing blocks) comparison in various environments