### PR TITLE
fix: typo on account cleared clipboard message

### DIFF
--- a/src/gui/windows/clipboard_deleted.zig
+++ b/src/gui/windows/clipboard_deleted.zig
@@ -36,5 +36,5 @@ pub fn render() void {
 		return;
 	}
 	draw.setColor(0xffff8080);
-	draw.print("You clipboard was cleared.", .{}, 0, 0, 16, .left);
+	draw.print("Your clipboard was cleared.", .{}, 0, 0, 16, .left);
 }


### PR DESCRIPTION
Pretty straight forward fix correction.


fix for #2555 