### PR TITLE
Don't hardcode the path to bash

### DIFF
--- a/debug_linux.sh
+++ b/debug_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 

--- a/run_linux.sh
+++ b/run_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 

--- a/scripts/install_compiler_linux.sh
+++ b/scripts/install_compiler_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 fail () {
 	exit 1


### PR DESCRIPTION
Considering `/bin/bash` isn't guaranteed to exist on some systems, it makes sense to use `/usr/bin/env bash` so that the path is dynamically looked up via `$PATH`.