### PR TITLE
Make the music slider be linear

### DIFF
--- a/src/gui/windows/sound.zig
+++ b/src/gui/windows/sound.zig
@@ -18,23 +18,12 @@ pub var window = GuiWindow{
 };
 
 fn musicCallback(newValue: f32) void {
-	settings.musicVolume = deziBelToLinear(newValue);
+	settings.musicVolume = newValue;
 	settings.save();
 }
 
-fn deziBelToLinear(x: f32) f32 {
-	if (x < -59.95) return 0;
-	return std.math.pow(f32, 10, x/20);
-}
-
-fn linearToDezibel(x: f32) f32 {
-	const db = 20*std.math.log10(x);
-	if (db < -59.95) return -60;
-	return db;
-}
-
 fn musicFormatter(allocator: NeverFailingAllocator, value: f32) []const u8 {
-	const percentage = 100*deziBelToLinear(value);
+	const percentage = 100*value;
 	if (percentage == 0) return allocator.dupe(u8, "Music volume: Off");
 	return std.fmt.allocPrint(allocator.allocator, "Music volume:", .{}) catch unreachable;
 }
@@ -43,7 +32,7 @@ const padding: f32 = 8;
 
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
-	list.add(ContinuousSlider.init(.{0, 0}, 128, -60, 0, linearToDezibel(settings.musicVolume), &musicCallback, &musicFormatter));
+	list.add(ContinuousSlider.init(.{0, 0}, 128, 0, 1, settings.musicVolume, &musicCallback, &musicFormatter));
 	list.finish(.center);
 	window.rootComponent = list.toComponent();
 	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));


### PR DESCRIPTION
A simple change that makes it so that halfway across the music slider actually sounds like 50% volume, rather than having the slider be the amount of decibels, which is non-linear.
fixes #2644 