### PR TITLE
Allow any number of colors for materials in tool textures

### DIFF
--- a/src/items.zig
+++ b/src/items.zig
@@ -433,7 +433,6 @@ const TextureGenerator = struct { // MARK: TextureGenerator
 				}
 			}
 		}
-		std.log.info("\n", .{});
 	}
 };
 


### PR DESCRIPTION
Fixes #2235

Before:
<img width="173" height="88" alt="image-49" src="https://github.com/user-attachments/assets/8ea2f882-29bc-4fa6-909a-48449d4c006d" />

After:
<img width="216" height="216" alt="image" src="https://github.com/user-attachments/assets/65690c1e-849d-474f-91e0-049f9e6bb429" /><img width="216" height="216" alt="image" src="https://github.com/user-attachments/assets/bbcd628c-f882-48fa-b12b-6462c3b0375b" />

- - -
Tools may look ever so slightly different, but this was necessary to allow higher numbers of colors to not have large regions on the edges with only one color. I also added brief explanations for steps I thought were especially confusing.

fixes #2235
