### PR TITLE
Add parsePlayerId for command usage

### DIFF
--- a/src/server/command/_command.zig
+++ b/src/server/command/_command.zig
@@ -77,8 +77,12 @@ pub fn parseCoordinates(split: *std.mem.SplitIterator(u8, .scalar), source: *Use
 }
 
 pub fn parsePlayerId(playerId: []const u8, source: *User) !*User {
-	const id = std.fmt.parseInt(u32, playerId, 10) catch {
-		source.sendMessage("#ff0000Player ids must be integers, found \"{s}\"", .{playerId});
+	if (!std.ascii.startsWithIgnoreCase(playerId, "@")) {
+		source.sendMessage("#ff0000Player id specifiers always start with @, found \"{s}\"", .{playerId});
+		return error.InvalidArg;
+	}
+	const id = std.fmt.parseInt(u32, playerId[1..], 10) catch {
+		source.sendMessage("#ff0000Player ids must be integers, found \"{s}\"", .{playerId[1..]});
 		return error.InvalidArg;
 	};
 	return main.server.getUserById(id) catch {

--- a/src/server/command/_command.zig
+++ b/src/server/command/_command.zig
@@ -75,3 +75,14 @@ pub fn parseCoordinates(split: *std.mem.SplitIterator(u8, .scalar), source: *Use
 		break :blk output;
 	};
 }
+
+pub fn parsePlayerId(playerId: []const u8, source: *User) !*User {
+	const id = std.fmt.parseInt(u32, playerId, 10) catch {
+		source.sendMessage("#ff0000Player ids must be integers, found \"{s}\"", .{playerId});
+		return error.InvalidArg;
+	};
+	return main.server.getUserById(id) catch {
+		source.sendMessage("#ff0000Player with id {d} not found", .{id});
+		return error.InvalidArg;
+	};
+}

--- a/src/server/command/_command.zig
+++ b/src/server/command/_command.zig
@@ -76,7 +76,7 @@ pub fn parseCoordinates(split: *std.mem.SplitIterator(u8, .scalar), source: *Use
 	};
 }
 
-pub fn parsePlayerIdAndIncreaseRefCount(playerId: []const u8, source: *User) !*User {
+fn parsePlayerIdAndIncreaseRefCount(playerId: []const u8, source: *User) !*User {
 	if (!std.ascii.startsWithIgnoreCase(playerId, "@")) {
 		source.sendMessage("#ff0000Player id specifiers always start with @, found \"{s}\"", .{playerId});
 		return error.InvalidArg;
@@ -90,3 +90,30 @@ pub fn parsePlayerIdAndIncreaseRefCount(playerId: []const u8, source: *User) !*U
 		return error.InvalidArg;
 	};
 }
+
+pub const Target = struct {
+	user: *User,
+	increasedRefCount: bool,
+
+	pub fn init(split: *std.mem.SplitIterator(u8, .scalar), source: *User) !Target {
+		var increasedRefCount = false;
+		const user: *User = blk: {
+			const userId = split.peek() orelse {
+				source.sendMessage("#ff0000Too few arguments for command", .{});
+				return error.TooFewArguments;
+			};
+			if (userId[0] == '@') {
+				const user = parsePlayerIdAndIncreaseRefCount(userId, source) catch return error.InvalidArgs;
+				increasedRefCount = true;
+				_ = split.next();
+				break :blk user;
+			}
+			break :blk source;
+		};
+		return .{.user = user, .increasedRefCount = increasedRefCount};
+	}
+
+	pub fn deinit(self: Target) void {
+		if (self.increasedRefCount) self.user.decreaseRefCount();
+	}
+};

--- a/src/server/command/_command.zig
+++ b/src/server/command/_command.zig
@@ -85,7 +85,7 @@ pub fn parsePlayerIdAndIncreaseRefCount(playerId: []const u8, source: *User) !*U
 		source.sendMessage("#ff0000Player ids must be integers, found \"{s}\"", .{playerId[1..]});
 		return error.InvalidArg;
 	};
-	return main.server.getUserByIdAndIncreaseRefCount(id) catch {
+	return main.server.getUserByIdAndIncreaseRefCount(id) orelse {
 		source.sendMessage("#ff0000Player with id {d} not found", .{id});
 		return error.InvalidArg;
 	};

--- a/src/server/command/_command.zig
+++ b/src/server/command/_command.zig
@@ -76,7 +76,7 @@ pub fn parseCoordinates(split: *std.mem.SplitIterator(u8, .scalar), source: *Use
 	};
 }
 
-pub fn parsePlayerId(playerId: []const u8, source: *User) !*User {
+pub fn parsePlayerIdAndIncreaseRefCount(playerId: []const u8, source: *User) !*User {
 	if (!std.ascii.startsWithIgnoreCase(playerId, "@")) {
 		source.sendMessage("#ff0000Player id specifiers always start with @, found \"{s}\"", .{playerId});
 		return error.InvalidArg;
@@ -85,7 +85,7 @@ pub fn parsePlayerId(playerId: []const u8, source: *User) !*User {
 		source.sendMessage("#ff0000Player ids must be integers, found \"{s}\"", .{playerId[1..]});
 		return error.InvalidArg;
 	};
-	return main.server.getUserById(id) catch {
+	return main.server.getUserByIdAndIncreaseRefCount(id) catch {
 		source.sendMessage("#ff0000Player with id {d} not found", .{id});
 		return error.InvalidArg;
 	};

--- a/src/server/command/permission/perm.zig
+++ b/src/server/command/permission/perm.zig
@@ -4,6 +4,7 @@ const main = @import("main");
 const User = main.server.User;
 const permission = main.server.permission;
 const ListType = permission.Permissions.ListType;
+const command = main.server.command;
 
 pub const description = "Performs changes on the permissions of the player or shows the if has permission for a specific permission path";
 pub const usage =
@@ -21,12 +22,12 @@ pub fn execute(args: []const u8, source: *User) void {
 	if (split.next()) |arg| {
 		if (std.ascii.eqlIgnoreCase(arg, "remove")) {
 			const helper = Helper.parseHelper(source, &split) catch return;
-			if (!source.permissions.removePermission(helper.listType, helper.permissionPath)) {
+			if (!helper.permissions.removePermission(helper.listType, helper.permissionPath)) {
 				source.sendMessage("#ff0000Permission path {s} is not present inside users permission {s}list", .{helper.permissionPath, @tagName(helper.listType)});
 			}
 		} else if (std.ascii.eqlIgnoreCase(arg, "add")) {
 			const helper = Helper.parseHelper(source, &split) catch return;
-			source.permissions.addPermission(helper.listType, helper.permissionPath);
+			helper.permissions.addPermission(helper.listType, helper.permissionPath);
 		} else if (arg[0] == '/') {
 			if (split.next() != null) {
 				source.sendMessage("#ff0000Not the right amount of arguments for /perm", .{});
@@ -46,10 +47,11 @@ pub fn execute(args: []const u8, source: *User) void {
 const Helper = struct {
 	listType: ListType,
 	permissionPath: []const u8,
+	permissions: *permission.Permissions,
 
 	pub fn parseHelper(source: *User, split: *std.mem.SplitIterator(u8, .scalar)) error{InvalidArgs}!Helper {
 		var listType: ListType = undefined;
-		const arg = split.next() orelse {
+		var arg = split.next() orelse {
 			source.sendMessage("#ff0000Too few arguments for command /perm", .{});
 			return error.InvalidArgs;
 		};
@@ -62,13 +64,22 @@ const Helper = struct {
 			return error.InvalidArgs;
 		}
 
-		const permissionPath = split.next() orelse {
-			source.sendMessage("#ff0000Too few arguments for command /perm.", .{});
+		arg = split.next() orelse {
+			source.sendMessage("#ff0000Too few arguments for command /perm", .{});
 			return error.InvalidArgs;
 		};
 
-		if (permissionPath[0] != '/') {
-			source.sendMessage("#ff0000Permission paths always begin with a \"/\", got: {s}", .{permissionPath});
+		const permissions: *permission.Permissions = blk: {
+			if (split.next()) |next| {
+				const user = command.parsePlayerId(arg, source) catch return error.InvalidArgs;
+				arg = next;
+				break :blk &user.permissions;
+			}
+			break :blk &source.permissions;
+		};
+
+		if (arg[0] != '/') {
+			source.sendMessage("#ff0000Permission paths always begin with a \"/\", got: {s}", .{arg});
 			return error.InvalidArgs;
 		}
 
@@ -77,6 +88,6 @@ const Helper = struct {
 			return error.InvalidArgs;
 		}
 
-		return .{.listType = listType, .permissionPath = permissionPath};
+		return .{.listType = listType, .permissionPath = arg, .permissions = permissions};
 	}
 };

--- a/src/server/command/permission/perm.zig
+++ b/src/server/command/permission/perm.zig
@@ -26,39 +26,30 @@ pub fn execute(args: []const u8, source: *User) void {
 		if (std.ascii.eqlIgnoreCase(arg, "remove")) {
 			const helper = Helper.init(source, &split) catch return;
 			defer helper.deinit();
-			if (!helper.user.permissions.removePermission(helper.listType, helper.permissionPath)) {
+			if (!helper.target.user.permissions.removePermission(helper.listType, helper.permissionPath)) {
 				source.sendMessage("#ff0000Permission path {s} is not present inside users permission {s}list", .{helper.permissionPath, @tagName(helper.listType)});
 			}
 		} else if (std.ascii.eqlIgnoreCase(arg, "add")) {
 			const helper = Helper.init(source, &split) catch return;
 			defer helper.deinit();
-			helper.user.permissions.addPermission(helper.listType, helper.permissionPath);
+			helper.target.user.permissions.addPermission(helper.listType, helper.permissionPath);
 		} else {
-			var _arg = arg;
-			var increasedRefCount = false;
-			const user: *User = blk: {
-				if (split.next()) |next| {
-					const user = command.parsePlayerIdAndIncreaseRefCount(arg, source) catch return;
-					_arg = next;
-					increasedRefCount = true;
-					break :blk user;
-				}
-				break :blk source;
-			};
-			defer if (increasedRefCount) user.decreaseRefCount();
+			split.reset();
+			const target = command.Target.init(&split, source) catch return;
+			defer target.deinit();
 
-			if (split.next() != null) {
-				source.sendMessage("#ff0000Not the right amount of arguments for /perm", .{});
+			const permissionPath = split.next() orelse {
+				source.sendMessage("#ff0000Too few arguments for /perm", .{});
+				return;
+			};
+			if (permissionPath[0] != '/') {
+				source.sendMessage("#ff0000Permission paths always begin with a \"/\", got: {s}", .{permissionPath});
 				return;
 			}
-			if (_arg[0] != '/') {
-				source.sendMessage("#ff0000Permission paths always begin with a \"/\", got: {s}", .{_arg});
-				return;
-			}
-			if (user.hasPermission(_arg)) {
-				source.sendMessage("#00ff00Player {s}#ff0000 has permission for path: {s}", .{user.name, _arg});
+			if (target.user.hasPermission(permissionPath)) {
+				source.sendMessage("#00ff00Player {s}#00ff00 has permission for path: {s}", .{target.user.name, permissionPath});
 			} else {
-				source.sendMessage("#ff0000Player {s}#ff0000 has no permission for path: {s}", .{user.name, _arg});
+				source.sendMessage("#ff0000Player {s}#ff0000 has no permission for path: {s}", .{target.user.name, permissionPath});
 			}
 		}
 	}
@@ -67,12 +58,11 @@ pub fn execute(args: []const u8, source: *User) void {
 const Helper = struct {
 	listType: ListType,
 	permissionPath: []const u8,
-	user: *User,
-	increasedRefCount: bool,
+	target: command.Target,
 
 	pub fn init(source: *User, split: *std.mem.SplitIterator(u8, .scalar)) error{InvalidArgs}!Helper {
 		var listType: ListType = undefined;
-		var arg = split.next() orelse {
+		const arg = split.next() orelse {
 			source.sendMessage("#ff0000Too few arguments for command /perm", .{});
 			return error.InvalidArgs;
 		};
@@ -85,24 +75,15 @@ const Helper = struct {
 			return error.InvalidArgs;
 		}
 
-		arg = split.next() orelse {
-			source.sendMessage("#ff0000Too few arguments for command /perm", .{});
+		const target = command.Target.init(split, source) catch return error.InvalidArgs;
+		errdefer target.deinit();
+
+		const permissionPath = split.next() orelse {
+			source.sendMessage("#ff0000Too few arguments for command /perm.", .{});
 			return error.InvalidArgs;
 		};
 
-		var increasedRefCount = false;
-		const user: *User = blk: {
-			if (split.next()) |next| {
-				const user = command.parsePlayerIdAndIncreaseRefCount(arg, source) catch return error.InvalidArgs;
-				arg = next;
-				increasedRefCount = true;
-				break :blk user;
-			}
-			break :blk source;
-		};
-		errdefer if (increasedRefCount) user.decreaseRefCount();
-
-		if (arg[0] != '/') {
+		if (permissionPath[0] != '/') {
 			source.sendMessage("#ff0000Permission paths always begin with a \"/\", got: {s}", .{arg});
 			return error.InvalidArgs;
 		}
@@ -112,10 +93,10 @@ const Helper = struct {
 			return error.InvalidArgs;
 		}
 
-		return .{.listType = listType, .permissionPath = arg, .user = user, .increasedRefCount = increasedRefCount};
+		return .{.listType = listType, .permissionPath = permissionPath, .target = target};
 	}
 
 	pub fn deinit(self: Helper) void {
-		if (self.increasedRefCount) self.user.decreaseRefCount();
+		self.target.deinit();
 	}
 };

--- a/src/server/command/permission/perm.zig
+++ b/src/server/command/permission/perm.zig
@@ -24,28 +24,28 @@ pub fn execute(args: []const u8, source: *User) void {
 	var split = std.mem.splitScalar(u8, args, ' ');
 	if (split.next()) |arg| {
 		if (std.ascii.eqlIgnoreCase(arg, "remove")) {
-			const helper = Helper.parseHelper(source, &split) catch return;
-			defer if (helper.isReference) helper.user.decreaseRefCount();
+			const helper = Helper.init(source, &split) catch return;
+			defer helper.deinit();
 			if (!helper.user.permissions.removePermission(helper.listType, helper.permissionPath)) {
 				source.sendMessage("#ff0000Permission path {s} is not present inside users permission {s}list", .{helper.permissionPath, @tagName(helper.listType)});
 			}
 		} else if (std.ascii.eqlIgnoreCase(arg, "add")) {
-			const helper = Helper.parseHelper(source, &split) catch return;
-			defer if (helper.isReference) helper.user.decreaseRefCount();
+			const helper = Helper.init(source, &split) catch return;
+			defer helper.deinit();
 			helper.user.permissions.addPermission(helper.listType, helper.permissionPath);
 		} else {
 			var _arg = arg;
-			var isReference = false;
+			var increasedRefCount = false;
 			const user: *User = blk: {
 				if (split.next()) |next| {
 					const user = command.parsePlayerIdAndIncreaseRefCount(arg, source) catch return;
 					_arg = next;
-					isReference = true;
+					increasedRefCount = true;
 					break :blk user;
 				}
 				break :blk source;
 			};
-			defer if (isReference) user.decreaseRefCount();
+			defer if (increasedRefCount) user.decreaseRefCount();
 
 			if (split.next() != null) {
 				source.sendMessage("#ff0000Not the right amount of arguments for /perm", .{});
@@ -68,9 +68,9 @@ const Helper = struct {
 	listType: ListType,
 	permissionPath: []const u8,
 	user: *User,
-	isReference: bool,
+	increasedRefCount: bool,
 
-	pub fn parseHelper(source: *User, split: *std.mem.SplitIterator(u8, .scalar)) error{InvalidArgs}!Helper {
+	pub fn init(source: *User, split: *std.mem.SplitIterator(u8, .scalar)) error{InvalidArgs}!Helper {
 		var listType: ListType = undefined;
 		var arg = split.next() orelse {
 			source.sendMessage("#ff0000Too few arguments for command /perm", .{});
@@ -90,17 +90,17 @@ const Helper = struct {
 			return error.InvalidArgs;
 		};
 
-		var isReference = false;
+		var increasedRefCount = false;
 		const user: *User = blk: {
 			if (split.next()) |next| {
 				const user = command.parsePlayerIdAndIncreaseRefCount(arg, source) catch return error.InvalidArgs;
 				arg = next;
-				isReference = true;
+				increasedRefCount = true;
 				break :blk user;
 			}
 			break :blk source;
 		};
-		errdefer if (isReference) user.decreaseRefCount();
+		errdefer if (increasedRefCount) user.decreaseRefCount();
 
 		if (arg[0] != '/') {
 			source.sendMessage("#ff0000Permission paths always begin with a \"/\", got: {s}", .{arg});
@@ -112,6 +112,10 @@ const Helper = struct {
 			return error.InvalidArgs;
 		}
 
-		return .{.listType = listType, .permissionPath = arg, .user = user, .isReference = isReference};
+		return .{.listType = listType, .permissionPath = arg, .user = user, .increasedRefCount = increasedRefCount};
+	}
+
+	pub fn deinit(self: Helper) void {
+		if (self.increasedRefCount) self.user.decreaseRefCount();
 	}
 };

--- a/src/server/command/permission/perm.zig
+++ b/src/server/command/permission/perm.zig
@@ -49,7 +49,7 @@ pub fn execute(args: []const u8, source: *User) void {
 			if (target.user.hasPermission(permissionPath)) {
 				source.sendMessage("#00ff00Player {s}§#00ff00 has permission for path: {s}", .{target.user.name, permissionPath});
 			} else {
-				source.sendMessage("#ff0000Player {s}#ff0000 has no permission for path: {s}", .{target.user.name, permissionPath});
+				source.sendMessage("#ff0000Player {s}§#ff0000 has no permission for path: {s}", .{target.user.name, permissionPath});
 			}
 		}
 	}

--- a/src/server/command/permission/perm.zig
+++ b/src/server/command/permission/perm.zig
@@ -25,25 +25,27 @@ pub fn execute(args: []const u8, source: *User) void {
 	if (split.next()) |arg| {
 		if (std.ascii.eqlIgnoreCase(arg, "remove")) {
 			const helper = Helper.parseHelper(source, &split) catch return;
-			defer if (helper.user.id != source.id) helper.user.decreaseRefCount();
+			defer if (helper.isReference) helper.user.decreaseRefCount();
 			if (!helper.user.permissions.removePermission(helper.listType, helper.permissionPath)) {
 				source.sendMessage("#ff0000Permission path {s} is not present inside users permission {s}list", .{helper.permissionPath, @tagName(helper.listType)});
 			}
 		} else if (std.ascii.eqlIgnoreCase(arg, "add")) {
 			const helper = Helper.parseHelper(source, &split) catch return;
-			defer if (helper.user.id != source.id) helper.user.decreaseRefCount();
+			defer if (helper.isReference) helper.user.decreaseRefCount();
 			helper.user.permissions.addPermission(helper.listType, helper.permissionPath);
 		} else {
 			var _arg = arg;
+			var isReference = false;
 			const user: *User = blk: {
 				if (split.next()) |next| {
 					const user = command.parsePlayerId(arg, source) catch return;
 					_arg = next;
+					isReference = true;
 					break :blk user;
 				}
 				break :blk source;
 			};
-			defer if (user.id != source.id) user.decreaseRefCount();
+			defer if (isReference) user.decreaseRefCount();
 
 			if (split.next() != null) {
 				source.sendMessage("#ff0000Not the right amount of arguments for /perm", .{});
@@ -66,6 +68,7 @@ const Helper = struct {
 	listType: ListType,
 	permissionPath: []const u8,
 	user: *User,
+	isReference: bool,
 
 	pub fn parseHelper(source: *User, split: *std.mem.SplitIterator(u8, .scalar)) error{InvalidArgs}!Helper {
 		var listType: ListType = undefined;
@@ -87,14 +90,17 @@ const Helper = struct {
 			return error.InvalidArgs;
 		};
 
+		var isReference = false;
 		const user: *User = blk: {
 			if (split.next()) |next| {
 				const user = command.parsePlayerId(arg, source) catch return error.InvalidArgs;
 				arg = next;
+				isReference = true;
 				break :blk user;
 			}
 			break :blk source;
 		};
+		errdefer if (isReference) user.decreaseRefCount();
 
 		if (arg[0] != '/') {
 			source.sendMessage("#ff0000Permission paths always begin with a \"/\", got: {s}", .{arg});
@@ -106,6 +112,6 @@ const Helper = struct {
 			return error.InvalidArgs;
 		}
 
-		return .{.listType = listType, .permissionPath = arg, .user = user};
+		return .{.listType = listType, .permissionPath = arg, .user = user, .isReference = isReference};
 	}
 };

--- a/src/server/command/permission/perm.zig
+++ b/src/server/command/permission/perm.zig
@@ -38,7 +38,7 @@ pub fn execute(args: []const u8, source: *User) void {
 			var isReference = false;
 			const user: *User = blk: {
 				if (split.next()) |next| {
-					const user = command.parsePlayerId(arg, source) catch return;
+					const user = command.parsePlayerIdAndIncreaseRefCount(arg, source) catch return;
 					_arg = next;
 					isReference = true;
 					break :blk user;
@@ -93,7 +93,7 @@ const Helper = struct {
 		var isReference = false;
 		const user: *User = blk: {
 			if (split.next()) |next| {
-				const user = command.parsePlayerId(arg, source) catch return error.InvalidArgs;
+				const user = command.parsePlayerIdAndIncreaseRefCount(arg, source) catch return error.InvalidArgs;
 				arg = next;
 				isReference = true;
 				break :blk user;

--- a/src/server/command/permission/perm.zig
+++ b/src/server/command/permission/perm.zig
@@ -11,9 +11,9 @@ pub const usage =
 	\\/perm add <whitelist/blacklist> <permissionPath>
 	\\/perm remove <whitelist/blacklist> <permissionPath>
 	\\/perm <permissionPath>
-	\\/perm add <whitelist/blacklist> <playerId> <permissionPath>
-	\\/perm remove <whitelist/blacklist> <playerId> <permissionPath>
-	\\/perm <playerId> <permissionPath>
+	\\/perm add <whitelist/blacklist> @<playerId> <permissionPath>
+	\\/perm remove <whitelist/blacklist> @<playerId> <permissionPath>
+	\\/perm @<playerId> <permissionPath>
 ;
 
 pub fn execute(args: []const u8, source: *User) void {

--- a/src/server/command/permission/perm.zig
+++ b/src/server/command/permission/perm.zig
@@ -11,6 +11,9 @@ pub const usage =
 	\\/perm add <whitelist/blacklist> <permissionPath>
 	\\/perm remove <whitelist/blacklist> <permissionPath>
 	\\/perm <permissionPath>
+	\\/perm add <whitelist/blacklist> <playerId> <permissionPath>
+	\\/perm remove <whitelist/blacklist> <playerId> <permissionPath>
+	\\/perm <playerId> <permissionPath>
 ;
 
 pub fn execute(args: []const u8, source: *User) void {
@@ -28,18 +31,29 @@ pub fn execute(args: []const u8, source: *User) void {
 		} else if (std.ascii.eqlIgnoreCase(arg, "add")) {
 			const helper = Helper.parseHelper(source, &split) catch return;
 			helper.permissions.addPermission(helper.listType, helper.permissionPath);
-		} else if (arg[0] == '/') {
+		} else {
+			var _arg = arg;
+			const user: *User = blk: {
+				if (split.next()) |next| {
+					const user = command.parsePlayerId(arg, source) catch return;
+					_arg = next;
+					break :blk user;
+				}
+				break :blk source;
+			};
 			if (split.next() != null) {
 				source.sendMessage("#ff0000Not the right amount of arguments for /perm", .{});
 				return;
 			}
-			if (source.hasPermission(arg)) {
-				source.sendMessage("#00ff00User has permission for path: {s}", .{arg});
-			} else {
-				source.sendMessage("#ff0000User has no permission for path: {s}", .{arg});
+			if (_arg[0] != '/') {
+				source.sendMessage("#ff0000Permission paths always begin with a \"/\", got: {s}", .{_arg});
+				return;
 			}
-		} else {
-			source.sendMessage("#ff0000Expected either add, remove or a valid permission path, found \"{s}\"", .{arg});
+			if (user.hasPermission(_arg)) {
+				source.sendMessage("#00ff00Player {s}#ff0000 has permission for path: {s}", .{user.name, _arg});
+			} else {
+				source.sendMessage("#ff0000Player {s}#ff0000 has no permission for path: {s}", .{user.name, _arg});
+			}
 		}
 	}
 }

--- a/src/server/command/permission/perm.zig
+++ b/src/server/command/permission/perm.zig
@@ -47,7 +47,7 @@ pub fn execute(args: []const u8, source: *User) void {
 				return;
 			}
 			if (target.user.hasPermission(permissionPath)) {
-				source.sendMessage("#00ff00Player {s}#00ff00 has permission for path: {s}", .{target.user.name, permissionPath});
+				source.sendMessage("#00ff00Player {s}§#00ff00 has permission for path: {s}", .{target.user.name, permissionPath});
 			} else {
 				source.sendMessage("#ff0000Player {s}#ff0000 has no permission for path: {s}", .{target.user.name, permissionPath});
 			}

--- a/src/server/command/permission/perm.zig
+++ b/src/server/command/permission/perm.zig
@@ -25,12 +25,14 @@ pub fn execute(args: []const u8, source: *User) void {
 	if (split.next()) |arg| {
 		if (std.ascii.eqlIgnoreCase(arg, "remove")) {
 			const helper = Helper.parseHelper(source, &split) catch return;
-			if (!helper.permissions.removePermission(helper.listType, helper.permissionPath)) {
+			defer if (helper.user.id != source.id) helper.user.decreaseRefCount();
+			if (!helper.user.permissions.removePermission(helper.listType, helper.permissionPath)) {
 				source.sendMessage("#ff0000Permission path {s} is not present inside users permission {s}list", .{helper.permissionPath, @tagName(helper.listType)});
 			}
 		} else if (std.ascii.eqlIgnoreCase(arg, "add")) {
 			const helper = Helper.parseHelper(source, &split) catch return;
-			helper.permissions.addPermission(helper.listType, helper.permissionPath);
+			defer if (helper.user.id != source.id) helper.user.decreaseRefCount();
+			helper.user.permissions.addPermission(helper.listType, helper.permissionPath);
 		} else {
 			var _arg = arg;
 			const user: *User = blk: {
@@ -41,6 +43,8 @@ pub fn execute(args: []const u8, source: *User) void {
 				}
 				break :blk source;
 			};
+			defer if (user.id != source.id) user.decreaseRefCount();
+
 			if (split.next() != null) {
 				source.sendMessage("#ff0000Not the right amount of arguments for /perm", .{});
 				return;
@@ -61,7 +65,7 @@ pub fn execute(args: []const u8, source: *User) void {
 const Helper = struct {
 	listType: ListType,
 	permissionPath: []const u8,
-	permissions: *permission.Permissions,
+	user: *User,
 
 	pub fn parseHelper(source: *User, split: *std.mem.SplitIterator(u8, .scalar)) error{InvalidArgs}!Helper {
 		var listType: ListType = undefined;
@@ -83,13 +87,13 @@ const Helper = struct {
 			return error.InvalidArgs;
 		};
 
-		const permissions: *permission.Permissions = blk: {
+		const user: *User = blk: {
 			if (split.next()) |next| {
 				const user = command.parsePlayerId(arg, source) catch return error.InvalidArgs;
 				arg = next;
-				break :blk &user.permissions;
+				break :blk user;
 			}
-			break :blk &source.permissions;
+			break :blk source;
 		};
 
 		if (arg[0] != '/') {
@@ -102,6 +106,6 @@ const Helper = struct {
 			return error.InvalidArgs;
 		}
 
-		return .{.listType = listType, .permissionPath = arg, .permissions = permissions};
+		return .{.listType = listType, .permissionPath = arg, .user = user};
 	}
 };

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -794,7 +794,7 @@ pub fn sendMessage(comptime fmt: []const u8, args: anytype) void {
 	sendRawMessage(msg);
 }
 
-pub fn getUserByIdAndIncreaseRefCount(id: u32) !*User {
+pub fn getUserByIdAndIncreaseRefCount(id: u32) ?*User {
 	const userList = getUserListAndIncreaseRefCount(main.stackAllocator);
 	defer freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
 	for (userList) |user| {
@@ -803,5 +803,5 @@ pub fn getUserByIdAndIncreaseRefCount(id: u32) !*User {
 			return user;
 		}
 	}
-	return error.UserNotFound;
+	return null;
 }

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -794,7 +794,7 @@ pub fn sendMessage(comptime fmt: []const u8, args: anytype) void {
 	sendRawMessage(msg);
 }
 
-pub fn getUserById(id: u32) !*User {
+pub fn getUserByIdAndIncreaseRefCount(id: u32) !*User {
 	const userList = getUserListAndIncreaseRefCount(main.stackAllocator);
 	defer freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
 	for (userList) |user| {

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -798,7 +798,10 @@ pub fn getUserById(id: u32) !*User {
 	const userList = getUserListAndIncreaseRefCount(main.stackAllocator);
 	defer freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
 	for (userList) |user| {
-		if (user.id == id) return user;
+		if (user.id == id) {
+			user.increaseRefCount();
+			return user;
+		}
 	}
 	return error.UserNotFound;
 }

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -793,3 +793,12 @@ pub fn sendMessage(comptime fmt: []const u8, args: anytype) void {
 	defer main.stackAllocator.free(msg);
 	sendRawMessage(msg);
 }
+
+pub fn getUserById(id: u32) !*User {
+	const userList = getUserListAndIncreaseRefCount(main.stackAllocator);
+	defer freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+	for (userList) |user| {
+		if (user.id == id) return user;
+	}
+	return error.UserNotFound;
+}


### PR DESCRIPTION
With #2660 I think this will close #2615

This PR adds a helper function to `_command.zig` for parsing `playerIds` and also tests this by implementing it for `/perm`
This also solves the problem that currently the permission layer is only a hindrance because you weren't in a good way able to change other players permissions.
