### PR TITLE
ItemDrops be more visible

### DIFF
--- a/src/itemdrop.zig
+++ b/src/itemdrop.zig
@@ -43,7 +43,7 @@ pub const ItemDropNetworkData = struct {
 
 pub const ItemDropManager = struct { // MARK: ItemDropManager
 	/// Half the side length of all item entities hitboxes as a cube.
-	pub const radius: f64 = 0.1;
+	pub const radius: f64 = 0.4;
 	/// Side length of all item entities hitboxes as a cube.
 	pub const diameter: f64 = 2*radius;
 


### PR DESCRIPTION
Items are hard to spot, because they tend to lay on the ground or be half sunken in the ground.
for example:
<img width="55" height="53" alt="image" src="https://github.com/user-attachments/assets/1dae2542-77a6-4ac3-993b-493303f811e9" />
 **before**
<img width="141" height="161" alt="image" src="https://github.com/user-attachments/assets/a43ab55d-a1a0-4c59-ad76-21089fa76de7" />
**after**
<img width="165" height="123" alt="image" src="https://github.com/user-attachments/assets/59fc6c7e-7e08-4a90-85fc-4407aee7b87c" />
