### PR TITLE
Floating Island Stalagtites

### DIFF
--- a/assets/cubyz/biomes/cave/sky_islands/_defaults.zig.zon
+++ b/assets/cubyz/biomes/cave/sky_islands/_defaults.zig.zon
@@ -90,5 +90,30 @@
 			.height = 1,
 			.height_variation = 0,
 		},
+		.{
+			.id = "cubyz:stalagmite",
+			.block = "cubyz:nimbusite/base",
+			.generationMode = .ceiling,
+			.chance = 0.36,
+			.size = 2,
+			.size_variation = 4,
+		},
+
+		.{
+			.id = "cubyz:stalagmite",
+			.block = "cubyz:nimbusite/base",
+			.generationMode = .ceiling,
+			.chance = 0.12,
+			.size = 4,
+			.size_variation = 6,
+		},
+		.{
+			.id = "cubyz:stalagmite",
+			.block = "cubyz:nimbusite/base",
+			.generationMode = .ceiling,
+			.chance = 0.08,
+			.size = 6,
+			.size_variation = 8,
+		},
 	},
 }

--- a/assets/cubyz/biomes/cave/sky_islands/base.zig.zon
+++ b/assets/cubyz/biomes/cave/sky_islands/base.zig.zon
@@ -1,5 +1,6 @@
 .{
 	.chance = 1,
+	.caveNoiseStrength = 16,
 
 	.caveModels = .{
 		.{

--- a/assets/cubyz/blocks/jade_ore.zig.zon
+++ b/assets/cubyz/blocks/jade_ore.zig.zon
@@ -27,7 +27,7 @@
 		},
 	},
 	.ore = .{
-		.veins = 4,
+		.veins = 6,
 		.size = 4,
 		.minHeight = 350,
 		.density = 0.3,


### PR DESCRIPTION
Right now, the floating islands are very round and flat, so I increased the cave noise strength there and added a bunch of stalactites. Since the stalactites cover up a decent amount of the bottom of the islands, I also made jade 50% more common.
- - -
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4947408d-3a97-4b56-b8ea-01abc297d960" />
<img width="1920" height="1080" alt="Screenshot_20260319_124501" src="https://github.com/user-attachments/assets/dacd8cfc-c07d-4e59-a40e-8d2bd287c360" />
<img width="1920" height="1080" alt="Screenshot_20260319_124521" src="https://github.com/user-attachments/assets/0e27a0aa-e4b5-49ee-a2a1-cb0e9b7b4793" />
