### PR TITLE
Mixed forest clearing tweaks

### DIFF
--- a/assets/cubyz/biomes/forest/mixed/oak_birch_clearing.zig.zon
+++ b/assets/cubyz/biomes/forest/mixed/oak_birch_clearing.zig.zon
@@ -1,6 +1,8 @@
 .{
 	.chance = 0,
 	.keepOriginalTerrain = 1,
+	.minHeight = 22,
+	.maxHeight = 40,
 	.properties = .{},
 	.minRadius = 20,
 	.maxRadius = 32,

--- a/assets/cubyz/biomes/forest/mixed/oak_pine_clearing.zig.zon
+++ b/assets/cubyz/biomes/forest/mixed/oak_pine_clearing.zig.zon
@@ -1,6 +1,8 @@
 .{
 	.chance = 0,
 	.keepOriginalTerrain = 1,
+	.minHeight = 22,
+	.maxHeight = 45,
 	.properties = .{},
 	.minRadius = 20,
 	.maxRadius = 32,


### PR DESCRIPTION
- Slightly more common
- keepOriginalTerrain (no weird hills or pits)
- Radius variation
- Low chance for trees (smoother transition and some more variation)
- Fewer fallen trees (so it doesn't look like a chopped forest)

<img width="1455" height="872" alt="image" src="https://github.com/user-attachments/assets/b465b005-09cc-49a9-82b1-780e7fa5adc0" />

