### PR TITLE
Refactor physics to use PhysicsState and InputState structs

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -221,7 +221,7 @@ pub const collision = struct {
 		};
 	}
 
-	const VolumeProperties = struct {
+	pub const VolumeProperties = struct {
 		terminalVelocity: f64,
 		density: f64,
 		maxDensity: f64,
@@ -813,17 +813,26 @@ pub fn hyperSpeedToggle(_: main.Window.Key.Modifiers) void {
 }
 
 pub fn update(deltaTime: f64) void { // MARK: update()
-	physics.calculateProperties();
-	var acc = Vec3d{0, 0, 0};
+	var physicsState = physics.PhysicsState.fromPlayer();
+	var inputState: physics.InputState = .{
+		.boundingBox = Player.outerBoundingBox,
+		.isFlying = Player.isFlying.load(.monotonic),
+		.isGhost = Player.isGhost.load(.monotonic),
+		.hasCollision = !Player.isGhost.load(.monotonic),
+		.runTouchBlocks = true,
+		.entity = &Player.super,
+		.steppingHeight = Player.steppingHeight(),
+	};
+	physics.calculateProperties(&physicsState, inputState, .client);
 	const speedMultiplier: f32 = if (Player.hyperSpeed.load(.monotonic)) 4.0 else 1.0;
 
-	const density = if (Player.isFlying.load(.monotonic)) 0.0 else Player.volumeProperties.density;
-	const maxDensity = if (Player.isFlying.load(.monotonic)) 0.0 else Player.volumeProperties.maxDensity;
+	const density = if (inputState.isFlying) 0.0 else physicsState.volumeProperties.density;
+	const maxDensity = if (inputState.isFlying) 0.0 else physicsState.volumeProperties.maxDensity;
 
-	var jumping = false;
+	inputState.jumping = false;
 	Player.jumpCooldown -= deltaTime;
 	// At equillibrium we want to have dv/dt = a - λv = 0 → a = λ*v
-	const fricMul = speedMultiplier*Player.mobileFriction;
+	const fricMul = speedMultiplier*physicsState.mobileFriction;
 
 	const horizontalForward = vec.rotateZ(Vec3d{0, 1, 0}, -camera.rotation[2]);
 	const forward = vec.normalize(std.math.lerp(horizontalForward, camera.direction, @as(Vec3d, @splat(density/@max(1.0, maxDensity)))));
@@ -838,10 +847,10 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 		}));
 		if (KeyBoard.key("forward").value > 0.0) {
 			if (KeyBoard.key("sprint").pressed and !Player.crouching) {
-				if (Player.isGhost.load(.monotonic)) {
+				if (inputState.isGhost) {
 					movementSpeed = @max(movementSpeed, 128*KeyBoard.key("forward").value);
 					movementDir += forward*@as(Vec3d, @splat(128*KeyBoard.key("forward").value));
-				} else if (Player.isFlying.load(.monotonic)) {
+				} else if (inputState.isFlying) {
 					movementSpeed = @max(movementSpeed, 32*KeyBoard.key("forward").value);
 					movementDir += forward*@as(Vec3d, @splat(32*KeyBoard.key("forward").value));
 				} else {
@@ -862,9 +871,9 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 			movementDir += right*@as(Vec3d, @splat(-walkingSpeed*KeyBoard.key("right").value));
 		}
 		if (KeyBoard.key("jump").pressed) {
-			if (Player.isFlying.load(.monotonic)) {
+			if (inputState.isFlying) {
 				if (KeyBoard.key("sprint").pressed) {
-					if (Player.isGhost.load(.monotonic)) {
+					if (inputState.isGhost) {
 						movementSpeed = @max(movementSpeed, 60);
 						movementDir[2] += 60;
 					} else {
@@ -875,13 +884,13 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 					movementSpeed = @max(movementSpeed, 5.5);
 					movementDir[2] += 5.5;
 				}
-			} else if ((Player.onGround or Player.jumpCoyote > 0.0) and Player.jumpCooldown <= 0) {
-				jumping = true;
+			} else if ((physicsState.onGround or physicsState.jumpCoyote > 0.0) and Player.jumpCooldown <= 0) {
+				inputState.jumping = true;
 				Player.jumpCooldown = Player.jumpCooldownConstant;
-				if (!Player.onGround) {
-					Player.eye.coyote = 0;
+				if (!physicsState.onGround) {
+					physicsState.eye.?.coyote = 0;
 				}
-				Player.jumpCoyote = 0;
+				physicsState.jumpCoyote = 0;
 			} else if (!KeyBoard.key("fall").pressed) {
 				movementSpeed = @max(movementSpeed, walkingSpeed);
 				movementDir[2] += walkingSpeed;
@@ -890,9 +899,9 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 			Player.jumpCooldown = 0;
 		}
 		if (KeyBoard.key("fall").pressed) {
-			if (Player.isFlying.load(.monotonic)) {
+			if (inputState.isFlying) {
 				if (KeyBoard.key("sprint").pressed) {
-					if (Player.isGhost.load(.monotonic)) {
+					if (inputState.isGhost) {
 						movementSpeed = @max(movementSpeed, 60);
 						movementDir[2] -= 60;
 					} else {
@@ -915,7 +924,7 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 			} else {
 				movementDir /= @splat(movementSpeed);
 			}
-			acc += movementDir*@as(Vec3d, @splat(movementSpeed*fricMul));
+			inputState.movementForce += movementDir*@as(Vec3d, @splat(movementSpeed*fricMul));
 		}
 
 		const newSlot: i32 = @as(i32, @intCast(Player.selectedSlot)) -% main.Window.scrollOffsetInteger;
@@ -928,7 +937,7 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 		main.game.camera.moveRotation(newPos[0]/64.0, newPos[1]/64.0);
 	}
 
-	Player.crouching = main.Window.grabbed and KeyBoard.key("crouch").pressed and !Player.isFlying.load(.monotonic);
+	Player.crouching = main.Window.grabbed and KeyBoard.key("crouch").pressed and !inputState.isFlying;
 
 	if (collision.collides(.client, .x, 0, Player.super.pos + Player.standingBoundingBoxExtent - Player.crouchingBoundingBoxExtent, .{
 		.min = -Player.standingBoundingBoxExtent,
@@ -947,7 +956,7 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 
 		const newOuterBox = (Player.crouchingBoundingBoxExtent - Player.standingBoundingBoxExtent)*@as(Vec3d, @splat(smoothPerc)) + Player.standingBoundingBoxExtent;
 
-		Player.super.pos += newOuterBox - Player.outerBoundingBoxExtent + Vec3d{0.0, 0.0, 0.0001*@abs(newOuterBox[2] - Player.outerBoundingBoxExtent[2])};
+		physicsState.pos += newOuterBox - Player.outerBoundingBoxExtent + Vec3d{0.0, 0.0, 0.0001*@abs(newOuterBox[2] - Player.outerBoundingBoxExtent[2])};
 
 		Player.outerBoundingBoxExtent = newOuterBox;
 
@@ -955,14 +964,19 @@ pub fn update(deltaTime: f64) void { // MARK: update()
 			.min = -Player.outerBoundingBoxExtent,
 			.max = Player.outerBoundingBoxExtent,
 		};
-		Player.eye.box = .{
+		physicsState.eye.?.box = .{
 			.min = -Vec3d{Player.outerBoundingBoxExtent[0]*0.2, Player.outerBoundingBoxExtent[1]*0.2, Player.outerBoundingBoxExtent[2] - 0.2},
 			.max = Vec3d{Player.outerBoundingBoxExtent[0]*0.2, Player.outerBoundingBoxExtent[1]*0.2, Player.outerBoundingBoxExtent[2] - 0.05},
 		};
-		Player.eye.desiredPos = (Vec3d{0, 0, 1.3 - Player.crouchingBoundingBoxExtent[2]} - Vec3d{0, 0, 1.7 - Player.standingBoundingBoxExtent[2]})*@as(Vec3f, @splat(smoothPerc)) + Vec3d{0, 0, 1.7 - Player.standingBoundingBoxExtent[2]};
+		physicsState.eye.?.desiredPos = (Vec3d{0, 0, 1.3 - Player.crouchingBoundingBoxExtent[2]} - Vec3d{0, 0, 1.7 - Player.standingBoundingBoxExtent[2]})*@as(Vec3f, @splat(smoothPerc)) + Vec3d{0, 0, 1.7 - Player.standingBoundingBoxExtent[2]};
 	}
-
-	physics.update(deltaTime, acc, jumping);
+	inputState.crouching = Player.crouching;
+	inputState.boundingBox = Player.outerBoundingBox;
+	physics.update(deltaTime, &physicsState, inputState, .client);
+	if (physicsState.fallDamage > 0.01) {
+		main.sync.addHealth(-physicsState.fallDamage, .fall, .client, Player.id);
+	}
+	physicsState.toPlayer();
 
 	const time = main.timestamp();
 	if (nextBlockPlaceTime) |*placeTime| {

--- a/src/physics.zig
+++ b/src/physics.zig
@@ -16,28 +16,86 @@ pub const airTerminalVelocity = 90.0;
 pub const airDensity = 0.001;
 const playerDensity = 1.2;
 
-pub fn calculateProperties() void {
-	if (main.renderer.mesh_storage.getBlockFromRenderThread(@intFromFloat(@floor(Player.super.pos[0])), @intFromFloat(@floor(Player.super.pos[1])), @intFromFloat(@floor(Player.super.pos[2]))) != null) {
-		Player.volumeProperties = collision.calculateVolumeProperties(.client, Player.super.pos, Player.outerBoundingBox, .{.density = airDensity, .terminalVelocity = airTerminalVelocity, .maxDensity = airDensity, .mobileFriction = 1.0/airTerminalVelocity});
-		const groundFriction = if (!Player.onGround and !Player.isFlying.load(.monotonic)) 0 else collision.calculateSurfaceProperties(.client, Player.super.pos, Player.outerBoundingBox, 20).friction;
-		const volumeFrictionCoeffecient: f32 = @floatCast(gravity/Player.volumeProperties.terminalVelocity);
-		const mobileFriction: f32 = @floatCast(gravity*Player.volumeProperties.mobileFriction);
-		Player.currentFriction = if (Player.isFlying.load(.monotonic)) 20 else groundFriction + volumeFrictionCoeffecient;
-		Player.mobileFriction = if (Player.isFlying.load(.monotonic)) 20 else groundFriction + mobileFriction;
+pub const PhysicsState = struct {
+	pos: Vec3d,
+	vel: Vec3d,
+	volumeProperties: collision.VolumeProperties = .{.density = 0, .maxDensity = 0, .mobileFriction = 0, .terminalVelocity = 0},
+	currentFriction: f32 = 0,
+	mobileFriction: f32 = 0,
+	onGround: bool = false,
+	jumpCoyote: f64 = 0,
+	eye: ?*Player.EyeData = null,
+	fallDamage: f32 = 0.0,
+
+	pub fn fromPlayer() PhysicsState {
+		return .{
+			.pos = Player.super.pos,
+			.vel = Player.super.vel,
+			.volumeProperties = Player.volumeProperties,
+			.currentFriction = Player.currentFriction,
+			.mobileFriction = Player.mobileFriction,
+			.onGround = Player.onGround,
+			.jumpCoyote = Player.jumpCoyote,
+			.eye = &Player.eye,
+		};
 	}
+
+	pub fn toPlayer(self: PhysicsState) void {
+		Player.mutex.lock();
+		defer Player.mutex.unlock();
+		Player.super.pos = self.pos;
+		Player.super.vel = self.vel;
+		Player.volumeProperties = self.volumeProperties;
+		Player.currentFriction = self.currentFriction;
+		Player.mobileFriction = self.mobileFriction;
+		Player.onGround = self.onGround;
+		Player.jumpCoyote = self.jumpCoyote;
+	}
+};
+
+pub const InputState = struct {
+	boundingBox: collision.Box = .{.min = @splat(0), .max = @splat(0)},
+	movementForce: Vec3d = .{0, 0, 0},
+	jumping: bool = false,
+	crouching: bool = false,
+	isFlying: bool = false,
+	isGhost: bool = false,
+	entityGravity: f64 = gravity,
+	entityDensity: f64 = playerDensity,
+	steppingHeight: Vec3d = .{0, 0, 0},
+	jumpHeight: f64 = Player.jumpHeight,
+	hasCollision: bool = true,
+	runTouchBlocks: bool = false,
+	entity: ?*main.server.Entity = null,
+};
+
+const volumeDefaults: collision.VolumeProperties = .{
+	.density = airDensity,
+	.terminalVelocity = airTerminalVelocity,
+	.maxDensity = airDensity,
+	.mobileFriction = 1.0/airTerminalVelocity,
+};
+
+pub fn calculateProperties(state: *PhysicsState, input: InputState, comptime side: main.utils.Side) void {
+	state.volumeProperties = collision.calculateVolumeProperties(side, state.pos, input.boundingBox, volumeDefaults);
+	const groundFriction = if (!state.onGround and !input.isFlying) 0 else collision.calculateSurfaceProperties(side, state.pos, input.boundingBox, 20).friction;
+	const volumeFrictionCoeffecient: f32 = @floatCast(input.entityGravity/state.volumeProperties.terminalVelocity);
+	const mobileFriction: f32 = @floatCast(input.entityGravity*state.volumeProperties.mobileFriction);
+	state.currentFriction = if (input.isFlying) 20 else groundFriction + volumeFrictionCoeffecient;
+	state.mobileFriction = if (input.isFlying) 20 else groundFriction + mobileFriction;
 }
 
-pub fn update(deltaTime: f64, inputAcc: Vec3d, jumping: bool) void { // MARK: update()
+pub fn update(deltaTime: f64, state: *PhysicsState, input: InputState, comptime side: main.utils.Side) void { // MARK: update()
 	var move: Vec3d = .{0, 0, 0};
-	if (main.renderer.mesh_storage.getBlockFromRenderThread(@intFromFloat(@floor(Player.super.pos[0])), @intFromFloat(@floor(Player.super.pos[1])), @intFromFloat(@floor(Player.super.pos[2]))) != null) {
-		const effectiveGravity = gravity*(playerDensity - Player.volumeProperties.density)/playerDensity;
-		const volumeFrictionCoeffecient: f32 = @floatCast(gravity/Player.volumeProperties.terminalVelocity);
-		var acc = inputAcc;
-		if (!Player.isFlying.load(.monotonic)) {
+	if (side == .server or main.renderer.mesh_storage.getBlockFromRenderThread(@intFromFloat(@floor(state.pos[0])), @intFromFloat(@floor(state.pos[1])), @intFromFloat(@floor(state.pos[2]))) != null) {
+		const effectiveGravity = input.entityGravity*(input.entityDensity - state.volumeProperties.density)/input.entityDensity;
+		const volumeFrictionCoeffecient: f32 = @floatCast(input.entityGravity/state.volumeProperties.terminalVelocity);
+		var acc = input.movementForce;
+		if (!input.isFlying) {
 			acc[2] -= effectiveGravity;
 		}
 
-		const baseFrictionCoefficient: f32 = Player.currentFriction;
+		const baseFrictionCoefficient: f32 = state.currentFriction;
 		var directionalFrictionCoefficients: Vec3f = @splat(0);
 
 		// This our model for movement on a single frame:
@@ -46,13 +104,13 @@ pub fn update(deltaTime: f64, inputAcc: Vec3d, jumping: bool) void { // MARK: up
 		// Where a is the acceleration and λ is the friction coefficient
 		inline for (0..3) |i| {
 			var frictionCoefficient = baseFrictionCoefficient + directionalFrictionCoefficients[i];
-			if (i == 2 and jumping) { // No friction while jumping
+			if (i == 2 and input.jumping) { // No friction while jumping
 				// Here we want to ensure a specified jump height under air friction.
-				const jumpVelocity = @sqrt(Player.jumpHeight*gravity*2);
-				Player.super.vel[i] = @max(jumpVelocity, Player.super.vel[i] + jumpVelocity);
+				const jumpVelocity = @sqrt(input.jumpHeight*input.entityGravity*2);
+				state.vel[i] = @max(jumpVelocity, state.vel[i] + jumpVelocity);
 				frictionCoefficient = volumeFrictionCoeffecient;
 			}
-			const v_0 = Player.super.vel[i];
+			const v_0 = state.vel[i];
 			const a = acc[i];
 			// Here the solution can be easily derived:
 			// dv/dt = a - λ·v
@@ -67,197 +125,214 @@ pub fn update(deltaTime: f64, inputAcc: Vec3d, jumping: bool) void { // MARK: up
 			// With x(0) = 0 we get C = c_1/λ
 			// x(t) = a/λt - c_1/λ e^(λ (-t)) + c_1/λ
 			const c_1 = v_0 - a/frictionCoefficient;
-			Player.super.vel[i] = a/frictionCoefficient + c_1*@exp(-frictionCoefficient*deltaTime);
+			state.vel[i] = a/frictionCoefficient + c_1*@exp(-frictionCoefficient*deltaTime);
 			move[i] = a/frictionCoefficient*deltaTime - c_1/frictionCoefficient*@exp(-frictionCoefficient*deltaTime) + c_1/frictionCoefficient;
 		}
 
-		acc = @splat(0);
-		// Apply springs to the eye position:
-		var springConstants = Vec3d{0, 0, 0};
-		{
-			const forceMultipliers = Vec3d{
-				400,
-				400,
-				400,
-			};
-			const frictionMultipliers = Vec3d{
-				30,
-				30,
-				30,
-			};
-			const strength = (-Player.eye.pos)/(Player.eye.box.max - Player.eye.box.min);
-			const force = strength*forceMultipliers;
-			const friction = frictionMultipliers;
-			springConstants += forceMultipliers/(Player.eye.box.max - Player.eye.box.min);
-			directionalFrictionCoefficients += @floatCast(friction);
-			acc += force;
-		}
+		if (state.eye) |eyeData| {
+			acc = @splat(0);
+			// Apply springs to the eye position:
+			var springConstants = Vec3d{0, 0, 0};
+			{
+				const forceMultipliers = Vec3d{
+					400,
+					400,
+					400,
+				};
+				const frictionMultipliers = Vec3d{
+					30,
+					30,
+					30,
+				};
+				const strength = (-eyeData.pos)/(eyeData.box.max - eyeData.box.min);
+				const force = strength*forceMultipliers;
+				const friction = frictionMultipliers;
+				springConstants += forceMultipliers/(eyeData.box.max - eyeData.box.min);
+				directionalFrictionCoefficients += @floatCast(friction);
+				acc += force;
+			}
 
-		// This our model for movement of the eye position on a single frame:
-		// dv/dt = a - k*x - λ·v
-		// dx/dt = v
-		// Where a is the acceleration, k is the spring constant and λ is the friction coefficient
-		inline for (0..3) |i| blk: {
-			if (Player.eye.step[i]) {
-				const oldPos = Player.eye.pos[i];
-				const newPos = oldPos + Player.eye.vel[i]*deltaTime;
-				if (newPos*std.math.sign(Player.eye.vel[i]) <= -0.1) {
-					Player.eye.pos[i] = newPos;
-					break :blk;
-				} else {
-					Player.eye.step[i] = false;
+			// This our model for movement of the eye position on a single frame:
+			// dv/dt = a - k*x - λ·v
+			// dx/dt = v
+			// Where a is the acceleration, k is the spring constant and λ is the friction coefficient
+			inline for (0..3) |i| blk: {
+				if (eyeData.step[i]) {
+					const oldPos = eyeData.pos[i];
+					const newPos = oldPos + eyeData.vel[i]*deltaTime;
+					if (newPos*std.math.sign(eyeData.vel[i]) <= -0.1) {
+						eyeData.pos[i] = newPos;
+						break :blk;
+					} else {
+						eyeData.step[i] = false;
+					}
 				}
+				if (i == 2 and eyeData.coyote > 0) {
+					break :blk;
+				}
+				const frictionCoefficient = directionalFrictionCoefficients[i];
+				const v_0 = eyeData.vel[i];
+				const k = springConstants[i];
+				const a = acc[i];
+				// here we need to solve the full equation:
+				// The solution of this differential equation is given by
+				// x(t) = a/k + c_1 e^(1/2 t (-c_3 - λ)) + c_2 e^(1/2 t (c_3 - λ))
+				// With c_3 = sqrt(λ^2 - 4 k) which can be imaginary
+				// v(t) is just the derivative, given by
+				// v(t) = 1/2 (-c_3 - λ) c_1 e^(1/2 t (-c_3 - λ)) + (1/2 (c_3 - λ)) c_2 e^(1/2 t (c_3 - λ))
+				// Now for simplicity we set x(0) = 0 and v(0) = v₀
+				// a/k + c_1 + c_2 = 0 → c_1 = -a/k - c_2
+				// (-c_3 - λ) c_1 + (c_3 - λ) c_2 = 2v₀
+				// → (-c_3 - λ) (-a/k - c_2) + (c_3 - λ) c_2 = 2v₀
+				// → (-c_3 - λ) (-a/k) - (-c_3 - λ)c_2 + (c_3 - λ) c_2 = 2v₀
+				// → ((c_3 - λ) - (-c_3 - λ))c_2 = 2v₀ - (c_3 + λ) (a/k)
+				// → (c_3 - λ + c_3 + λ)c_2 = 2v₀ - (c_3 + λ) (a/k)
+				// → 2 c_3 c_2 = 2v₀ - (c_3 + λ) (a/k)
+				// → c_2 = (2v₀ - (c_3 + λ) (a/k))/(2 c_3)
+				// → c_2 = v₀/c_3 - (1 + λ/c_3)/2 (a/k)
+				// In total we get:
+				// c_3 = sqrt(λ^2 - 4 k)
+				// c_2 = (2v₀ - (c_3 + λ) (a/k))/(2 c_3)
+				// c_1 = -a/k - c_2
+				const c_3 = vec.Complex.fromSqrt(frictionCoefficient*frictionCoefficient - 4*k);
+				const c_2 = (((c_3.addScalar(frictionCoefficient).mulScalar(-a/k)).addScalar(2*v_0)).div(c_3.mulScalar(2)));
+				const c_1 = c_2.addScalar(a/k).negate();
+				// v(t) = 1/2 (-c_3 - λ) c_1 e^(1/2 t (-c_3 - λ)) + (1/2 (c_3 - λ)) c_2 e^(1/2 t (c_3 - λ))
+				// x(t) = a/k + c_1 e^(1/2 t (-c_3 - λ)) + c_2 e^(1/2 t (c_3 - λ))
+				const firstTerm = c_1.mul((c_3.negate().subScalar(frictionCoefficient)).mulScalar(deltaTime/2).exp());
+				const secondTerm = c_2.mul((c_3.subScalar(frictionCoefficient)).mulScalar(deltaTime/2).exp());
+				eyeData.vel[i] = firstTerm.mul(c_3.negate().subScalar(frictionCoefficient).mulScalar(0.5)).add(secondTerm.mul((c_3.subScalar(frictionCoefficient)).mulScalar(0.5))).val[0];
+				eyeData.pos[i] += firstTerm.add(secondTerm).addScalar(a/k).val[0];
 			}
-			if (i == 2 and Player.eye.coyote > 0) {
-				break :blk;
-			}
-			const frictionCoefficient = directionalFrictionCoefficients[i];
-			const v_0 = Player.eye.vel[i];
-			const k = springConstants[i];
-			const a = acc[i];
-			// here we need to solve the full equation:
-			// The solution of this differential equation is given by
-			// x(t) = a/k + c_1 e^(1/2 t (-c_3 - λ)) + c_2 e^(1/2 t (c_3 - λ))
-			// With c_3 = sqrt(λ^2 - 4 k) which can be imaginary
-			// v(t) is just the derivative, given by
-			// v(t) = 1/2 (-c_3 - λ) c_1 e^(1/2 t (-c_3 - λ)) + (1/2 (c_3 - λ)) c_2 e^(1/2 t (c_3 - λ))
-			// Now for simplicity we set x(0) = 0 and v(0) = v₀
-			// a/k + c_1 + c_2 = 0 → c_1 = -a/k - c_2
-			// (-c_3 - λ) c_1 + (c_3 - λ) c_2 = 2v₀
-			// → (-c_3 - λ) (-a/k - c_2) + (c_3 - λ) c_2 = 2v₀
-			// → (-c_3 - λ) (-a/k) - (-c_3 - λ)c_2 + (c_3 - λ) c_2 = 2v₀
-			// → ((c_3 - λ) - (-c_3 - λ))c_2 = 2v₀ - (c_3 + λ) (a/k)
-			// → (c_3 - λ + c_3 + λ)c_2 = 2v₀ - (c_3 + λ) (a/k)
-			// → 2 c_3 c_2 = 2v₀ - (c_3 + λ) (a/k)
-			// → c_2 = (2v₀ - (c_3 + λ) (a/k))/(2 c_3)
-			// → c_2 = v₀/c_3 - (1 + λ/c_3)/2 (a/k)
-			// In total we get:
-			// c_3 = sqrt(λ^2 - 4 k)
-			// c_2 = (2v₀ - (c_3 + λ) (a/k))/(2 c_3)
-			// c_1 = -a/k - c_2
-			const c_3 = vec.Complex.fromSqrt(frictionCoefficient*frictionCoefficient - 4*k);
-			const c_2 = (((c_3.addScalar(frictionCoefficient).mulScalar(-a/k)).addScalar(2*v_0)).div(c_3.mulScalar(2)));
-			const c_1 = c_2.addScalar(a/k).negate();
-			// v(t) = 1/2 (-c_3 - λ) c_1 e^(1/2 t (-c_3 - λ)) + (1/2 (c_3 - λ)) c_2 e^(1/2 t (c_3 - λ))
-			// x(t) = a/k + c_1 e^(1/2 t (-c_3 - λ)) + c_2 e^(1/2 t (c_3 - λ))
-			const firstTerm = c_1.mul((c_3.negate().subScalar(frictionCoefficient)).mulScalar(deltaTime/2).exp());
-			const secondTerm = c_2.mul((c_3.subScalar(frictionCoefficient)).mulScalar(deltaTime/2).exp());
-			Player.eye.vel[i] = firstTerm.mul(c_3.negate().subScalar(frictionCoefficient).mulScalar(0.5)).add(secondTerm.mul((c_3.subScalar(frictionCoefficient)).mulScalar(0.5))).val[0];
-			Player.eye.pos[i] += firstTerm.add(secondTerm).addScalar(a/k).val[0];
 		}
 	}
 
-	if (!Player.isGhost.load(.monotonic)) {
-		Player.mutex.lock();
-		defer Player.mutex.unlock();
-
-		const hitBox = Player.outerBoundingBox;
-		var steppingHeight = Player.steppingHeight()[2];
-		if (Player.super.vel[2] > 0) {
-			steppingHeight = Player.super.vel[2]*Player.super.vel[2]/gravity/2;
+	if (input.hasCollision) {
+		const hitBox = input.boundingBox;
+		var steppingHeight = input.steppingHeight[2];
+		if (state.vel[2] > 0) {
+			steppingHeight = state.vel[2]*state.vel[2]/input.entityGravity/2;
 		}
-		steppingHeight = @min(steppingHeight, Player.eye.pos[2] - Player.eye.box.min[2]);
+		if (state.eye) |eyeData| {
+			steppingHeight = @min(steppingHeight, eyeData.pos[2] - eyeData.box.min[2]);
+		}
 
-		const slipLimit = 0.25*Player.currentFriction;
+		const slipLimit = 0.25*state.currentFriction;
 
-		const xMovement = collision.collideOrStep(.client, .x, move[0], Player.super.pos, hitBox, steppingHeight);
-		Player.super.pos += xMovement;
-		if (Player.crouching and Player.onGround and @abs(Player.super.vel[0]) < slipLimit) {
-			if (collision.collides(.client, .x, 0, Player.super.pos - Vec3d{0, 0, 1}, hitBox) == null) {
-				Player.super.pos -= xMovement;
-				Player.super.vel[0] = 0;
+		const xMovement = collision.collideOrStep(side, .x, move[0], state.pos, hitBox, steppingHeight);
+		state.pos += xMovement;
+		if (input.crouching and state.onGround and @abs(state.vel[0]) < slipLimit) {
+			if (collision.collides(side, .x, 0, state.pos - Vec3d{0, 0, 1}, hitBox) == null) {
+				state.pos -= xMovement;
+				state.vel[0] = 0;
 			}
 		}
 
-		const yMovement = collision.collideOrStep(.client, .y, move[1], Player.super.pos, hitBox, steppingHeight);
-		Player.super.pos += yMovement;
-		if (Player.crouching and Player.onGround and @abs(Player.super.vel[1]) < slipLimit) {
-			if (collision.collides(.client, .y, 0, Player.super.pos - Vec3d{0, 0, 1}, hitBox) == null) {
-				Player.super.pos -= yMovement;
-				Player.super.vel[1] = 0;
+		const yMovement = collision.collideOrStep(side, .y, move[1], state.pos, hitBox, steppingHeight);
+		state.pos += yMovement;
+		if (input.crouching and state.onGround and @abs(state.vel[1]) < slipLimit) {
+			if (collision.collides(side, .y, 0, state.pos - Vec3d{0, 0, 1}, hitBox) == null) {
+				state.pos -= yMovement;
+				state.vel[1] = 0;
 			}
 		}
 
 		if (xMovement[0] != move[0]) {
-			Player.super.vel[0] = 0;
+			state.vel[0] = 0;
 		}
 		if (yMovement[1] != move[1]) {
-			Player.super.vel[1] = 0;
+			state.vel[1] = 0;
 		}
 
 		const stepAmount = xMovement[2] + yMovement[2];
 		if (stepAmount > 0) {
-			if (Player.eye.coyote <= 0) {
-				Player.eye.vel[2] = @max(1.5*vec.length(Player.super.vel), Player.eye.vel[2], 4);
-				Player.eye.step[2] = true;
-				if (Player.super.vel[2] > 0) {
-					Player.eye.vel[2] = Player.super.vel[2];
-					Player.eye.step[2] = false;
+			if (state.eye) |eyeData| {
+				if (eyeData.coyote <= 0) {
+					eyeData.vel[2] = @max(1.5*vec.length(state.vel), eyeData.vel[2], 4);
+					eyeData.step[2] = true;
+					if (state.vel[2] > 0) {
+						eyeData.vel[2] = state.vel[2];
+						eyeData.step[2] = false;
+					}
+				} else {
+					eyeData.coyote = 0;
 				}
-			} else {
-				Player.eye.coyote = 0;
+				eyeData.pos[2] -= stepAmount;
 			}
-			Player.eye.pos[2] -= stepAmount;
 			move[2] = -0.01;
-			Player.onGround = true;
+			state.onGround = true;
 		}
 
-		const wasOnGround = Player.onGround;
-		Player.onGround = false;
-		Player.super.pos[2] += move[2];
-		if (collision.collides(.client, .z, -move[2], Player.super.pos, hitBox)) |box| {
+		const wasOnGround = state.onGround;
+		state.onGround = false;
+		state.pos[2] += move[2];
+		if (collision.collides(side, .z, -move[2], state.pos, hitBox)) |box| {
 			if (move[2] < 0) {
-				if (!wasOnGround) {
-					Player.eye.vel[2] = Player.super.vel[2];
-					Player.eye.pos[2] -= (box.max[2] - hitBox.min[2] - Player.super.pos[2]);
+				if (state.eye) |eyeData| {
+					if (!wasOnGround) {
+						eyeData.vel[2] = state.vel[2];
+						eyeData.pos[2] -= (box.max[2] - hitBox.min[2] - state.pos[2]);
+					}
+					eyeData.coyote = 0;
 				}
-				Player.onGround = true;
-				Player.super.pos[2] = box.max[2] - hitBox.min[2];
-				Player.eye.coyote = 0;
+				state.onGround = true;
+				state.pos[2] = box.max[2] - hitBox.min[2];
 			} else {
-				Player.super.pos[2] = box.min[2] - hitBox.max[2];
+				state.pos[2] = box.min[2] - hitBox.max[2];
 			}
-			var bounciness = if (Player.isFlying.load(.monotonic)) 0 else collision.calculateSurfaceProperties(.client, Player.super.pos, Player.outerBoundingBox, 0.0).bounciness;
-			if (Player.crouching) {
+			var bounciness = if (input.isFlying) 0 else collision.calculateSurfaceProperties(side, state.pos, input.boundingBox, 0.0).bounciness;
+			if (input.crouching) {
 				bounciness *= 0.5;
 			}
 			var velocityChange: f64 = undefined;
 
-			if (bounciness != 0.0 and Player.super.vel[2] < -3.0) {
-				velocityChange = Player.super.vel[2]*@as(f64, @floatCast(1 - bounciness));
-				Player.super.vel[2] = -Player.super.vel[2]*bounciness;
-				Player.jumpCoyote = Player.jumpCoyoteTimeConstant + deltaTime;
-				Player.eye.vel[2] *= 2;
+			if (bounciness != 0.0 and state.vel[2] < -3.0) {
+				velocityChange = state.vel[2]*@as(f64, @floatCast(1 - bounciness));
+				state.vel[2] = -state.vel[2]*bounciness;
+				state.jumpCoyote = Player.jumpCoyoteTimeConstant + deltaTime;
+				if (state.eye) |eyeData| {
+					eyeData.vel[2] *= 2;
+				}
 			} else {
-				velocityChange = Player.super.vel[2];
-				Player.super.vel[2] = 0;
+				velocityChange = state.vel[2];
+				state.vel[2] = 0;
 			}
-			const damage: f32 = @floatCast(@round(@max((velocityChange*velocityChange)/(2*gravity) - 7, 0))/2);
+			const damage: f32 = @floatCast(@round(@max((velocityChange*velocityChange)/(2*input.entityGravity) - 7, 0))/2);
 			if (damage > 0.01) {
-				main.sync.addHealth(-damage, .fall, .client, Player.id);
+				state.fallDamage += damage;
 			}
 
 			// Always unstuck upwards for now
-			while (collision.collides(.client, .z, 0, Player.super.pos, hitBox)) |_| {
-				Player.super.pos[2] += 1;
+			while (collision.collides(side, .z, 0, state.pos, hitBox)) |_| {
+				state.pos[2] += 1;
 			}
 		} else if (wasOnGround and move[2] < 0) {
-			// If the player drops off a ledge, they might just be walking over a small gap, so lock the y position of the eyes that long.
-			// This calculates how long the player has to fall until we know they're not walking over a small gap.
+			// If the entity drops off a ledge, they might just be walking over a small gap, so lock the y position of the eyes that long.
+			// This calculates how long the entity has to fall until we know they're not walking over a small gap.
 			// We add deltaTime because we subtract deltaTime at the bottom of update
-			Player.eye.coyote = @sqrt(2*Player.steppingHeight()[2]/gravity) + deltaTime;
-			Player.jumpCoyote = Player.jumpCoyoteTimeConstant + deltaTime;
-			Player.eye.pos[2] -= move[2];
-		} else if (Player.eye.coyote > 0) {
-			Player.eye.pos[2] -= move[2];
+			state.jumpCoyote = Player.jumpCoyoteTimeConstant + deltaTime;
+			if (state.eye) |eyeData| {
+				eyeData.coyote = @sqrt(2*input.steppingHeight[2]/input.entityGravity) + deltaTime;
+				eyeData.pos[2] -= move[2];
+			}
+		} else if (state.eye) |eyeData| {
+			if (eyeData.coyote > 0) {
+				eyeData.pos[2] -= move[2];
+			}
 		}
-		collision.touchBlocks(&Player.super, hitBox, .client, deltaTime);
+		if (input.runTouchBlocks) {
+			if (input.entity) |entity| {
+				collision.touchBlocks(entity, hitBox, side, deltaTime);
+			}
+		}
 	} else {
-		Player.super.pos += move;
+		state.pos += move;
 	}
 
-	// Clamp the eye.position and subtract eye coyote time.
-	Player.eye.pos = @max(Player.eye.box.min, @min(Player.eye.pos, Player.eye.box.max));
-	Player.eye.coyote -= deltaTime;
-	Player.jumpCoyote -= deltaTime;
+	// Clamp the eye position and subtract eye coyote time.
+	if (state.eye) |eyeData| {
+		eyeData.pos = @max(eyeData.box.min, @min(eyeData.pos, eyeData.box.max));
+		eyeData.coyote -= deltaTime;
+	}
+	state.jumpCoyote -= deltaTime;
 }


### PR DESCRIPTION
Extracts PhysicsState and InputState structs in physics.zig so that calculateProperties() and update() operate on struct parameters instead of reading/writing Player globals directly. This is a pure refactor with no behavior change.

This is prep work for #1663, once the physics functions take generic structs, item drops and particles can reuse the same code path instead of duplicating collision/friction/gravity logic.

Follow up PR will migrate item drops and particles to use the shared functions.