### PR TITLE
Fix block breaking animation staying after switching to creative and breaking a block

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -1109,7 +1109,6 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 				mesh_storage.removeBreakingAnimation(lastSelectedBlockPos);
 			}
 
-
 			var newBlock = block;
 			block.mode().onBlockBreaking(inventory.getStack(slot).item, relPos, lastDir, &newBlock);
 			main.sync.ClientSide.mutex.unlock();


### PR DESCRIPTION
<img width="1920" height="1080" alt="Screenshot_20260320_180955" src="https://github.com/user-attachments/assets/bd1d8f24-2741-46c1-8207-9562927a7bc3" />

I plan to also do #1048 in the future, but I think that should be a separate pr