### PR TITLE
Introduce new Sync command CraftTool and remove Inventory.Type

### DIFF
--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -396,7 +396,7 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 		serverShared: void,
 		creative: void,
 		crafting: *const main.items.Recipe,
-		workbenchResult: *ClientInventory,
+		workbenchResult: ClientInventory,
 	};
 	super: Inventory,
 	type: ClientType,
@@ -504,7 +504,7 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 		std.debug.assert(source.type == .workbenchResult);
 		for (destinations) |inv| std.debug.assert(inv.type == .serverShared);
 
-		main.sync.ClientSide.executeCommand(.{.craftTool = .init(destinations, source.type.workbenchResult.*)});
+		main.sync.ClientSide.executeCommand(.{.craftTool = .init(destinations, source.type.workbenchResult)});
 	}
 
 	pub fn placeBlock(self: ClientInventory, slot: u32) void {

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -605,9 +605,11 @@ pub const CanHoldReturn = union(enum) {
 
 pub fn canHold(self: Inventory, sourceStack: ItemStack) CanHoldReturn {
 	if (sourceStack.amount == 0) return .yes;
+	if (self.source == .workbench and !sync.Command.canPutIntoWorkbench(sourceStack.item)) return .{.remainingAmount = sourceStack.amount};
 
 	var remainingAmount = sourceStack.amount;
-	for (self._items) |*destStack| {
+	for (self._items, 0..) |*destStack, destSlot| {
+		if (self.source == .workbench and self.source.workbench.toolIndex.slotInfos()[destSlot].disabled) continue;
 		if (std.meta.eql(destStack.item, sourceStack.item) or destStack.item == .null) {
 			const amount = @min(sourceStack.item.stackSize() - destStack.amount, remainingAmount);
 			remainingAmount -= amount;
@@ -761,9 +763,11 @@ pub const Inventories = struct { // MARK: Inventories
 		var selectedEmptyInv: ?Inventory = null;
 
 		outer: for (self.inventories) |dest| {
+			if (dest.source == .workbench and !sync.Command.canPutIntoWorkbench(item)) continue;
 			var emptySlot: ?u32 = null;
 			var hasItem = false;
 			for (dest._items, 0..) |*destStack, destSlot| {
+				if (dest.source == .workbench and dest.source.workbench.toolIndex.slotInfos()[destSlot].disabled) continue;
 				if (destStack.item == .null and emptySlot == null) {
 					emptySlot = @intCast(destSlot);
 					if (selectedEmptySlot == null) {

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -68,6 +68,15 @@ pub const ClientSide = struct {
 		main.utils.assertLocked(&main.sync.ClientSide.mutex);
 		return serverToClientMap.get(serverId);
 	}
+
+	fn getInventoryByClientId(clientId: InventoryId) ?Inventory {
+		main.utils.assertLocked(&main.sync.ClientSide.mutex);
+		var it = serverToClientMap.valueIterator();
+		while (it.next()) |inv| {
+			if (inv.id == clientId) return inv.*;
+		}
+		return null;
+	}
 };
 
 pub const ServerSide = struct { // MARK: ServerSide
@@ -503,13 +512,13 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 	pub fn craftTool(source: ClientInventory, destinations: []const ClientInventory) void {
 		std.debug.assert(source.type == .workbenchResult);
 		for (destinations) |inv| std.debug.assert(inv.type == .serverShared);
-		const workbenchResultInv = blk: {
+		const workbenchInv = blk: {
 			main.sync.ClientSide.mutex.lock();
 			defer main.sync.ClientSide.mutex.unlock();
-			break :blk getInventory(source.type.workbenchResult, .client, null);
+			break :blk ClientSide.getInventoryByClientId(source.type.workbenchResult);
 		} orelse return;
 
-		main.sync.ClientSide.executeCommand(.{.craftTool = .init(destinations, workbenchResultInv)});
+		main.sync.ClientSide.executeCommand(.{.craftTool = .init(destinations, workbenchInv)});
 	}
 
 	pub fn placeBlock(self: ClientInventory, slot: u32) void {

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -427,6 +427,13 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 			carried.fillFromCreative(0, dest.getItem(destSlot));
 			return;
 		}
+		if (dest.type == .workbenchResult) {
+			dest.craftTool(&.{carried});
+			return;
+		}
+		if (carried.type == .workbenchResult) {
+			carried.craftTool(&.{dest});
+		}
 		std.debug.assert(dest.type == .serverShared);
 		main.sync.ClientSide.executeCommand(.{.depositOrSwap = .{.dest = .{.inv = dest.super, .slot = destSlot}, .source = .{.inv = carried.super, .slot = 0}}});
 	}
@@ -445,6 +452,9 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 		if (carried.type == .creative) {
 			carried.fillFromCreative(0, source.getItem(sourceSlot));
 			return;
+		}
+		if (source.type == .workbenchResult) {
+			source.craftTool(&.{carried});
 		}
 		main.sync.ClientSide.executeCommand(.{.takeHalf = .{.dest = .{.inv = carried.super, .slot = 0}, .source = .{.inv = source.super, .slot = sourceSlot}}});
 	}
@@ -497,6 +507,13 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 		std.debug.assert(craftingInv.type == .crafting);
 
 		main.sync.ClientSide.executeCommand(.{.craftFrom = .init(destinations, &.{source}, craftingInv.type.crafting)});
+	}
+
+	pub fn craftTool(source: ClientInventory, destinations: []const ClientInventory) void {
+		std.debug.assert(source.type == .workbenchResult);
+		for (destinations) |inv| std.debug.assert(inv.type == .serverShared);
+
+		main.sync.ClientSide.executeCommand(.{.craftTool = .init(destinations, main.gui.windowlist.workbench.craftingGridInv)});
 	}
 
 	pub fn placeBlock(self: ClientInventory, slot: u32) void {

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -79,10 +79,10 @@ pub const ServerSide = struct { // MARK: ServerSide
 
 		const Managed = enum { internallyManaged, externallyManaged };
 
-		fn init(len: usize, typ: Inventory.Type, source: Source, managed: Managed, callbacks: Callbacks) ServerInventory {
+		fn init(len: usize, source: Source, managed: Managed, callbacks: Callbacks) ServerInventory {
 			main.utils.assertLocked(&inventoryCreationMutex);
 			return .{
-				.inv = Inventory._init(main.globalAllocator, len, typ, source, .server, callbacks),
+				.inv = Inventory._init(main.globalAllocator, len, source, .server, callbacks),
 				.users = .{},
 				.source = source,
 				.managed = managed,
@@ -183,10 +183,10 @@ pub const ServerSide = struct { // MARK: ServerSide
 		freeIdList.append(id);
 	}
 
-	pub fn createExternallyManagedInventory(len: usize, typ: Inventory.Type, source: Source, data: *BinaryReader, callbacks: Callbacks) InventoryId {
+	pub fn createExternallyManagedInventory(len: usize, source: Source, data: *BinaryReader, callbacks: Callbacks) InventoryId {
 		inventoryCreationMutex.lock();
 		defer inventoryCreationMutex.unlock();
-		const inventory = ServerInventory.init(len, typ, source, .externallyManaged, callbacks);
+		const inventory = ServerInventory.init(len, source, .externallyManaged, callbacks);
 		inventories.items()[@intFromEnum(inventory.inv.id)] = inventory;
 		inventory.inv.fromBytes(data);
 		return inventory.inv.id;
@@ -224,7 +224,7 @@ pub const ServerSide = struct { // MARK: ServerSide
 		inv.deinit();
 	}
 
-	pub fn createInventory(user: *main.server.User, clientId: InventoryId, len: usize, typ: Inventory.Type, source: Source) !void {
+	pub fn createInventory(user: *main.server.User, clientId: InventoryId, len: usize, source: Source) !void {
 		sync.threadContext.assertCorrectContext(.server);
 		var callbacks: Callbacks = .{};
 		switch (source) {
@@ -272,7 +272,7 @@ pub const ServerSide = struct { // MARK: ServerSide
 		}
 
 		inventoryCreationMutex.lock();
-		const inventory = ServerInventory.init(len, typ, source, .internallyManaged, callbacks);
+		const inventory = ServerInventory.init(len, source, .internallyManaged, callbacks);
 		inventoryCreationMutex.unlock();
 
 		inventories.items()[@intFromEnum(inventory.inv.id)] = inventory;
@@ -401,9 +401,9 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 	super: Inventory,
 	type: ClientType,
 
-	pub fn init(allocator: NeverFailingAllocator, _size: usize, _type: Type, clientType: ClientType, source: Source, callbacks: Callbacks) ClientInventory {
+	pub fn init(allocator: NeverFailingAllocator, _size: usize, clientType: ClientType, source: Source, callbacks: Callbacks) ClientInventory {
 		const self: ClientInventory = .{
-			.super = Inventory._init(allocator, _size, _type, source, .client, callbacks),
+			.super = Inventory._init(allocator, _size, source, .client, callbacks),
 			.type = clientType,
 		};
 		if (clientType == .serverShared) {
@@ -475,7 +475,6 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 
 	pub fn depositToAny(source: ClientInventory, sourceSlot: u32, destinations: []const ClientInventory, amount: u16) void {
 		std.debug.assert(source.type == .serverShared);
-		for (destinations) |inv| std.debug.assert(inv.super.type == .normal);
 		main.sync.ClientSide.executeCommand(.{.depositToAny = .init(destinations, .{.inv = source.super, .slot = sourceSlot}, amount)});
 	}
 
@@ -545,25 +544,13 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 
 const Inventory = @This(); // MARK: Inventory
 
-pub const TypeEnum = enum(u8) {
-	normal = 0,
-	workbench = 3,
-};
-pub const Type = union(TypeEnum) {
-	normal: void,
-	workbench: ToolTypeIndex,
-};
-
-type: Type,
 id: InventoryId,
 _items: []ItemStack,
 source: Source,
 callbacks: Callbacks,
 
-fn _init(allocator: NeverFailingAllocator, _size: usize, _type: Type, source: Source, side: sync.Side, callbacks: Callbacks) Inventory {
-	if (_type == .workbench) std.debug.assert(_size == 26);
+fn _init(allocator: NeverFailingAllocator, _size: usize, source: Source, side: sync.Side, callbacks: Callbacks) Inventory {
 	const self = Inventory{
-		.type = _type,
 		._items = allocator.alloc(ItemStack, _size),
 		.id = switch (side) {
 			.client => ClientSide.nextId(),
@@ -590,34 +577,7 @@ pub fn _deinit(self: Inventory, allocator: NeverFailingAllocator, side: sync.Sid
 }
 
 pub fn update(self: Inventory) void {
-	defer if (self.callbacks.onUpdateCallback) |cb| cb(self.source);
-	if (self.type == .workbench) {
-		self._items[self._items.len - 1].deinit();
-		self._items[self._items.len - 1] = .{};
-		var availableItems: [25]?BaseItemIndex = undefined;
-		const slotInfos = self.type.workbench.slotInfos();
-
-		for (0..25) |i| {
-			if (self._items[i].item == .baseItem) {
-				availableItems[i] = self._items[i].item.baseItem;
-			} else {
-				if (!slotInfos[i].optional and !slotInfos[i].disabled) {
-					return;
-				}
-				availableItems[i] = null;
-			}
-		}
-		var hash = std.hash.Crc32.init();
-		for (availableItems) |item| {
-			if (item != null) {
-				hash.update(item.?.id());
-			} else {
-				hash.update("none");
-			}
-		}
-		self._items[self._items.len - 1].item = Item{.tool = Tool.initFromCraftingGrid(availableItems, hash.final(), self.type.workbench)};
-		self._items[self._items.len - 1].amount = 1;
-	}
+	if (self.callbacks.onUpdateCallback) |cb| cb(self.source);
 }
 
 pub fn size(self: Inventory) usize {

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -396,7 +396,7 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 		serverShared: void,
 		creative: void,
 		crafting: *const main.items.Recipe,
-		workbenchResult: void,
+		workbenchResult: *ClientInventory,
 	};
 	super: Inventory,
 	type: ClientType,
@@ -504,7 +504,7 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 		std.debug.assert(source.type == .workbenchResult);
 		for (destinations) |inv| std.debug.assert(inv.type == .serverShared);
 
-		main.sync.ClientSide.executeCommand(.{.craftTool = .init(destinations, main.gui.windowlist.workbench.craftingGridInv)});
+		main.sync.ClientSide.executeCommand(.{.craftTool = .init(destinations, source.type.workbenchResult.*)});
 	}
 
 	pub fn placeBlock(self: ClientInventory, slot: u32) void {

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -423,16 +423,13 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 	}
 
 	pub fn depositOrSwap(dest: ClientInventory, destSlot: u32, carried: ClientInventory) void {
+		std.debug.assert(carried.type == .serverShared);
 		if (dest.type == .creative) {
 			carried.fillFromCreative(0, dest.getItem(destSlot));
 			return;
 		}
 		if (dest.type == .workbenchResult) {
 			dest.craftTool(&.{carried});
-			return;
-		}
-		if (carried.type == .workbenchResult) {
-			carried.craftTool(&.{dest});
 			return;
 		}
 		std.debug.assert(dest.type == .serverShared);

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -387,16 +387,12 @@ pub const Source = union(SourceType) {
 	playerInventory: u32,
 	hand: u32,
 	blockInventory: Vec3i,
-	workbench: struct { playerId: u32 },
+	workbench: struct { playerId: u32, toolIndex: ToolTypeIndex },
 	other: void,
 };
 
 pub const ClientInventory = struct { // MARK: ClientInventory
-	const ClientType = union(enum) {
-		serverShared: void,
-		creative: void,
-		crafting: *const main.items.Recipe,
-	};
+	const ClientType = union(enum) { serverShared: void, creative: void, crafting: *const main.items.Recipe, workbenchResult: void };
 	super: Inventory,
 	type: ClientType,
 

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -396,7 +396,7 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 		serverShared: void,
 		creative: void,
 		crafting: *const main.items.Recipe,
-		workbenchResult: ClientInventory,
+		workbenchResult: InventoryId,
 	};
 	super: Inventory,
 	type: ClientType,
@@ -503,8 +503,13 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 	pub fn craftTool(source: ClientInventory, destinations: []const ClientInventory) void {
 		std.debug.assert(source.type == .workbenchResult);
 		for (destinations) |inv| std.debug.assert(inv.type == .serverShared);
+		const workbenchResultInv = blk: {
+			main.sync.ClientSide.mutex.lock();
+			defer main.sync.ClientSide.mutex.unlock();
+			break :blk getInventory(source.type.workbenchResult, .client, null);
+		} orelse return;
 
-		main.sync.ClientSide.executeCommand(.{.craftTool = .init(destinations, source.type.workbenchResult)});
+		main.sync.ClientSide.executeCommand(.{.craftTool = .init(destinations, workbenchResultInv)});
 	}
 
 	pub fn placeBlock(self: ClientInventory, slot: u32) void {

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -428,10 +428,6 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 			carried.fillFromCreative(0, dest.getItem(destSlot));
 			return;
 		}
-		if (dest.type == .workbenchResult) {
-			dest.craftTool(&.{carried});
-			return;
-		}
 		std.debug.assert(dest.type == .serverShared);
 		main.sync.ClientSide.executeCommand(.{.depositOrSwap = .{.dest = .{.inv = dest.super, .slot = destSlot}, .source = .{.inv = carried.super, .slot = 0}}});
 	}
@@ -451,10 +447,7 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 			carried.fillFromCreative(0, source.getItem(sourceSlot));
 			return;
 		}
-		if (source.type == .workbenchResult) {
-			source.craftTool(&.{carried});
-			return;
-		}
+		std.debug.assert(carried.type == .serverShared);
 		main.sync.ClientSide.executeCommand(.{.takeHalf = .{.dest = .{.inv = carried.super, .slot = 0}, .source = .{.inv = source.super, .slot = sourceSlot}}});
 	}
 

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -433,6 +433,7 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 		}
 		if (carried.type == .workbenchResult) {
 			carried.craftTool(&.{dest});
+			return;
 		}
 		std.debug.assert(dest.type == .serverShared);
 		main.sync.ClientSide.executeCommand(.{.depositOrSwap = .{.dest = .{.inv = dest.super, .slot = destSlot}, .source = .{.inv = carried.super, .slot = 0}}});

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -456,6 +456,7 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 		}
 		if (source.type == .workbenchResult) {
 			source.craftTool(&.{carried});
+			return;
 		}
 		main.sync.ClientSide.executeCommand(.{.takeHalf = .{.dest = .{.inv = carried.super, .slot = 0}, .source = .{.inv = source.super, .slot = sourceSlot}}});
 	}

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -392,7 +392,12 @@ pub const Source = union(SourceType) {
 };
 
 pub const ClientInventory = struct { // MARK: ClientInventory
-	const ClientType = union(enum) { serverShared: void, creative: void, crafting: *const main.items.Recipe, workbenchResult: void };
+	const ClientType = union(enum) {
+		serverShared: void,
+		creative: void,
+		crafting: *const main.items.Recipe,
+		workbenchResult: void,
+	};
 	super: Inventory,
 	type: ClientType,
 

--- a/src/block_entity.zig
+++ b/src/block_entity.zig
@@ -225,7 +225,7 @@ pub const BlockEntityTypes = struct {
 
 			const data = StorageServer.getOrPut(pos, chunk);
 			std.debug.assert(!data.foundExisting);
-			data.valuePtr.invId = main.items.Inventory.ServerSide.createExternallyManagedInventory(inventorySize, .normal, .{.blockInventory = pos}, reader, inventoryCallbacks);
+			data.valuePtr.invId = main.items.Inventory.ServerSide.createExternallyManagedInventory(inventorySize, .{.blockInventory = pos}, reader, inventoryCallbacks);
 		}
 
 		pub fn onUnloadServer(dataIndex: BlockEntityIndex) void {
@@ -251,7 +251,7 @@ pub const BlockEntityTypes = struct {
 		pub fn onInteract(pos: Vec3i, _: *Chunk) main.callbacks.Result {
 			main.network.protocols.blockEntityUpdate.sendClientDataUpdateToServer(main.game.world.?.conn, pos);
 
-			const inventory = main.items.Inventory.ClientInventory.init(main.globalAllocator, inventorySize, .normal, .serverShared, .{.blockInventory = pos}, .{});
+			const inventory = main.items.Inventory.ClientInventory.init(main.globalAllocator, inventorySize, .serverShared, .{.blockInventory = pos}, .{});
 
 			main.gui.windowlist.chest.setInventory(inventory);
 			main.gui.openWindow("chest");
@@ -273,7 +273,7 @@ pub const BlockEntityTypes = struct {
 					const data = StorageServer.getOrPut(pos, chunk);
 					if (data.foundExisting) return;
 					var reader = BinaryReader.init(&.{});
-					data.valuePtr.invId = main.items.Inventory.ServerSide.createExternallyManagedInventory(inventorySize, .normal, .{.blockInventory = pos}, &reader, inventoryCallbacks);
+					data.valuePtr.invId = main.items.Inventory.ServerSide.createExternallyManagedInventory(inventorySize, .{.blockInventory = pos}, &reader, inventoryCallbacks);
 				},
 			}
 		}

--- a/src/game.zig
+++ b/src/game.zig
@@ -692,7 +692,7 @@ pub const World = struct { // MARK: World
 		defer main.stackAllocator.free(path);
 		try assets.loadWorldAssets(path, self.blockPalette, self.itemPalette, self.toolPalette, self.biomePalette);
 		Player.id = zon.get(u32, "player_id", std.math.maxInt(u32));
-		Player.inventory = ClientInventory.init(main.globalAllocator, Player.inventorySize, .normal, .serverShared, .{.playerInventory = Player.id}, .{});
+		Player.inventory = ClientInventory.init(main.globalAllocator, Player.inventorySize, .serverShared, .{.playerInventory = Player.id}, .{});
 		Player.loadFrom(zon.getChild("player"));
 		self.playerBiome = .init(main.server.terrain.biomes.getPlaceholderBiome());
 		main.audio.setMusic(self.playerBiome.raw.preferredMusic);

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -743,7 +743,7 @@ pub const inventory = struct { // MARK: inventory
 				carried.distribute(targetInventories, targetSlots);
 				leftClickSlots.clearRetainingCapacity();
 			} else if (hoveredItemSlot) |hovered| {
-				if (hovered.inventory.type == .crafting) return;
+				if (hovered.inventory.type == .crafting or hovered.inventory.type == .workbenchResult) return;
 				if (main.KeyBoard.key("mainGuiButton").modsOnPress.shift) {
 					if (hovered.inventory.type == .creative) {
 						const item = hovered.inventory.getItem(hovered.itemSlot);

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -655,10 +655,7 @@ pub const inventory = struct { // MARK: inventory
 		if (itemSlot.mode == .immutable) return;
 		const mainGuiButton = main.KeyBoard.key("mainGuiButton");
 		const secondaryGuiButton = main.KeyBoard.key("secondaryGuiButton");
-		if (itemSlot.inventory.type == .crafting and itemSlot.mode == .takeOnly and mainGuiButton.pressed and (recipeItem != .null or itemSlot.pressed)) {
-			const item = itemSlot.inventory.getItem(itemSlot.itemSlot);
-			if (recipeItem == .null and item != .null) recipeItem = item.clone();
-			if (!std.meta.eql(item, recipeItem)) return;
+		if ((itemSlot.inventory.type == .crafting or itemSlot.inventory.type == .workbenchResult) and itemSlot.mode == .takeOnly and mainGuiButton.pressed and (recipeItem != .null or itemSlot.pressed)) {
 			const time = main.timestamp();
 			if (!isCrafting) {
 				isCrafting = true;
@@ -668,10 +665,22 @@ pub const inventory = struct { // MARK: inventory
 			while (time.durationTo(nextCraftingAction).nanoseconds <= 0) {
 				nextCraftingAction = nextCraftingAction.addDuration(craftingCooldown);
 				craftingCooldown.nanoseconds -= @divTrunc((craftingCooldown.nanoseconds -% minCraftingCooldown.nanoseconds)*craftingCooldown.nanoseconds, std.time.ns_per_s);
-				if (mainGuiButton.modsOnPress.shift) {
-					main.game.Player.inventory.craftFrom(&.{main.game.Player.inventory}, itemSlot.inventory);
-				} else {
-					main.game.Player.inventory.craftFrom(&.{carried}, itemSlot.inventory);
+
+				if (itemSlot.inventory.type == .crafting) {
+					const item = itemSlot.inventory.getItem(itemSlot.itemSlot);
+					if (recipeItem == .null and item != .null) recipeItem = item.clone();
+					if (!std.meta.eql(item, recipeItem)) return;
+					if (mainGuiButton.modsOnPress.shift) {
+						main.game.Player.inventory.craftFrom(&.{main.game.Player.inventory}, itemSlot.inventory);
+					} else {
+						main.game.Player.inventory.craftFrom(&.{carried}, itemSlot.inventory);
+					}
+				} else if (itemSlot.inventory.type == .workbenchResult) {
+					if (mainGuiButton.modsOnPress.shift) {
+						itemSlot.inventory.craftTool(&.{main.game.Player.inventory});
+					} else {
+						itemSlot.inventory.craftTool(&.{carried});
+					}
 				}
 			}
 			return;

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -760,7 +760,7 @@ pub const inventory = struct { // MARK: inventory
 			if (rightClickSlots.items.len != 0) {
 				rightClickSlots.clearRetainingCapacity();
 			} else if (hoveredItemSlot) |hovered| {
-				if (hovered.inventory.type == .crafting) return;
+				if (hovered.inventory.type == .crafting or hovered.inventory.type == .workbenchResult) return;
 				if (hovered.inventory.type == .creative) {
 					carried.deposit(0, hovered.inventory, hovered.itemSlot, 1);
 				} else {

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -609,7 +609,7 @@ pub const inventory = struct { // MARK: inventory
 	var isCrafting: bool = false;
 
 	pub fn init() void {
-		carried = ClientInventory.init(main.globalAllocator, 1, .normal, .serverShared, .{.hand = main.game.Player.id}, .{});
+		carried = ClientInventory.init(main.globalAllocator, 1, .serverShared, .{.hand = main.game.Player.id}, .{});
 		carriedItemSlot = ItemSlot.init(.{0, 0}, carried, 0, .default, .normal);
 		carriedItemSlot.renderFrame = false;
 		initialized = true;

--- a/src/gui/windows/creative_inventory.zig
+++ b/src/gui/windows/creative_inventory.zig
@@ -98,7 +98,7 @@ fn initContent() void {
 
 		std.mem.sort(Item, items.items, {}, lessThan);
 		const slotCount = items.items.len + (slotsPerRow - items.items.len%slotsPerRow);
-		inventory = ClientInventory.init(main.globalAllocator, slotCount, .normal, .creative, .other, .{});
+		inventory = ClientInventory.init(main.globalAllocator, slotCount, .creative, .other, .{});
 		for (0..items.items.len) |i| {
 			inventory.super._items[i] = .{.item = items.items[i], .amount = 1};
 		}

--- a/src/gui/windows/inventory_crafting.zig
+++ b/src/gui/windows/inventory_crafting.zig
@@ -94,7 +94,7 @@ fn findAvailableRecipes(list: *VerticalList) bool {
 			continue :outer; // Ingredient not found.
 		}
 		// All ingredients found: Add it to the list.
-		const inv = ClientInventory.init(main.globalAllocator, recipe.sourceItems.len + 1, .normal, .{.crafting = recipe}, .other, .{});
+		const inv = ClientInventory.init(main.globalAllocator, recipe.sourceItems.len + 1, .{.crafting = recipe}, .other, .{});
 
 		for (0..recipe.sourceAmounts.len) |index| {
 			inv.super._items[index].amount = recipe.sourceAmounts[index];

--- a/src/gui/windows/workbench.zig
+++ b/src/gui/windows/workbench.zig
@@ -35,7 +35,7 @@ pub var window = GuiWindow{
 
 const padding: f32 = 8;
 
-var craftingGridInv: ClientInventory = undefined;
+pub var craftingGridInv: ClientInventory = undefined;
 var craftingResultInv: ClientInventory = undefined;
 
 var itemSlots: [25]*ItemSlot = undefined;
@@ -59,8 +59,8 @@ fn updateResult(_: main.items.Inventory.Source) void {
 	const slotInfos = toolTypes.items[currentToolType].slotInfos();
 
 	for (0..25) |i| {
-		if (craftingGridInv._items[i].item == .baseItem) {
-			availableItems[i] = craftingGridInv._items[i].item.baseItem;
+		if (craftingGridInv.super._items[i].item == .baseItem) {
+			availableItems[i] = craftingGridInv.super._items[i].item.baseItem;
 		} else {
 			if (!slotInfos[i].optional and !slotInfos[i].disabled) {
 				return;
@@ -76,12 +76,12 @@ fn updateResult(_: main.items.Inventory.Source) void {
 			hash.update("none");
 		}
 	}
-	craftingResultInv._items[0] = Item{.tool = main.items.Tool.initFromCraftingGrid(availableItems, hash.final(), toolTypes.items[currentToolType])};
+	craftingResultInv.super._items[0] = .{.item = Item{.tool = main.items.Tool.initFromCraftingGrid(availableItems, hash.final(), toolTypes.items[currentToolType])}, .amount = 1};
 }
 
 fn openInventory() void {
-	craftingGridInv = ClientInventory.init(main.globalAllocator, 25, .normal, .serverShared, .{.workbench = .{.playerId = main.game.Player.id, .toolIndex = toolTypes[currentToolType]}}, .{});
-	craftingResultInv = ClientInventory.init(main.globalAllocator, 1, .normal, .workbenchResult, .other, .{.onUpdateCallback = &updateResult});
+	craftingGridInv = ClientInventory.init(main.globalAllocator, 25, .normal, .serverShared, .{.workbench = .{.playerId = main.game.Player.id, .toolIndex = toolTypes.items[currentToolType]}}, .{.onUpdateCallback = &updateResult});
+	craftingResultInv = ClientInventory.init(main.globalAllocator, 1, .normal, .workbenchResult, .other, .{});
 	const list = HorizontalList.init();
 	{ // crafting grid
 		const grid = VerticalList.init(.{0, 0}, 300, 0);
@@ -119,7 +119,7 @@ fn openInventory() void {
 }
 
 fn closeInventory() void {
-	craftingResultInv.deinit(main.globalAllocator);
+	craftingGridInv.deinit(main.globalAllocator);
 	craftingResultInv.deinit(main.globalAllocator);
 	if (window.rootComponent) |*comp| {
 		comp.deinit();

--- a/src/gui/windows/workbench.zig
+++ b/src/gui/windows/workbench.zig
@@ -82,8 +82,8 @@ fn updateResult(_: main.items.Inventory.Source) void {
 }
 
 fn openInventory() void {
-	craftingGridInv = ClientInventory.init(main.globalAllocator, 25, .normal, .serverShared, .{.workbench = .{.playerId = main.game.Player.id, .toolIndex = toolTypes.items[currentToolType]}}, .{.onUpdateCallback = &updateResult});
-	craftingResultInv = ClientInventory.init(main.globalAllocator, 1, .normal, .workbenchResult, .other, .{});
+	craftingGridInv = ClientInventory.init(main.globalAllocator, 25, .serverShared, .{.workbench = .{.playerId = main.game.Player.id, .toolIndex = toolTypes.items[currentToolType]}}, .{.onUpdateCallback = &updateResult});
+	craftingResultInv = ClientInventory.init(main.globalAllocator, 1, .workbenchResult, .other, .{});
 	const list = HorizontalList.init();
 	{ // crafting grid
 		const grid = VerticalList.init(.{0, 0}, 300, 0);

--- a/src/gui/windows/workbench.zig
+++ b/src/gui/windows/workbench.zig
@@ -57,28 +57,7 @@ fn toggleTool() void {
 fn updateResult(_: main.items.Inventory.Source) void {
 	craftingResultInv.super._items[0].deinit();
 	craftingResultInv.super._items[0] = .{};
-	var availableItems: [25]?main.items.BaseItemIndex = undefined;
-	const slotInfos = toolTypes.items[currentToolType].slotInfos();
-
-	for (0..25) |i| {
-		if (craftingGridInv.super._items[i].item == .baseItem) {
-			availableItems[i] = craftingGridInv.super._items[i].item.baseItem;
-		} else {
-			if (!slotInfos[i].optional and !slotInfos[i].disabled) {
-				return;
-			}
-			availableItems[i] = null;
-		}
-	}
-	var hash = std.hash.Crc32.init();
-	for (availableItems) |item| {
-		if (item != null) {
-			hash.update(item.?.id());
-		} else {
-			hash.update("none");
-		}
-	}
-	craftingResultInv.super._items[0] = .{.item = Item{.tool = main.items.Tool.initFromCraftingGrid(availableItems, hash.final(), toolTypes.items[currentToolType])}, .amount = 1};
+	craftingResultInv.super._items[0] = .{.item = Item{.tool = main.items.Tool.initFromInventory(craftingGridInv.super) orelse return}, .amount = 1};
 }
 
 fn openInventory() void {

--- a/src/gui/windows/workbench.zig
+++ b/src/gui/windows/workbench.zig
@@ -62,7 +62,7 @@ fn updateResult(_: main.items.Inventory.Source) void {
 
 fn openInventory() void {
 	craftingGridInv = ClientInventory.init(main.globalAllocator, 25, .serverShared, .{.workbench = .{.playerId = main.game.Player.id, .toolIndex = toolTypes.items[currentToolType]}}, .{.onUpdateCallback = &updateResult});
-	craftingResultInv = ClientInventory.init(main.globalAllocator, 1, .workbenchResult, .other, .{});
+	craftingResultInv = ClientInventory.init(main.globalAllocator, 1, .{.workbenchResult = &craftingGridInv}, .other, .{});
 	const list = HorizontalList.init();
 	{ // crafting grid
 		const grid = VerticalList.init(.{0, 0}, 300, 0);

--- a/src/gui/windows/workbench.zig
+++ b/src/gui/windows/workbench.zig
@@ -62,7 +62,7 @@ fn updateResult(_: main.items.Inventory.Source) void {
 
 fn openInventory() void {
 	craftingGridInv = ClientInventory.init(main.globalAllocator, 25, .serverShared, .{.workbench = .{.playerId = main.game.Player.id, .toolIndex = toolTypes.items[currentToolType]}}, .{.onUpdateCallback = &updateResult});
-	craftingResultInv = ClientInventory.init(main.globalAllocator, 1, .{.workbenchResult = craftingGridInv}, .other, .{});
+	craftingResultInv = ClientInventory.init(main.globalAllocator, 1, .{.workbenchResult = craftingGridInv.super.id}, .other, .{});
 	const list = HorizontalList.init();
 	{ // crafting grid
 		const grid = VerticalList.init(.{0, 0}, 300, 0);

--- a/src/gui/windows/workbench.zig
+++ b/src/gui/windows/workbench.zig
@@ -62,7 +62,7 @@ fn updateResult(_: main.items.Inventory.Source) void {
 
 fn openInventory() void {
 	craftingGridInv = ClientInventory.init(main.globalAllocator, 25, .serverShared, .{.workbench = .{.playerId = main.game.Player.id, .toolIndex = toolTypes.items[currentToolType]}}, .{.onUpdateCallback = &updateResult});
-	craftingResultInv = ClientInventory.init(main.globalAllocator, 1, .{.workbenchResult = &craftingGridInv}, .other, .{});
+	craftingResultInv = ClientInventory.init(main.globalAllocator, 1, .{.workbenchResult = craftingGridInv}, .other, .{});
 	const list = HorizontalList.init();
 	{ // crafting grid
 		const grid = VerticalList.init(.{0, 0}, 300, 0);

--- a/src/gui/windows/workbench.zig
+++ b/src/gui/windows/workbench.zig
@@ -55,6 +55,8 @@ fn toggleTool() void {
 }
 
 fn updateResult(_: main.items.Inventory.Source) void {
+	craftingResultInv.super._items[0].deinit();
+	craftingResultInv.super._items[0] = .{};
 	var availableItems: [25]?main.items.BaseItemIndex = undefined;
 	const slotInfos = toolTypes.items[currentToolType].slotInfos();
 

--- a/src/gui/windows/workbench.zig
+++ b/src/gui/windows/workbench.zig
@@ -35,7 +35,8 @@ pub var window = GuiWindow{
 
 const padding: f32 = 8;
 
-var inv: ClientInventory = undefined;
+var craftingGridInv: ClientInventory = undefined;
+var craftingResultInv: ClientInventory = undefined;
 
 var itemSlots: [25]*ItemSlot = undefined;
 
@@ -53,8 +54,34 @@ fn toggleTool() void {
 	needsUpdate = true;
 }
 
+fn updateResult(_: main.items.Inventory.Source) void {
+	var availableItems: [25]?main.items.BaseItemIndex = undefined;
+	const slotInfos = toolTypes.items[currentToolType].slotInfos();
+
+	for (0..25) |i| {
+		if (craftingGridInv._items[i].item == .baseItem) {
+			availableItems[i] = craftingGridInv._items[i].item.baseItem;
+		} else {
+			if (!slotInfos[i].optional and !slotInfos[i].disabled) {
+				return;
+			}
+			availableItems[i] = null;
+		}
+	}
+	var hash = std.hash.Crc32.init();
+	for (availableItems) |item| {
+		if (item != null) {
+			hash.update(item.?.id());
+		} else {
+			hash.update("none");
+		}
+	}
+	craftingResultInv._items[0] = Item{.tool = main.items.Tool.initFromCraftingGrid(availableItems, hash.final(), toolTypes.items[currentToolType])};
+}
+
 fn openInventory() void {
-	inv = ClientInventory.init(main.globalAllocator, 26, .{.workbench = toolTypes.items[currentToolType]}, .serverShared, .{.workbench = .{.playerId = main.game.Player.id}}, .{});
+	craftingGridInv = ClientInventory.init(main.globalAllocator, 25, .normal, .serverShared, .{.workbench = .{.playerId = main.game.Player.id, .toolIndex = toolTypes[currentToolType]}}, .{});
+	craftingResultInv = ClientInventory.init(main.globalAllocator, 1, .normal, .workbenchResult, .other, .{.onUpdateCallback = &updateResult});
 	const list = HorizontalList.init();
 	{ // crafting grid
 		const grid = VerticalList.init(.{0, 0}, 300, 0);
@@ -64,7 +91,7 @@ fn openInventory() void {
 			for (0..5) |x| {
 				const index = x + y*5;
 				const slotInfo = toolTypes.items[currentToolType].slotInfos()[index];
-				const slot = ItemSlot.init(.{0, 0}, inv, @intCast(index), if (slotInfo.disabled) .invisible else if (slotInfo.optional) .immutable else .default, if (slotInfo.disabled) .immutable else .normal);
+				const slot = ItemSlot.init(.{0, 0}, craftingGridInv, @intCast(index), if (slotInfo.disabled) .invisible else if (slotInfo.optional) .immutable else .default, if (slotInfo.disabled) .immutable else .normal);
 				itemSlots[index] = slot;
 				row.add(slot);
 			}
@@ -79,7 +106,7 @@ fn openInventory() void {
 	const buttonHeight = verticalThing.size[1];
 	const craftingResultList = HorizontalList.init();
 	craftingResultList.add(Icon.init(.{0, 0}, .{32, 32}, inventory_crafting.arrowTexture, false));
-	craftingResultList.add(ItemSlot.init(.{8, 0}, inv, 25, .craftingResult, .takeOnly));
+	craftingResultList.add(ItemSlot.init(.{8, 0}, craftingResultInv, 0, .craftingResult, .takeOnly));
 	craftingResultList.finish(.{padding, padding}, .center);
 	verticalThing.add(craftingResultList);
 	verticalThing.size[1] += buttonHeight + 2*padding; // Centering the thing
@@ -92,7 +119,8 @@ fn openInventory() void {
 }
 
 fn closeInventory() void {
-	inv.deinit(main.globalAllocator);
+	craftingResultInv.deinit(main.globalAllocator);
+	craftingResultInv.deinit(main.globalAllocator);
 	if (window.rootComponent) |*comp| {
 		comp.deinit();
 		window.rootComponent = null;
@@ -108,7 +136,7 @@ pub fn update() void {
 }
 
 pub fn render() void {
-	const currentResult = inv.getItem(25);
+	const currentResult = craftingResultInv.getItem(0);
 	if (currentResult == .null) return;
 
 	const offsetX = 5*ItemSlot.sizeWithBorder + 20;

--- a/src/items.zig
+++ b/src/items.zig
@@ -698,7 +698,7 @@ pub const Tool = struct { // MARK: Tool
 		return result;
 	}
 
-	pub fn initFromCraftingGrid(craftingGrid: [25]?BaseItemIndex, seed: u32, typ: ToolTypeIndex) *Tool {
+	fn initFromCraftingGrid(craftingGrid: [25]?BaseItemIndex, seed: u32, typ: ToolTypeIndex) *Tool {
 		const self = init();
 		self.seed = seed;
 		self.craftingGrid = craftingGrid;
@@ -708,6 +708,32 @@ pub const Tool = struct { // MARK: Tool
 		TextureGenerator.generate(self);
 		ToolPhysics.evaluateTool(self);
 		return self;
+	}
+
+	pub fn initFromInventory(inventory: Inventory) ?*Tool {
+		std.debug.assert(inventory.source == .workbench);
+		const slotInfos = inventory.source.workbench.toolIndex.slotInfos();
+		var availableItems: [25]?main.items.BaseItemIndex = undefined;
+
+		for (0..25) |i| {
+			if (inventory._items[i].item == .baseItem) {
+				availableItems[i] = inventory._items[i].item.baseItem;
+			} else {
+				if (!slotInfos[i].optional and !slotInfos[i].disabled) {
+					return null;
+				}
+				availableItems[i] = null;
+			}
+		}
+		var hash = std.hash.Crc32.init();
+		for (availableItems) |item| {
+			if (item != null) {
+				hash.update(item.?.id());
+			} else {
+				hash.update("none");
+			}
+		}
+		return initFromCraftingGrid(availableItems, hash.final(), inventory.source.workbench.toolIndex);
 	}
 
 	pub fn initFromZon(zon: ZonElement) *Tool {

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -977,7 +977,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 			readerInput = "";
 		};
 		var reader: main.utils.BinaryReader = .init(readerInput);
-		return main.items.Inventory.ServerSide.createExternallyManagedInventory(size, .normal, source, &reader, .{});
+		return main.items.Inventory.ServerSide.createExternallyManagedInventory(size, source, &reader, .{});
 	}
 
 	fn savePlayerInventory(allocator: NeverFailingAllocator, inv: main.items.Inventory) []const u8 {

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1306,11 +1306,8 @@ pub const Command = struct { // MARK: Command
 		destinations: Inventory.Inventories,
 		craftingGrid: Inventory,
 
-		pub fn init(destinations: []const Inventory.ClientInventory, craftingGrid: Inventory.ClientInventory) CraftTool {
-			return .{
-				.destinations = .initFromClientInventories(main.globalAllocator, destinations),
-				.craftingGrid = craftingGrid.super,
-			};
+		pub fn init(destinations: []const Inventory.ClientInventory, craftingGrid: Inventory) CraftTool {
+			return .{.destinations = .initFromClientInventories(main.globalAllocator, destinations), .craftingGrid = craftingGrid};
 		}
 
 		fn finalize(self: CraftTool, _: Side, _: *BinaryReader) !void {

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -754,10 +754,10 @@ pub const Command = struct { // MARK: Command
 		}
 	}
 
-	fn canPutIntoWorkbench(source: InventoryAndSlot) bool {
-		return switch (source.ref().item) {
+	pub fn canPutIntoWorkbench(item: Item) bool {
+		return switch (item) {
 			.null => true,
-			.baseItem => |item| item.material() != null,
+			.baseItem => |baseItem| baseItem.material() != null,
 			.tool => false,
 		};
 	}
@@ -868,7 +868,7 @@ pub const Command = struct { // MARK: Command
 
 		fn run(self: DepositOrSwap, ctx: Context) error{serverFailure}!void {
 			if (self.dest.inv.source == .workbench and self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled) return;
-			if (self.dest.inv.source == .workbench and !canPutIntoWorkbench(self.source)) return;
+			if (self.dest.inv.source == .workbench and !canPutIntoWorkbench(self.source.ref().item)) return;
 
 			const itemDest = self.dest.ref().item;
 			const itemSource = self.source.ref().item;
@@ -884,7 +884,8 @@ pub const Command = struct { // MARK: Command
 					return;
 				}
 			}
-			if (self.source.inv.source == .workbench and !canPutIntoWorkbench(self.dest)) return;
+			if (self.source.inv.source == .workbench and self.source.inv.source.workbench.toolIndex.slotInfos()[self.source.slot].disabled) return;
+			if (self.source.inv.source == .workbench and !canPutIntoWorkbench(self.dest.ref().item)) return;
 			ctx.execute(.{.swap = .{
 				.dest = self.dest,
 				.source = self.source,
@@ -911,7 +912,7 @@ pub const Command = struct { // MARK: Command
 
 		fn run(self: Deposit, ctx: Context) error{serverFailure}!void {
 			if (self.dest.inv.source == .workbench and self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled) return;
-			if (self.dest.inv.source == .workbench and !canPutIntoWorkbench(self.source)) return;
+			if (self.dest.inv.source == .workbench and !canPutIntoWorkbench(self.source.ref().item)) return;
 			const itemSource = self.source.ref().item;
 			if (itemSource == .null) return;
 			const itemDest = self.dest.ref().item;
@@ -955,7 +956,7 @@ pub const Command = struct { // MARK: Command
 		source: InventoryAndSlot,
 
 		fn run(self: TakeHalf, ctx: Context) error{serverFailure}!void {
-			if (self.source.inv.source == .workbench and self.source.inv.source.workbench.toolIndex.slotInfos()[self.source.slot].disabled) return;
+			if (self.dest.inv.source == .workbench and self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled) return;
 
 			const itemSource = self.source.ref().item;
 			if (itemSource == .null) return;
@@ -999,7 +1000,6 @@ pub const Command = struct { // MARK: Command
 
 		fn run(self: Drop, ctx: Context) error{serverFailure}!void {
 			if (self.source.ref().item == .null) return;
-			if (self.source.inv.source == .workbench and self.source.inv.source.workbench.toolIndex.slotInfos()[self.source.slot].disabled) return;
 
 			const amount = @min(self.source.ref().amount, self.desiredAmount);
 			if (ctx.side == .server) {
@@ -1033,7 +1033,7 @@ pub const Command = struct { // MARK: Command
 		amount: u16 = 0,
 
 		fn run(self: FillFromCreative, ctx: Context) error{serverFailure}!void {
-			if (self.dest.inv.source == .workbench and self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled) return;
+			if (self.dest.inv.source == .workbench and (self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled or !canPutIntoWorkbench(self.item))) return;
 			if (ctx.side == .server and ctx.user != null and ctx.gamemode != .creative) return;
 			if (ctx.side == .client and ctx.gamemode != .creative) return;
 

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -806,6 +806,7 @@ pub const Command = struct { // MARK: Command
 				},
 				.workbench => |val| {
 					writer.writeInt(u32, val.playerId);
+					writer.writeEnum(main.items.ToolTypeIndex, val.toolIndex);
 				},
 				.other => {},
 				.alreadyFreed => unreachable,
@@ -828,7 +829,7 @@ pub const Command = struct { // MARK: Command
 				.playerInventory => .{.playerInventory = try reader.readInt(u32)},
 				.hand => .{.hand = try reader.readInt(u32)},
 				.blockInventory => .{.blockInventory = try reader.readVec(Vec3i)},
-				.workbench => .{.workbench = .{.playerId = try reader.readInt(u32)}},
+				.workbench => .{.workbench = .{.playerId = try reader.readInt(u32), .toolIndex = try reader.readEnum(main.items.ToolTypeIndex)}},
 				.other => .{.other = {}},
 				.alreadyFreed => return error.Invalid,
 			};
@@ -1353,13 +1354,11 @@ pub const Command = struct { // MARK: Command
 	const CraftTool = struct { // MARK: CraftTool
 		destinations: Inventory.Inventories,
 		craftingGrid: Inventory,
-		toolIndex: main.items.ToolTypeIndex,
 
-		pub fn init(destinations: []const Inventory.ClientInventory, craftingGrid: Inventory.ClientInventory, toolIndex: main.items.ToolTypeIndex) CraftTool {
+		pub fn init(destinations: []const Inventory.ClientInventory, craftingGrid: Inventory.ClientInventory) CraftTool {
 			return .{
 				.destinations = .initFromClientInventories(main.globalAllocator, destinations),
 				.craftingGrid = craftingGrid.super,
-				.toolIndex = toolIndex,
 			};
 		}
 
@@ -1391,7 +1390,7 @@ pub const Command = struct { // MARK: Command
 					hash.update("none");
 				}
 			}
-			const tool = Item{.tool = main.items.Tool.initFromCraftingGrid(availableItems, hash.final(), self.toolIndex)};
+			const tool = Item{.tool = main.items.Tool.initFromCraftingGrid(availableItems, hash.final(), self.craftingGrid.source.workbench.toolIndex)};
 
 			if (self.destinations.canHold(.{.item = tool, .amount = 1}) != .yes) return;
 			ctx.cmd.removeToolCraftingIngredients(main.globalAllocator, self.craftingGrid, ctx.side);
@@ -1401,7 +1400,6 @@ pub const Command = struct { // MARK: Command
 		fn serialize(self: CraftTool, writer: *BinaryWriter) void {
 			self.destinations.toBytes(writer);
 			writer.writeEnum(InventoryId, self.craftingGrid.id);
-			writer.writeEnum(main.items.ToolTypeIndex, self.toolIndex);
 		}
 
 		fn deserialize(reader: *BinaryReader, side: Side, user: ?*main.server.User) !CraftTool {
@@ -1410,12 +1408,9 @@ pub const Command = struct { // MARK: Command
 
 			const craftingGrid = Inventory.getInventory(try reader.readEnum(InventoryId), side, user) orelse return error.InventoryNotFound;
 			if (craftingGrid.source != .workbench) return error.Invalid;
-
-			const toolIndex = try reader.readEnum(main.items.ToolTypeIndex);
 			return .{
 				.destinations = destinations,
 				.craftingGrid = craftingGrid,
-				.toolIndex = toolIndex,
 			};
 		}
 	};

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1350,6 +1350,76 @@ pub const Command = struct { // MARK: Command
 		}
 	};
 
+	const CraftTool = struct { // MARK: CraftFrom
+		destinations: Inventory.Inventories,
+		craftingGrid: Inventory,
+		toolIndex: main.items.ToolTypeIndex,
+
+		pub fn init(destinations: []const Inventory.ClientInventory, craftingGrid: Inventory.ClientInventory, toolIndex: main.items.ToolTypeIndex) CraftTool {
+			return .{
+				.destinations = .initFromClientInventories(main.globalAllocator, destinations),
+				.craftingGrid = craftingGrid.super,
+				.toolIndex = toolIndex,
+			};
+		}
+
+		fn finalize(self: CraftTool, _: Side, _: *BinaryReader) !void {
+			self.destinations.deinit(main.globalAllocator);
+		}
+
+		fn run(self: CraftTool, ctx: Context) error{serverFailure}!void {
+			for (self.destinations.inventories) |dest| if (dest.type != .normal) return;
+
+			var availableItems: [25]?main.items.BaseItemIndex = undefined;
+			const slotInfos = self.toolIndex.slotInfos();
+
+			for (0..25) |i| {
+				if (self._items[i].item == .baseItem) {
+					availableItems[i] = self._items[i].item.baseItem;
+				} else {
+					if (!slotInfos[i].optional and !slotInfos[i].disabled) {
+						return;
+					}
+					availableItems[i] = null;
+				}
+			}
+			var hash = std.hash.Crc32.init();
+			for (availableItems) |item| {
+				if (item != null) {
+					hash.update(item.?.id());
+				} else {
+					hash.update("none");
+				}
+			}
+			const tool = Item{.tool = main.items.Tool.initFromCraftingGrid(availableItems, hash.final(), self.toolIndex)};
+
+			if (self.destinations.canHold(.{.item = tool, .amount = 1}) != .yes) return;
+			ctx.cmd.removeToolCraftingIngredients(main.globalAllocator, self.craftingGrid, ctx.side);
+			self.destinations.putItemsInto(ctx, 1, .{.create = tool});
+		}
+
+		fn serialize(self: CraftTool, writer: *BinaryWriter) void {
+			self.destinations.toBytes(writer);
+			writer.writeEnum(InventoryId, self.craftingGrid.id);
+			writer.writeEnum(main.items.ToolTypeIndex, self.toolIndex);
+		}
+
+		fn deserialize(reader: *BinaryReader, side: Side, user: ?*main.server.User) !CraftTool {
+			const destinations = try Inventory.Inventories.fromBytes(main.globalAllocator, reader, side, user);
+			errdefer destinations.deinit(main.globalAllocator);
+
+			const craftingGrid = Inventory.getInventory(try reader.readEnum(InventoryId), side, user) orelse return error.InventoryNotFound;
+			if (craftingGrid.source != .workbench) return error.Invalid;
+
+			const toolIndex = try reader.readEnum(main.items.ToolTypeIndex);
+			return .{
+				.destinations = destinations,
+				.craftingGrid = craftingGrid,
+				.toolIndex = toolIndex,
+			};
+		}
+	};
+
 	const Clear = struct { // MARK: Clear
 		inv: Inventory,
 

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -232,6 +232,7 @@ pub const Command = struct { // MARK: Command
 		depositOrDrop = 7,
 		depositToAny = 11,
 		craftFrom = 13,
+		craftTool = 15,
 		clear = 8,
 		updateBlock = 9,
 		addHealth = 10,
@@ -249,6 +250,7 @@ pub const Command = struct { // MARK: Command
 		depositOrDrop: DepositOrDrop,
 		depositToAny: DepositToAny,
 		craftFrom: CraftFrom,
+		craftTool: CraftTool,
 		clear: Clear,
 		updateBlock: UpdateBlock,
 		addHealth: AddHealth,
@@ -879,18 +881,6 @@ pub const Command = struct { // MARK: Command
 		fn run(self: DepositOrSwap, ctx: Context) error{serverFailure}!void {
 			std.debug.assert(self.source.inv.type == .normal);
 			if (self.dest.inv.source == .workbench and self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled) return;
-			// TODO MOVE
-			if (false and self.dest.inv.type == .workbench and self.dest.slot == 25) {
-				if (self.source.ref().item == .null and self.dest.ref().item != .null) {
-					ctx.execute(.{.move = .{
-						.dest = self.source,
-						.source = self.dest,
-						.amount = 1,
-					}});
-					ctx.cmd.removeToolCraftingIngredients(ctx.allocator, self.dest.inv, ctx.side);
-				}
-				return;
-			}
 			if (self.dest.inv.source == .workbench and !canPutIntoWorkbench(self.source)) return;
 
 			const itemDest = self.dest.ref().item;
@@ -981,18 +971,7 @@ pub const Command = struct { // MARK: Command
 		fn run(self: TakeHalf, ctx: Context) error{serverFailure}!void {
 			std.debug.assert(self.dest.inv.type == .normal);
 			if (self.source.inv.source == .workbench and self.source.inv.source.workbench.toolIndex.slotInfos()[self.source.slot].disabled) return;
-			// TODO MOVE
-			if (false and self.source.inv.type == .workbench and self.source.slot == 25) {
-				if (self.dest.ref().item == .null and self.source.ref().item != .null) {
-					ctx.execute(.{.move = .{
-						.dest = self.dest,
-						.source = self.source,
-						.amount = 1,
-					}});
-					ctx.cmd.removeToolCraftingIngredients(ctx.allocator, self.source.inv, ctx.side);
-				}
-				return;
-			}
+
 			const itemSource = self.source.ref().item;
 			if (itemSource == .null) return;
 			const desiredAmount = (1 + self.source.ref().amount)/2;
@@ -1036,10 +1015,7 @@ pub const Command = struct { // MARK: Command
 		fn run(self: Drop, ctx: Context) error{serverFailure}!void {
 			if (self.source.ref().item == .null) return;
 			if (self.source.inv.source == .workbench and self.source.inv.source.workbench.toolIndex.slotInfos()[self.source.slot].disabled) return;
-			// TODO MOVE
-			if (false and self.source.inv.type == .workbench and self.source.slot == 25) {
-				ctx.cmd.removeToolCraftingIngredients(ctx.allocator, self.source.inv, ctx.side);
-			}
+
 			const amount = @min(self.source.ref().amount, self.desiredAmount);
 			if (ctx.side == .server) {
 				const direction = vec.rotateZ(vec.rotateX(Vec3f{0, 1, 0}, -ctx.user.?.player.rot[0]), -ctx.user.?.player.rot[2]);
@@ -1371,11 +1347,11 @@ pub const Command = struct { // MARK: Command
 			for (self.destinations.inventories) |dest| if (dest.type != .normal) return;
 
 			var availableItems: [25]?main.items.BaseItemIndex = undefined;
-			const slotInfos = self.toolIndex.slotInfos();
+			const slotInfos = self.craftingGrid.source.workbench.toolIndex.slotInfos();
 
 			for (0..25) |i| {
-				if (self._items[i].item == .baseItem) {
-					availableItems[i] = self._items[i].item.baseItem;
+				if (self.craftingGrid._items[i].item == .baseItem) {
+					availableItems[i] = self.craftingGrid._items[i].item.baseItem;
 				} else {
 					if (!slotInfos[i].optional and !slotInfos[i].disabled) {
 						return;
@@ -1395,7 +1371,7 @@ pub const Command = struct { // MARK: Command
 
 			if (self.destinations.canHold(.{.item = tool, .amount = 1}) != .yes) return;
 			ctx.cmd.removeToolCraftingIngredients(main.globalAllocator, self.craftingGrid, ctx.side);
-			self.destinations.putItemsInto(ctx, 1, .{.create = tool});
+			_ = self.destinations.putItemsInto(ctx, 1, .{.create = tool});
 		}
 
 		fn serialize(self: CraftTool, writer: *BinaryWriter) void {

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1350,7 +1350,7 @@ pub const Command = struct { // MARK: Command
 		}
 	};
 
-	const CraftTool = struct { // MARK: CraftFrom
+	const CraftTool = struct { // MARK: CraftTool
 		destinations: Inventory.Inventories,
 		craftingGrid: Inventory,
 		toolIndex: main.items.ToolTypeIndex,

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -797,7 +797,6 @@ pub const Command = struct { // MARK: Command
 		fn serialize(self: Open, writer: *BinaryWriter) void {
 			writer.writeEnum(InventoryId, self.inv.id);
 			writer.writeInt(usize, self.inv._items.len);
-			writer.writeEnum(Inventory.TypeEnum, self.inv.type);
 			writer.writeEnum(Inventory.SourceType, self.source);
 			switch (self.source) {
 				.playerInventory, .hand => |val| {
@@ -813,19 +812,12 @@ pub const Command = struct { // MARK: Command
 				.other => {},
 				.alreadyFreed => unreachable,
 			}
-			switch (self.inv.type) {
-				.normal => {},
-				.workbench => {
-					writer.writeSlice(self.inv.type.workbench.id());
-				},
-			}
 		}
 
 		fn deserialize(reader: *BinaryReader, side: Side, user: ?*main.server.User) !Open {
 			if (side != .server or user == null) return error.Invalid;
 			const id = try reader.readEnum(InventoryId);
 			const len = try reader.readInt(u64);
-			const typeEnum = try reader.readEnum(Inventory.TypeEnum);
 			const sourceType = try reader.readEnum(Inventory.SourceType);
 			const source: Inventory.Source = switch (sourceType) {
 				.playerInventory => .{.playerInventory = try reader.readInt(u32)},
@@ -835,11 +827,7 @@ pub const Command = struct { // MARK: Command
 				.other => .{.other = {}},
 				.alreadyFreed => return error.Invalid,
 			};
-			const typ: Inventory.Type = switch (typeEnum) {
-				inline .normal => |tag| tag,
-				.workbench => .{.workbench = main.items.ToolTypeIndex.fromId(reader.remaining) orelse return error.Invalid},
-			};
-			try Inventory.ServerSide.createInventory(user.?, id, len, typ, source);
+			try Inventory.ServerSide.createInventory(user.?, id, len, source);
 			return .{
 				.inv = Inventory.ServerSide.getInventory(user.?, id) orelse return error.InventoryNotFound,
 				.source = source,
@@ -879,7 +867,6 @@ pub const Command = struct { // MARK: Command
 		source: InventoryAndSlot,
 
 		fn run(self: DepositOrSwap, ctx: Context) error{serverFailure}!void {
-			std.debug.assert(self.source.inv.type == .normal);
 			if (self.dest.inv.source == .workbench and self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled) return;
 			if (self.dest.inv.source == .workbench and !canPutIntoWorkbench(self.source)) return;
 
@@ -923,7 +910,6 @@ pub const Command = struct { // MARK: Command
 		amount: u16,
 
 		fn run(self: Deposit, ctx: Context) error{serverFailure}!void {
-			if (self.source.inv.type != .normal and self.dest.inv.type != .normal) return error.serverFailure;
 			if (self.dest.inv.source == .workbench and self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled) return;
 			if (self.dest.inv.source == .workbench and !canPutIntoWorkbench(self.source)) return;
 			const itemSource = self.source.ref().item;
@@ -969,7 +955,6 @@ pub const Command = struct { // MARK: Command
 		source: InventoryAndSlot,
 
 		fn run(self: TakeHalf, ctx: Context) error{serverFailure}!void {
-			std.debug.assert(self.dest.inv.type == .normal);
 			if (self.source.inv.source == .workbench and self.source.inv.source.workbench.toolIndex.slotInfos()[self.source.slot].disabled) return;
 
 			const itemSource = self.source.ref().item;
@@ -1115,8 +1100,6 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn run(self: FillAnyFromCreative, ctx: Context) error{serverFailure}!void {
-			for (self.destinations.inventories) |dest| if (dest.type != .normal) return;
-
 			_ = self.destinations.putItemsInto(ctx, self.amount, .{.create = self.item});
 		}
 
@@ -1177,9 +1160,6 @@ pub const Command = struct { // MARK: Command
 		}
 
 		pub fn run(self: DepositOrDrop, ctx: Context) error{serverFailure}!void {
-			for (self.destinations.inventories) |dest| {
-				std.debug.assert(dest.type == .normal);
-			}
 			for (self.source._items, 0..) |*sourceStack, sourceSlot| {
 				if (sourceStack.item == .null) continue;
 				const remainingAmount = self.destinations.putItemsInto(ctx, sourceStack.amount, .{.move = .{.inv = self.source, .slot = @intCast(sourceSlot)}});
@@ -1230,9 +1210,6 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn run(self: DepositToAny, ctx: Context) error{serverFailure}!void {
-			for (self.destinations.inventories) |dest| {
-				if (dest.type != .normal) return;
-			}
 			const sourceStack = self.source.ref();
 			if (sourceStack.item == .null) return;
 			if (self.amount > sourceStack.amount) return;
@@ -1276,9 +1253,6 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn run(self: CraftFrom, ctx: Context) error{serverFailure}!void {
-			for (self.destinations.inventories) |dest| if (dest.type != .normal) return;
-			for (self.sources.inventories) |source| if (source.type != .normal) return;
-
 			if (self.destinations.canHold(.{.item = .{.baseItem = self.recipe.resultItem}, .amount = self.recipe.resultAmount}) != .yes) return;
 
 			// Can we even craft it?
@@ -1344,8 +1318,6 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn run(self: CraftTool, ctx: Context) error{serverFailure}!void {
-			for (self.destinations.inventories) |dest| if (dest.type != .normal) return;
-
 			var availableItems: [25]?main.items.BaseItemIndex = undefined;
 			const slotInfos = self.craftingGrid.source.workbench.toolIndex.slotInfos();
 
@@ -1496,8 +1468,6 @@ pub const Command = struct { // MARK: Command
 		};
 
 		fn run(self: UpdateBlock, ctx: Context) error{serverFailure}!void {
-			if (self.source.inv.type != .normal) return;
-
 			const stack = self.source.ref();
 
 			var shouldDropSourceBlockOnSuccess: bool = true;

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -741,7 +741,7 @@ pub const Command = struct { // MARK: Command
 	}
 
 	fn removeToolCraftingIngredients(self: *Command, allocator: NeverFailingAllocator, inv: Inventory, side: Side) void {
-		std.debug.assert(inv.type == .workbench);
+		std.debug.assert(inv.source == .workbench);
 		for (0..25) |i| {
 			if (inv._items[i].amount != 0) {
 				self.executeBaseOperation(allocator, .{.delete = .{
@@ -878,8 +878,9 @@ pub const Command = struct { // MARK: Command
 
 		fn run(self: DepositOrSwap, ctx: Context) error{serverFailure}!void {
 			std.debug.assert(self.source.inv.type == .normal);
-			if (self.dest.inv.type == .workbench and self.dest.slot != 25 and self.dest.inv.type.workbench.slotInfos()[self.dest.slot].disabled) return;
-			if (self.dest.inv.type == .workbench and self.dest.slot == 25) {
+			if (self.dest.inv.source == .workbench and self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled) return;
+			// TODO MOVE
+			if (false and self.dest.inv.type == .workbench and self.dest.slot == 25) {
 				if (self.source.ref().item == .null and self.dest.ref().item != .null) {
 					ctx.execute(.{.move = .{
 						.dest = self.source,
@@ -890,7 +891,7 @@ pub const Command = struct { // MARK: Command
 				}
 				return;
 			}
-			if (self.dest.inv.type == .workbench and !canPutIntoWorkbench(self.source)) return;
+			if (self.dest.inv.source == .workbench and !canPutIntoWorkbench(self.source)) return;
 
 			const itemDest = self.dest.ref().item;
 			const itemSource = self.source.ref().item;
@@ -906,7 +907,7 @@ pub const Command = struct { // MARK: Command
 					return;
 				}
 			}
-			if (self.source.inv.type == .workbench and !canPutIntoWorkbench(self.dest)) return;
+			if (self.source.inv.source == .workbench and !canPutIntoWorkbench(self.dest)) return;
 			ctx.execute(.{.swap = .{
 				.dest = self.dest,
 				.source = self.source,
@@ -933,8 +934,8 @@ pub const Command = struct { // MARK: Command
 
 		fn run(self: Deposit, ctx: Context) error{serverFailure}!void {
 			if (self.source.inv.type != .normal and self.dest.inv.type != .normal) return error.serverFailure;
-			if (self.dest.inv.type == .workbench and (self.dest.slot == 25 or self.dest.inv.type.workbench.slotInfos()[self.dest.slot].disabled)) return;
-			if (self.dest.inv.type == .workbench and !canPutIntoWorkbench(self.source)) return;
+			if (self.dest.inv.source == .workbench and self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled) return;
+			if (self.dest.inv.source == .workbench and !canPutIntoWorkbench(self.source)) return;
 			const itemSource = self.source.ref().item;
 			if (itemSource == .null) return;
 			const itemDest = self.dest.ref().item;
@@ -979,8 +980,9 @@ pub const Command = struct { // MARK: Command
 
 		fn run(self: TakeHalf, ctx: Context) error{serverFailure}!void {
 			std.debug.assert(self.dest.inv.type == .normal);
-			if (self.source.inv.type == .workbench and self.source.slot != 25 and self.source.inv.type.workbench.slotInfos()[self.source.slot].disabled) return;
-			if (self.source.inv.type == .workbench and self.source.slot == 25) {
+			if (self.source.inv.source == .workbench and self.source.inv.source.workbench.toolIndex.slotInfos()[self.source.slot].disabled) return;
+			// TODO MOVE
+			if (false and self.source.inv.type == .workbench and self.source.slot == 25) {
 				if (self.dest.ref().item == .null and self.source.ref().item != .null) {
 					ctx.execute(.{.move = .{
 						.dest = self.dest,
@@ -1033,8 +1035,9 @@ pub const Command = struct { // MARK: Command
 
 		fn run(self: Drop, ctx: Context) error{serverFailure}!void {
 			if (self.source.ref().item == .null) return;
-			if (self.source.inv.type == .workbench and self.source.slot != 25 and self.source.inv.type.workbench.slotInfos()[self.source.slot].disabled) return;
-			if (self.source.inv.type == .workbench and self.source.slot == 25) {
+			if (self.source.inv.source == .workbench and self.source.inv.source.workbench.toolIndex.slotInfos()[self.source.slot].disabled) return;
+			// TODO MOVE
+			if (false and self.source.inv.type == .workbench and self.source.slot == 25) {
 				ctx.cmd.removeToolCraftingIngredients(ctx.allocator, self.source.inv, ctx.side);
 			}
 			const amount = @min(self.source.ref().amount, self.desiredAmount);
@@ -1069,7 +1072,7 @@ pub const Command = struct { // MARK: Command
 		amount: u16 = 0,
 
 		fn run(self: FillFromCreative, ctx: Context) error{serverFailure}!void {
-			if (self.dest.inv.type == .workbench and (self.dest.slot == 25 or self.dest.inv.type.workbench.slotInfos()[self.dest.slot].disabled)) return;
+			if (self.dest.inv.source == .workbench and self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled) return;
 			if (ctx.side == .server and ctx.user != null and ctx.gamemode != .creative) return;
 			if (ctx.side == .client and ctx.gamemode != .creative) return;
 
@@ -1201,9 +1204,7 @@ pub const Command = struct { // MARK: Command
 			for (self.destinations.inventories) |dest| {
 				std.debug.assert(dest.type == .normal);
 			}
-			var sourceItems = self.source._items;
-			if (self.source.type == .workbench) sourceItems = self.source._items[0..25];
-			for (sourceItems, 0..) |*sourceStack, sourceSlot| {
+			for (self.source._items, 0..) |*sourceStack, sourceSlot| {
 				if (sourceStack.item == .null) continue;
 				const remainingAmount = self.destinations.putItemsInto(ctx, sourceStack.amount, .{.move = .{.inv = self.source, .slot = @intCast(sourceSlot)}});
 				if (remainingAmount == 0) continue;
@@ -1419,9 +1420,7 @@ pub const Command = struct { // MARK: Command
 		inv: Inventory,
 
 		pub fn run(self: Clear, ctx: Context) error{serverFailure}!void {
-			var items = self.inv._items;
-			if (self.inv.type == .workbench) items = self.inv._items[0..25];
-			for (items, 0..) |stack, slot| {
+			for (self.inv._items, 0..) |stack, slot| {
 				if (stack.item == .null) continue;
 
 				ctx.execute(.{.delete = .{

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -956,7 +956,7 @@ pub const Command = struct { // MARK: Command
 		source: InventoryAndSlot,
 
 		fn run(self: TakeHalf, ctx: Context) error{serverFailure}!void {
-			if (self.dest.inv.source == .workbench and self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled) return;
+			if (self.dest.inv.source == .workbench and (self.dest.inv.source.workbench.toolIndex.slotInfos()[self.dest.slot].disabled or !canPutIntoWorkbench(self.source.ref().item))) return;
 
 			const itemSource = self.source.ref().item;
 			if (itemSource == .null) return;

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1318,30 +1318,11 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn run(self: CraftTool, ctx: Context) error{serverFailure}!void {
-			var availableItems: [25]?main.items.BaseItemIndex = undefined;
-			const slotInfos = self.craftingGrid.source.workbench.toolIndex.slotInfos();
-
-			for (0..25) |i| {
-				if (self.craftingGrid._items[i].item == .baseItem) {
-					availableItems[i] = self.craftingGrid._items[i].item.baseItem;
-				} else {
-					if (!slotInfos[i].optional and !slotInfos[i].disabled) {
-						return;
-					}
-					availableItems[i] = null;
-				}
+			const tool = Item{.tool = main.items.Tool.initFromInventory(self.craftingGrid) orelse return};
+			if (self.destinations.canHold(.{.item = tool, .amount = 1}) != .yes) {
+				tool.deinit();
+				return;
 			}
-			var hash = std.hash.Crc32.init();
-			for (availableItems) |item| {
-				if (item != null) {
-					hash.update(item.?.id());
-				} else {
-					hash.update("none");
-				}
-			}
-			const tool = Item{.tool = main.items.Tool.initFromCraftingGrid(availableItems, hash.final(), self.craftingGrid.source.workbench.toolIndex)};
-
-			if (self.destinations.canHold(.{.item = tool, .amount = 1}) != .yes) return;
 			ctx.cmd.removeToolCraftingIngredients(main.globalAllocator, self.craftingGrid, ctx.side);
 			_ = self.destinations.putItemsInto(ctx, 1, .{.create = tool});
 		}


### PR DESCRIPTION
Closes #2529

- [x] write first iteration of the Sync command
- [x] split workbench inventories
- [x] point workbench crafting to the new sync command
- [x] remove old workbench sync code
- [x] remove `inventory.type`