### PR TITLE
More runtime formatting

### DIFF
--- a/src/assets.zig
+++ b/src/assets.zig
@@ -378,8 +378,8 @@ fn registerItem(assetFolder: []const u8, id: []const u8, zon: ZonElement) !void 
 	var replacementTexturePath: []const u8 = &.{};
 	defer main.stackAllocator.free(replacementTexturePath);
 	if (zon.get(?[]const u8, "texture", null)) |texture| {
-		texturePath = try std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/{s}/items/textures/{s}", .{assetFolder, mod, texture});
-		replacementTexturePath = try std.fmt.allocPrint(main.stackAllocator.allocator, "assets/{s}/items/textures/{s}", .{mod, texture});
+		texturePath = main.fmt.allocPrint(main.stackAllocator, "{s}/{s}/items/textures/{s}", .{assetFolder, mod, texture});
+		replacementTexturePath = main.fmt.allocPrint(main.stackAllocator, "assets/{s}/items/textures/{s}", .{mod, texture});
 	}
 	_ = items_zig.register(assetFolder, texturePath, replacementTexturePath, id, zon);
 }
@@ -677,7 +677,7 @@ pub fn loadWorldAssets(assetFolder: []const u8, blockPalette: *Palette, itemPale
 		break :blk null;
 	}) |addon| {
 		if (addon.kind == .directory) {
-			const path = std.fmt.allocPrintSentinel(main.stackAllocator.allocator, "assets/{s}/blocks/textures", .{addon.name}, 0) catch unreachable;
+			const path = main.fmt.allocPrintSentinel(main.stackAllocator, "assets/{s}/blocks/textures", .{addon.name}, 0);
 			defer main.stackAllocator.free(path);
 			// Check for access rights
 			if (!main.files.cwd().hasDir(path)) continue;
@@ -716,7 +716,7 @@ pub fn unloadAssets() void { // MARK: unloadAssets()
 		break :blk null;
 	}) |addon| {
 		if (addon.kind == .directory) {
-			const path = std.fmt.allocPrintSentinel(main.stackAllocator.allocator, "assets/{s}/blocks/textures", .{addon.name}, 0) catch unreachable;
+			const path = main.fmt.allocPrintSentinel(main.stackAllocator, "assets/{s}/blocks/textures", .{addon.name}, 0);
 			defer main.stackAllocator.free(path);
 			// Check for access rights
 			if (!main.files.cwd().hasDir(path)) continue;

--- a/src/audio.zig
+++ b/src/audio.zig
@@ -28,11 +28,11 @@ const AudioData = struct {
 		};
 		const addon = id[0..colonIndex];
 		const fileName = id[colonIndex + 1 ..];
-		const path1 = std.fmt.allocPrintSentinel(main.stackAllocator.allocator, "assets/{s}/music/{s}.ogg", .{addon, fileName}, 0) catch unreachable;
+		const path1 = main.fmt.allocPrintSentinel(main.stackAllocator, "assets/{s}/music/{s}.ogg", .{addon, fileName}, 0);
 		defer main.stackAllocator.free(path1);
 		var err: c_int = 0;
 		if (c.stb_vorbis_open_filename(path1.ptr, &err, null)) |ogg_stream| return ogg_stream;
-		const path2 = std.fmt.allocPrintSentinel(main.stackAllocator.allocator, "{s}/serverAssets/{s}/music/{s}.ogg", .{main.files.cubyzDirStr(), addon, fileName}, 0) catch unreachable;
+		const path2 = main.fmt.allocPrintSentinel(main.stackAllocator, "{s}/serverAssets/{s}/music/{s}.ogg", .{main.files.cubyzDirStr(), addon, fileName}, 0);
 		defer main.stackAllocator.free(path2);
 		if (c.stb_vorbis_open_filename(path2.ptr, &err, null)) |ogg_stream| return ogg_stream;
 		std.log.err("Couldn't find music with id \"{s}\". Searched path \"{s}\" and \"{s}\"", .{id, path1, path2});

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -628,7 +628,7 @@ pub const meshes = struct { // MARK: meshes
 	}
 
 	fn extendedPath(_allocator: main.heap.NeverFailingAllocator, path: []const u8, ending: []const u8) []const u8 {
-		return std.fmt.allocPrint(_allocator.allocator, "{s}{s}", .{path, ending}) catch unreachable;
+		return main.fmt.allocPrint(_allocator, "{s}{s}", .{path, ending});
 	}
 
 	fn readTextureFile(_path: []const u8, ending: []const u8, default: Image) Image {
@@ -681,7 +681,7 @@ pub const meshes = struct { // MARK: meshes
 		var splitter = std.mem.splitScalar(u8, textureId, ':');
 		const mod = splitter.first();
 		const id = splitter.rest();
-		var path = try std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/{s}/blocks/textures/{s}.png", .{assetFolder, mod, id});
+		var path = main.fmt.allocPrint(main.stackAllocator, "{s}/{s}/blocks/textures/{s}.png", .{assetFolder, mod, id});
 		defer main.stackAllocator.free(path);
 		// Test if it's already in the list:
 		for (textureIDs.items, 0..) |other, j| {
@@ -695,7 +695,7 @@ pub const meshes = struct { // MARK: meshes
 				std.log.err("Could not open file {s}: {s}", .{path, @errorName(err)});
 			}
 			main.stackAllocator.free(path);
-			path = try std.fmt.allocPrint(main.stackAllocator.allocator, "assets/{s}/blocks/textures/{s}.png", .{mod, id}); // Default to global assets.
+			path = main.fmt.allocPrint(main.stackAllocator, "assets/{s}/blocks/textures/{s}.png", .{mod, id}); // Default to global assets.
 			break :blk main.files.cwd().openFile(path) catch |err2| {
 				std.log.err("File not found. Searched in \"{s}\" and also in the assetFolder \"{s}\"", .{path, assetFolder});
 				return err2;
@@ -736,13 +736,13 @@ pub const meshes = struct { // MARK: meshes
 	pub fn registerBlockBreakingAnimation(assetFolder: []const u8) void {
 		var i: usize = 0;
 		while (true) : (i += 1) {
-			const path1 = std.fmt.allocPrint(main.stackAllocator.allocator, "assets/cubyz/blocks/textures/breaking/{}.png", .{i}) catch unreachable;
+			const path1 = main.fmt.allocPrint(main.stackAllocator, "assets/cubyz/blocks/textures/breaking/{}.png", .{i});
 			defer main.stackAllocator.free(path1);
-			const path2 = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/cubyz/blocks/textures/breaking/{}.png", .{assetFolder, i}) catch unreachable;
+			const path2 = main.fmt.allocPrint(main.stackAllocator, "{s}/cubyz/blocks/textures/breaking/{}.png", .{assetFolder, i});
 			defer main.stackAllocator.free(path2);
 			if (!main.files.cwd().hasFile(path1) and !main.files.cwd().hasFile(path2)) break;
 
-			const id = std.fmt.allocPrint(main.stackAllocator.allocator, "cubyz:breaking/{}", .{i}) catch unreachable;
+			const id = main.fmt.allocPrint(main.stackAllocator, "cubyz:breaking/{}", .{i});
 			defer main.stackAllocator.free(id);
 			blockBreakingTextures.append(main.worldArena, findTexture(id, assetFolder) catch break);
 		}

--- a/src/client/entity_manager.zig
+++ b/src/client/entity_manager.zig
@@ -114,7 +114,7 @@ pub fn renderNames(projMatrix: Mat4f, playerPos: Vec3d) void {
 		const alpha: u32 = @intFromFloat(std.math.clamp(0xff - transparency, 0, 0xff));
 		graphics.draw.setColor(alpha << 24);
 
-		const renderedName = std.fmt.allocPrint(main.stackAllocator.allocator, "{f}", .{ent}) catch unreachable;
+		const renderedName = main.fmt.allocPrint(main.stackAllocator, "{f}", .{ent});
 		defer main.stackAllocator.free(renderedName);
 		var buf = graphics.TextBuffer.init(main.stackAllocator, renderedName, .{.color = 0xffffff}, false, .center);
 		defer buf.deinit();

--- a/src/files.zig
+++ b/src/files.zig
@@ -111,7 +111,7 @@ pub const Dir = struct {
 	}
 
 	pub fn write(self: Dir, path: []const u8, data: []const u8) !void {
-		const tempPath = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}.tmp0", .{path}) catch unreachable;
+		const tempPath = main.fmt.allocPrint(main.stackAllocator, "{s}.tmp0", .{path});
 		defer main.stackAllocator.free(tempPath);
 
 		try self.dir.writeFile(.{.data = data, .sub_path = tempPath});

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -1,6 +1,22 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const main = @import("main");
+
+pub inline fn bufPrint(buf: []u8, comptime fmt: []const u8, args: anytype) std.fmt.BufPrintError![]u8 {
+	if (builtin.is_test) return std.fmt.bufPrint(buf, fmt, args);
+	var runtimeArgs: [args.len]FormatArg = undefined;
+	inline for (0..args.len) |i| {
+		runtimeArgs[i] = .fromAnytype(@TypeOf(args[i]), &args[i]);
+	}
+	return bufPrintRuntime(buf, fmt, &runtimeArgs);
+}
+
+pub noinline fn bufPrintRuntime(buf: []u8, fmt: []const u8, args: []const FormatArg) std.fmt.BufPrintError![]u8 {
+	var writer: std.Io.Writer = .fixed(buf);
+	format(&writer, fmt, args) catch return error.NoSpaceLeft;
+	return writer.buffered();
+}
 
 pub const FormatArg = union(enum) {
 	int: i128,

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -18,6 +18,38 @@ pub noinline fn bufPrintRuntime(buf: []u8, fmt: []const u8, args: []const Format
 	return writer.buffered();
 }
 
+pub inline fn allocPrint(gpa: main.heap.NeverFailingAllocator, comptime fmt: []const u8, args: anytype) []u8 {
+	if (builtin.is_test) return std.fmt.allocPrint(gpa.allocator, fmt, args) catch unreachable;
+	var runtimeArgs: [args.len]FormatArg = undefined;
+	inline for (0..args.len) |i| {
+		runtimeArgs[i] = .fromAnytype(@TypeOf(args[i]), &args[i]);
+	}
+	return allocPrintRuntime(gpa, fmt, &runtimeArgs);
+}
+
+pub noinline fn allocPrintRuntime(gpa: main.heap.NeverFailingAllocator, fmt: []const u8, args: []const FormatArg) []u8 {
+	var writer = std.Io.Writer.Allocating.initCapacity(gpa.allocator, fmt.len) catch unreachable;
+	defer writer.deinit();
+	format(&writer.writer, fmt, args) catch unreachable;
+	return writer.toOwnedSlice() catch unreachable;
+}
+
+pub inline fn allocPrintSentinel(gpa: main.heap.NeverFailingAllocator, comptime fmt: []const u8, args: anytype, comptime sentinel: u8) [:sentinel]u8 {
+	if (builtin.is_test) return std.fmt.allocPrintSentinel(gpa.allocator, fmt, args, sentinel) catch unreachable;
+	var runtimeArgs: [args.len]FormatArg = undefined;
+	inline for (0..args.len) |i| {
+		runtimeArgs[i] = .fromAnytype(@TypeOf(args[i]), &args[i]);
+	}
+	return allocPrintSentinelRuntime(gpa, fmt, &runtimeArgs, sentinel);
+}
+
+pub noinline fn allocPrintSentinelRuntime(gpa: main.heap.NeverFailingAllocator, fmt: []const u8, args: []const FormatArg, comptime sentinel: u8) [:sentinel]u8 {
+	var writer = std.Io.Writer.Allocating.initCapacity(gpa.allocator, fmt.len) catch unreachable;
+	defer writer.deinit();
+	format(&writer.writer, fmt, args) catch unreachable;
+	return writer.toOwnedSliceSentinel(sentinel) catch unreachable;
+}
+
 pub const FormatArg = union(enum) {
 	int: i128,
 	uint: u128,
@@ -54,7 +86,7 @@ pub const FormatArg = union(enum) {
 				if (@hasDecl(T, "format")) {
 					const typeErasedFormat = struct {
 						fn typeErasedFormat(ptr: *const anyopaque, writer: *std.Io.Writer) std.Io.Writer.Error!void {
-							return T.format(@as(*const T, @ptrCast(@alignCast(ptr))).*, writer);
+							return @as(*const T, @ptrCast(@alignCast(ptr))).*.format(writer);
 						}
 					}.typeErasedFormat;
 					return .{.formatFunction = .{.val = val, .function = typeErasedFormat}};

--- a/src/game.zig
+++ b/src/game.zig
@@ -688,7 +688,7 @@ pub const World = struct { // MARK: World
 		self.toolPalette = try assets.Palette.init(main.globalAllocator, zon.getChild("toolPalette"), null);
 		errdefer self.toolPalette.deinit();
 
-		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/serverAssets", .{main.files.cubyzDirStr()}) catch unreachable;
+		const path = main.fmt.allocPrint(main.stackAllocator, "{s}/serverAssets", .{main.files.cubyzDirStr()});
 		defer main.stackAllocator.free(path);
 		try assets.loadWorldAssets(path, self.blockPalette, self.itemPalette, self.toolPalette, self.biomePalette);
 		Player.id = zon.get(u32, "player_id", std.math.maxInt(u32));

--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -559,7 +559,7 @@ pub const draw = struct { // MARK: draw
 	}
 
 	pub inline fn print(comptime format: []const u8, args: anytype, x: f32, y: f32, fontSize: f32, alignment: TextBuffer.Alignment) void {
-		const string = std.fmt.allocPrint(main.stackAllocator.allocator, format, args) catch unreachable;
+		const string = main.fmt.allocPrint(main.stackAllocator, format, args);
 		defer main.stackAllocator.free(string);
 		text(string, x, y, fontSize, alignment);
 	}
@@ -2321,7 +2321,7 @@ pub const Texture = struct { // MARK: Texture
 
 		curSize = largestSize;
 		while (curSize != 0) : (curSize /= 2) {
-			const path = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}{}.png", .{pathPrefix, curSize}) catch unreachable;
+			const path = main.fmt.allocPrint(main.stackAllocator, "{s}{}.png", .{pathPrefix, curSize});
 			defer main.stackAllocator.free(path);
 			const image = Image.readFromFile(main.stackAllocator, path) catch |err| blk: {
 				std.log.err("Couldn't read image from {s}: {s}", .{path, @errorName(err)});

--- a/src/graphics/Window.zig
+++ b/src/graphics/Window.zig
@@ -216,7 +216,7 @@ pub const Gamepad = struct {
 				std.log.err("Failed to write controller mappings: {s}", .{@errorName(err)});
 				return;
 			};
-			const timeStampStr = std.fmt.allocPrint(main.stackAllocator.allocator, "{x}", .{self.*.curTimestamp}) catch unreachable;
+			const timeStampStr = main.fmt.allocPrint(main.stackAllocator, "{x}", .{self.*.curTimestamp});
 			defer main.stackAllocator.free(timeStampStr);
 			files.cwd().write("gamecontrollerdb.stamp", timeStampStr) catch |err| {
 				std.log.err("Failed to write controller mappings: {s}", .{@errorName(err)});

--- a/src/gui/components/Button.zig
+++ b/src/gui/components/Button.zig
@@ -25,10 +25,10 @@ const Textures = struct {
 
 	pub fn init(basePath: []const u8) Textures {
 		var self: Textures = undefined;
-		const buttonPath = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}.png", .{basePath}) catch unreachable;
+		const buttonPath = main.fmt.allocPrint(main.stackAllocator, "{s}.png", .{basePath});
 		defer main.stackAllocator.free(buttonPath);
 		self.texture = Texture.initFromFile(buttonPath);
-		const outlinePath = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}_outline.png", .{basePath}) catch unreachable;
+		const outlinePath = main.fmt.allocPrint(main.stackAllocator, "{s}_outline.png", .{basePath});
 		defer main.stackAllocator.free(outlinePath);
 		self.outlineTexture = Texture.initFromFile(outlinePath);
 		self.outlineTextureSize = @floatFromInt(self.outlineTexture.size());

--- a/src/gui/components/DiscreteSlider.zig
+++ b/src/gui/components/DiscreteSlider.zig
@@ -44,7 +44,7 @@ pub fn init(pos: Vec2f, width: f32, text: []const u8, comptime fmt: []const u8, 
 	const values = main.globalAllocator.alloc([]const u8, valueList.len);
 	var maxLen: usize = 0;
 	for (valueList, 0..) |value, i| {
-		values[i] = std.fmt.allocPrint(main.globalAllocator.allocator, fmt, .{value}) catch unreachable;
+		values[i] = main.fmt.allocPrint(main.globalAllocator, fmt, .{value});
 		maxLen = @max(maxLen, values[i].len);
 	}
 

--- a/src/gui/components/ItemSlot.zig
+++ b/src/gui/components/ItemSlot.zig
@@ -77,7 +77,7 @@ pub fn init(pos: Vec2f, inventory: ClientInventory, itemSlot: u32, texture: Text
 		.inventory = inventory,
 		.itemSlot = itemSlot,
 		.pos = pos,
-		.text = TextBuffer.init(main.globalAllocator, std.fmt.bufPrint(&buf, "{}", .{amount}) catch "∞", .{}, false, .right),
+		.text = TextBuffer.init(main.globalAllocator, main.fmt.bufPrint(&buf, "{}", .{amount}) catch "∞", .{}, false, .right),
 		.lastItemAmount = amount,
 		.texture = texture.value(),
 		.mode = mode,
@@ -100,7 +100,7 @@ fn refreshText(self: *ItemSlot) void {
 	var buf: [16]u8 = undefined;
 	self.text = TextBuffer.init(
 		main.globalAllocator,
-		std.fmt.bufPrint(&buf, "{}", .{amount}) catch "∞",
+		main.fmt.bufPrint(&buf, "{}", .{amount}) catch "∞",
 		.{.color = if (amount == 0) 0xff0000 else 0xffffff},
 		false,
 		.right,

--- a/src/gui/windows/advanced_controls.zig
+++ b/src/gui/windows/advanced_controls.zig
@@ -26,7 +26,7 @@ fn delayCallback(newValue: f32) void {
 }
 
 fn delayFormatter(allocator: main.heap.NeverFailingAllocator, value: f32) []const u8 {
-	return std.fmt.allocPrint(allocator.allocator, "#ffffffPlace/Break Delay: {d:.0} ms", .{value/1.0e6}) catch unreachable;
+	return main.fmt.allocPrint(allocator, "#ffffffPlace/Break Delay: {d:.0} ms", .{value/1.0e6});
 }
 
 fn speedCallback(newValue: f32) void {
@@ -35,7 +35,7 @@ fn speedCallback(newValue: f32) void {
 }
 
 fn speedFormatter(allocator: main.heap.NeverFailingAllocator, value: f32) []const u8 {
-	return std.fmt.allocPrint(allocator.allocator, "#ffffffPlace/Break Speed: {d:.0} ms", .{value/1.0e6}) catch unreachable;
+	return main.fmt.allocPrint(allocator, "#ffffffPlace/Break Speed: {d:.0} ms", .{value/1.0e6});
 }
 
 pub fn onOpen() void {

--- a/src/gui/windows/authentication/unlock.zig
+++ b/src/gui/windows/authentication/unlock.zig
@@ -33,7 +33,7 @@ fn apply() void {
 		if (err == error.AuthenticationFailed) {
 			incorrectPasswordLabel.updateText("#ff0000Incorrect password.");
 		} else {
-			const formattedError = std.fmt.allocPrint(main.stackAllocator.allocator, "#ff0000Authentication data is corrupted: {s}", .{@errorName(err)}) catch unreachable;
+			const formattedError = main.fmt.allocPrint(main.stackAllocator, "#ff0000Authentication data is corrupted: {s}", .{@errorName(err)});
 			defer main.stackAllocator.free(formattedError);
 			incorrectPasswordLabel.updateText(formattedError);
 		}

--- a/src/gui/windows/controls.zig
+++ b/src/gui/windows/controls.zig
@@ -71,11 +71,11 @@ fn updateDeadzone(deadzone: f32) void {
 }
 
 fn deadzoneFormatter(allocator: main.heap.NeverFailingAllocator, value: f32) []const u8 {
-	return std.fmt.allocPrint(allocator.allocator, "Deadzone: {d:.0}%", .{value*100}) catch unreachable;
+	return main.fmt.allocPrint(allocator, "Deadzone: {d:.0}%", .{value*100});
 }
 
 fn sensitivityFormatter(allocator: main.heap.NeverFailingAllocator, value: f32) []const u8 {
-	return std.fmt.allocPrint(allocator.allocator, "{s} Sensitivity: {d:.0}%", .{if (editingKeyboard) "Mouse" else "Controller", value*100}) catch unreachable;
+	return main.fmt.allocPrint(allocator, "{s} Sensitivity: {d:.0}%", .{if (editingKeyboard) "Mouse" else "Controller", value*100});
 }
 
 fn toggleKeyboard() void {

--- a/src/gui/windows/debug.zig
+++ b/src/gui/windows/debug.zig
@@ -30,12 +30,12 @@ pub var window = GuiWindow{
 pub fn render() void {
 	draw.setColor(0xffffffff);
 	var y: f32 = 0;
-	const fpsCapText = if (main.settings.fpsCap) |fpsCap| std.fmt.allocPrint(main.stackAllocator.allocator, " (limit: {d:.0} Hz)", .{fpsCap}) catch unreachable else "";
+	const fpsCapText = if (main.settings.fpsCap) |fpsCap| main.fmt.allocPrint(main.stackAllocator, " (limit: {d:.0} Hz)", .{fpsCap}) else "";
 	defer main.stackAllocator.allocator.free(fpsCapText);
-	const fpsLimit = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}{s}", .{
+	const fpsLimit = main.fmt.allocPrint(main.stackAllocator, "{s}{s}", .{
 		fpsCapText,
 		if (main.settings.vsync) " (vsync)" else "",
-	}) catch unreachable;
+	});
 	defer main.stackAllocator.allocator.free(fpsLimit);
 	draw.print("fps: {d:.0} Hz{s}", .{1.0/main.lastDeltaTime.load(.monotonic), fpsLimit}, 0, y, 8, .left);
 	y += 8;

--- a/src/gui/windows/delete_world_confirmation.zig
+++ b/src/gui/windows/delete_world_confirmation.zig
@@ -47,7 +47,7 @@ fn deleteWorld() void {
 
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
-	const text = std.fmt.allocPrint(main.stackAllocator.allocator, "Are you sure you want to delete the world **{s}**?", .{deleteWorldName}) catch unreachable;
+	const text = main.fmt.allocPrint(main.stackAllocator, "Are you sure you want to delete the world **{s}**?", .{deleteWorldName});
 	defer main.stackAllocator.free(text);
 	list.add(Label.init(.{0, 0}, 128, text, .center));
 	list.add(Button.initText(.{0, 0}, 128, "Yes", .init(deleteWorld)));

--- a/src/gui/windows/graphics.zig
+++ b/src/gui/windows/graphics.zig
@@ -74,11 +74,11 @@ fn fovCallback(newValue: f32) void {
 }
 
 fn fovFormatter(allocator: main.heap.NeverFailingAllocator, value: f32) []const u8 {
-	return std.fmt.allocPrint(allocator.allocator, "#ffffffField Of View: {d:.0}°", .{value}) catch unreachable;
+	return main.fmt.allocPrint(allocator, "#ffffffField Of View: {d:.0}°", .{value});
 }
 
 fn lodDistanceFormatter(allocator: main.heap.NeverFailingAllocator, value: f32) []const u8 {
-	return std.fmt.allocPrint(allocator.allocator, "#ffffffOpaque leaves distance: {d:.0}", .{@round(value)}) catch unreachable;
+	return main.fmt.allocPrint(allocator, "#ffffffOpaque leaves distance: {d:.0}", .{@round(value)});
 }
 
 fn lodDistanceCallback(newValue: f32) void {
@@ -87,7 +87,7 @@ fn lodDistanceCallback(newValue: f32) void {
 }
 
 fn contrastFormatter(allocator: main.heap.NeverFailingAllocator, value: f32) []const u8 {
-	return std.fmt.allocPrint(allocator.allocator, "#ffffffBlock Contrast: {d:.0}%", .{@round(value*100)}) catch unreachable;
+	return main.fmt.allocPrint(allocator, "#ffffffBlock Contrast: {d:.0}%", .{@round(value*100)});
 }
 
 fn contrastCallback(newValue: f32) void {
@@ -100,7 +100,7 @@ fn nightBrightnessCallback(newValue: f32) void {
 	settings.save();
 }
 fn nightBrightnessFormatter(allocator: main.heap.NeverFailingAllocator, _: f32) []const u8 {
-	return std.fmt.allocPrint(allocator.allocator, "Night Brightness", .{}) catch unreachable;
+	return main.fmt.allocPrint(allocator, "Night Brightness", .{});
 }
 
 fn bloomCallback(newValue: bool) void {

--- a/src/gui/windows/invite.zig
+++ b/src/gui/windows/invite.zig
@@ -30,7 +30,7 @@ const width: f32 = 420;
 
 fn discoverIpAddress() void {
 	main.server.connectionManager.makeOnline();
-	ipAddress = std.fmt.allocPrint(main.globalAllocator.allocator, "{f}", .{main.server.connectionManager.externalAddress}) catch unreachable;
+	ipAddress = main.fmt.allocPrint(main.globalAllocator, "{f}", .{main.server.connectionManager.externalAddress});
 	gotIpAddress.store(true, .release);
 }
 

--- a/src/gui/windows/manage_players.zig
+++ b/src/gui/windows/manage_players.zig
@@ -41,7 +41,7 @@ pub fn onOpen() void {
 				row.add(Label.init(.{0, 0}, 200, connection.user.?.name, .left));
 				row.add(Button.initText(.{0, 0}, 100, "Kick", .initWithPtr(kick, connection)));
 			} else {
-				const ip = std.fmt.allocPrint(main.stackAllocator.allocator, "{f}", .{connection.remoteAddress}) catch unreachable;
+				const ip = main.fmt.allocPrint(main.stackAllocator, "{f}", .{connection.remoteAddress});
 				defer main.stackAllocator.free(ip);
 				row.add(Label.init(.{0, 0}, 200, ip, .left));
 				row.add(Button.initText(.{0, 0}, 100, "Cancel", .initWithPtr(kick, connection)));

--- a/src/gui/windows/multiplayer.zig
+++ b/src/gui/windows/multiplayer.zig
@@ -34,7 +34,7 @@ fn discoverIpAddress() void {
 		ipAddress = main.globalAllocator.dupe(u8, @errorName(err));
 		return;
 	};
-	ipAddress = std.fmt.allocPrint(main.globalAllocator.allocator, "{f}", .{connection.?.externalAddress}) catch unreachable;
+	ipAddress = main.fmt.allocPrint(main.globalAllocator, "{f}", .{connection.?.externalAddress});
 	gotIpAddress.store(true, .release);
 }
 

--- a/src/gui/windows/notification.zig
+++ b/src/gui/windows/notification.zig
@@ -25,7 +25,7 @@ pub fn deinit() void {
 
 fn setNotificationText(comptime formatText: []const u8, args: anytype) void {
 	main.globalAllocator.free(text);
-	text = std.fmt.allocPrint(main.globalAllocator.allocator, formatText, args) catch unreachable;
+	text = main.fmt.allocPrint(main.globalAllocator, formatText, args);
 }
 
 pub fn raiseNotification(comptime formatText: []const u8, args: anytype) void {

--- a/src/gui/windows/save_creation.zig
+++ b/src/gui/windows/save_creation.zig
@@ -106,12 +106,12 @@ pub fn onOpen() void {
 
 	var num: usize = 1;
 	while (true) {
-		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/Save{}", .{num}) catch unreachable;
+		const path = main.fmt.allocPrint(main.stackAllocator, "saves/Save{}", .{num});
 		defer main.stackAllocator.free(path);
 		if (!main.files.cubyzDir().hasDir(path)) break;
 		num += 1;
 	}
-	const name = std.fmt.allocPrint(main.stackAllocator.allocator, "Save{}", .{num}) catch unreachable;
+	const name = main.fmt.allocPrint(main.stackAllocator, "Save{}", .{num});
 	defer main.stackAllocator.free(name);
 	nameInput = TextInput.init(.{0, 0}, 128, 22, name, .{.onNewline = .init(createWorld)});
 	list.add(nameInput);

--- a/src/gui/windows/save_selection.zig
+++ b/src/gui/windows/save_selection.zig
@@ -66,7 +66,7 @@ pub fn openWorld(name: []const u8) void {
 		main.heap.GarbageCollection.syncPoint();
 	}
 	clientConnection.world = &main.game.testWorld;
-	const ipPort = std.fmt.allocPrint(main.stackAllocator.allocator, "127.0.0.1:{}", .{main.server.connectionManager.localPort}) catch unreachable;
+	const ipPort = main.fmt.allocPrint(main.stackAllocator, "127.0.0.1:{}", .{main.server.connectionManager.localPort});
 	defer main.stackAllocator.free(ipPort);
 	main.game.world = &main.game.testWorld;
 	main.game.testWorld.init(ipPort, clientConnection) catch |err| {
@@ -89,7 +89,7 @@ fn deleteWorld(index: usize) void {
 }
 
 fn openFolder(index: usize) void {
-	const path = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/saves/{s}", .{main.files.cubyzDirStr(), worldList.items[index].fileName}) catch unreachable;
+	const path = main.fmt.allocPrint(main.stackAllocator, "{s}/saves/{s}", .{main.files.cubyzDirStr(), worldList.items[index].fileName});
 	defer main.stackAllocator.free(path);
 
 	main.files.openDirInWindow(path);
@@ -123,7 +123,7 @@ pub fn onOpen() void {
 			break :readingSaves;
 		}) |entry| {
 			if (entry.kind == .directory) {
-				const worldInfoPath = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/world.zig.zon", .{entry.name}) catch unreachable;
+				const worldInfoPath = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/world.zig.zon", .{entry.name});
 				defer main.stackAllocator.free(worldInfoPath);
 				const worldInfo = main.files.cubyzDir().readToZon(main.stackAllocator, worldInfoPath) catch |err| {
 					std.log.err("Couldn't open save {s}: {s}", .{worldInfoPath, @errorName(err)});

--- a/src/gui/windows/sound.zig
+++ b/src/gui/windows/sound.zig
@@ -36,7 +36,7 @@ fn linearToDezibel(x: f32) f32 {
 fn musicFormatter(allocator: NeverFailingAllocator, value: f32) []const u8 {
 	const percentage = 100*deziBelToLinear(value);
 	if (percentage == 0) return allocator.dupe(u8, "Music volume: Off");
-	return std.fmt.allocPrint(allocator.allocator, "Music volume:", .{}) catch unreachable;
+	return main.fmt.allocPrint(allocator, "Music volume:", .{});
 }
 
 const padding: f32 = 8;

--- a/src/items.zig
+++ b/src/items.zig
@@ -1203,13 +1203,13 @@ fn loadPixelSources(assetFolder: []const u8, id: []const u8, layerPostfix: []con
 	var split = std.mem.splitScalar(u8, id, ':');
 	const mod = split.first();
 	const tool = split.rest();
-	const path = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/{s}/tools/{s}{s}.png", .{assetFolder, mod, tool, layerPostfix}) catch unreachable;
+	const path = main.fmt.allocPrint(main.stackAllocator, "{s}/{s}/tools/{s}{s}.png", .{assetFolder, mod, tool, layerPostfix});
 	defer main.stackAllocator.free(path);
 	const image = main.graphics.Image.readFromFile(main.stackAllocator, path) catch |err| blk: {
 		if (err != error.FileNotFound) {
 			std.log.err("Error while reading tool image '{s}': {s}", .{path, @errorName(err)});
 		}
-		const replacementPath = std.fmt.allocPrint(main.stackAllocator.allocator, "assets/{s}/tools/{s}{s}.png", .{mod, tool, layerPostfix}) catch unreachable;
+		const replacementPath = main.fmt.allocPrint(main.stackAllocator, "assets/{s}/tools/{s}{s}.png", .{mod, tool, layerPostfix});
 		defer main.stackAllocator.free(replacementPath);
 		break :blk main.graphics.Image.readFromFile(main.stackAllocator, replacementPath) catch |err2| {
 			if (layerPostfix.len == 0 or err2 != error.FileNotFound)

--- a/src/main.zig
+++ b/src/main.zig
@@ -154,7 +154,7 @@ fn initLogging() void {
 
 	const _timestamp = (std.Io.Clock.Timestamp.now(io, .real) catch unreachable).raw;
 
-	const _path_str = std.fmt.allocPrint(stackAllocator.allocator, "logs/ts_{}.log", .{_timestamp.nanoseconds}) catch unreachable;
+	const _path_str = fmt.allocPrint(stackAllocator, "logs/ts_{}.log", .{_timestamp.nanoseconds});
 	defer stackAllocator.free(_path_str);
 
 	logFileTs = std.fs.cwd().createFile(_path_str, .{}) catch |err| {

--- a/src/migrations.zig
+++ b/src/migrations.zig
@@ -64,7 +64,7 @@ fn register(
 			continue;
 		}
 
-		const oldAssetId = std.fmt.allocPrint(main.worldArena.allocator, "{s}:{s}", .{addonName, oldZon}) catch unreachable;
+		const oldAssetId = main.fmt.allocPrint(main.worldArena, "{s}:{s}", .{addonName, oldZon});
 		const result = collection.getOrPut(main.worldArena.allocator, oldAssetId) catch unreachable;
 
 		if (result.found_existing) {
@@ -74,7 +74,7 @@ fn register(
 
 			main.worldArena.free(oldAssetId);
 		} else {
-			const newAssetId = std.fmt.allocPrint(main.worldArena.allocator, "{s}:{s}", .{addonName, newZon}) catch unreachable;
+			const newAssetId = main.fmt.allocPrint(main.worldArena, "{s}:{s}", .{addonName, newZon});
 
 			result.key_ptr.* = oldAssetId;
 			result.value_ptr.* = newAssetId;

--- a/src/network.zig
+++ b/src/network.zig
@@ -634,7 +634,7 @@ pub const ConnectionManager = struct { // MARK: ConnectionManager
 		}
 		if (self.allowNewConnections.load(.monotonic) or source.ip == Address.localHost) {
 			if (data.len != 0 and data[0] == @intFromEnum(Connection.ChannelId.init)) {
-				const ip = std.fmt.allocPrint(main.stackAllocator.allocator, "{f}", .{source}) catch unreachable;
+				const ip = main.fmt.allocPrint(main.stackAllocator, "{f}", .{source});
 				defer main.stackAllocator.free(ip);
 				const user = main.server.User.initAndIncreaseRefCount(main.server.connectionManager, ip) catch |err| {
 					std.log.err("Cannot connect user from external IP {f}: {s}", .{source, @errorName(err)});

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -207,7 +207,7 @@ pub const handShake = struct { // MARK: handShake
 				.signatureResponse => {
 					try conn.user.?.verifySignatures(reader);
 					{
-						const path = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/assets/", .{main.server.world.?.path}) catch unreachable;
+						const path = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/assets/", .{main.server.world.?.path});
 						defer main.stackAllocator.free(path);
 						var dir = try main.files.cubyzDir().openIterableDir(path);
 						defer dir.close();

--- a/src/particles.zig
+++ b/src/particles.zig
@@ -121,10 +121,10 @@ pub const ParticleManager = struct {
 		const mod = splitter.first();
 		const id = splitter.rest();
 
-		const gameAssetsPath = std.fmt.allocPrint(main.stackAllocator.allocator, "assets/{s}/particles/textures/{s}{s}", .{mod, id, suffix}) catch unreachable;
+		const gameAssetsPath = main.fmt.allocPrint(main.stackAllocator, "assets/{s}/particles/textures/{s}{s}", .{mod, id, suffix});
 		defer main.stackAllocator.free(gameAssetsPath);
 
-		const worldAssetsPath = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/{s}/particles/textures/{s}{s}", .{assetsFolder, mod, id, suffix}) catch unreachable;
+		const worldAssetsPath = main.fmt.allocPrint(main.stackAllocator, "{s}/{s}/particles/textures/{s}{s}", .{assetsFolder, mod, id, suffix});
 		defer main.stackAllocator.free(worldAssetsPath);
 
 		return graphics.Image.readFromFile(main.worldArena, worldAssetsPath) catch graphics.Image.readFromFile(main.worldArena, gameAssetsPath) catch {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -545,7 +545,7 @@ pub const MenuBackGround = struct {
 			defer main.stackAllocator.free(defaultImageData);
 			try dir.write("default_background.png", defaultImageData);
 
-			return std.fmt.allocPrint(allocator.allocator, "{s}/backgrounds/default_background.png", .{main.files.cubyzDirStr()}) catch unreachable;
+			return main.fmt.allocPrint(allocator, "{s}/backgrounds/default_background.png", .{main.files.cubyzDirStr()});
 		}
 
 		// Otherwise load a random texture from the backgrounds folder. The player may make their own pictures which can be chosen as well.
@@ -568,7 +568,7 @@ pub const MenuBackGround = struct {
 			return error.NoBackgroundImagesFound;
 		}
 		const theChosenOne = main.random.nextIntBounded(u32, &main.seed, @as(u32, @intCast(fileList.items.len)));
-		return std.fmt.allocPrint(allocator.allocator, "{s}/backgrounds/{s}", .{main.files.cubyzDirStr(), fileList.items[theChosenOne]}) catch unreachable;
+		return main.fmt.allocPrint(allocator, "{s}/backgrounds/{s}", .{main.files.cubyzDirStr(), fileList.items[theChosenOne]});
 	}
 
 	pub fn deinit() void {
@@ -653,7 +653,7 @@ pub const MenuBackGround = struct {
 		}
 		c.glBindFramebuffer(c.GL_FRAMEBUFFER, 0);
 
-		const fileName = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/backgrounds/{s}_{}.png", .{main.files.cubyzDirStr(), game.world.?.name, game.world.?.gameTime.load(.monotonic)}) catch unreachable;
+		const fileName = main.fmt.allocPrint(main.stackAllocator, "{s}/backgrounds/{s}_{}.png", .{main.files.cubyzDirStr(), game.world.?.name, game.world.?.gameTime.load(.monotonic)});
 		defer main.stackAllocator.free(fileName);
 		image.exportToFile(fileName) catch |err| {
 			std.log.err("Cannot write file {s} due to {s}", .{fileName, @errorName(err)});

--- a/src/server/command/worldedit/blueprint.zig
+++ b/src/server/command/worldedit/blueprint.zig
@@ -110,7 +110,7 @@ fn openBlueprintsDir(source: *User) ?Dir {
 
 fn ensureBlueprintExtension(allocator: NeverFailingAllocator, fileName: []const u8) []const u8 {
 	if (!std.ascii.endsWithIgnoreCase(fileName, ".blp")) {
-		return std.fmt.allocPrint(allocator.allocator, "{s}.blp", .{fileName}) catch unreachable;
+		return main.fmt.allocPrint(allocator, "{s}.blp", .{fileName});
 	} else {
 		return allocator.dupe(u8, fileName);
 	}

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -210,12 +210,12 @@ pub const User = struct { // MARK: User
 		{
 			const keyBase64 = keys.get(?[]const u8, @tagName(main.settings.launchConfig.preferredAuthenticationAlgorithm), null) orelse return error.PublicKeyNotPresent;
 			self.key = try .initFromBase64(keyBase64, main.settings.launchConfig.preferredAuthenticationAlgorithm);
-			self.newKeyString = std.fmt.allocPrint(main.globalAllocator.allocator, "{s}:{s}", .{@tagName(main.settings.launchConfig.preferredAuthenticationAlgorithm), keyBase64}) catch unreachable;
+			self.newKeyString = main.fmt.allocPrint(main.globalAllocator, "{s}:{s}", .{@tagName(main.settings.launchConfig.preferredAuthenticationAlgorithm), keyBase64});
 		}
 		var foundKey: bool = false;
 		for (std.meta.fieldNames(main.network.authentication.KeyTypeEnum)) |keyTypeName| {
 			const keyBase64 = keys.get(?[]const u8, keyTypeName, null) orelse continue;
-			const keyWithType = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}:{s}", .{keyTypeName, keyBase64}) catch unreachable;
+			const keyWithType = main.fmt.allocPrint(main.stackAllocator, "{s}:{s}", .{keyTypeName, keyBase64});
 			defer main.stackAllocator.free(keyWithType);
 			self.playerIndex = world.?.playerDatabase.get(keyWithType) orelse continue;
 			foundKey = true;
@@ -225,7 +225,7 @@ pub const User = struct { // MARK: User
 			break;
 		}
 		if (!foundKey) {
-			const nameEntry = std.fmt.allocPrint(main.stackAllocator.allocator, "name:{s}", .{name}) catch unreachable;
+			const nameEntry = main.fmt.allocPrint(main.stackAllocator, "name:{s}", .{name});
 			defer main.stackAllocator.free(nameEntry);
 			self.playerIndex = world.?.playerDatabase.get(nameEntry) orelse world.?.nextPlayerIndex.fetchAdd(1, .monotonic);
 		}
@@ -471,7 +471,7 @@ pub const User = struct { // MARK: User
 	}
 
 	pub fn sendMessage(self: *User, comptime fmt: []const u8, args: anytype) void {
-		const msg = std.fmt.allocPrint(main.stackAllocator.allocator, fmt, args) catch unreachable;
+		const msg = main.fmt.allocPrint(main.stackAllocator, fmt, args);
 		defer main.stackAllocator.free(msg);
 		self.sendRawMessage(msg);
 	}
@@ -533,7 +533,7 @@ fn init(name: []const u8, singlePlayerPort: ?u16) void { // MARK: init()
 		@panic("Can't generate world.");
 	};
 	if (singlePlayerPort) |port| blk: {
-		const ipString = std.fmt.allocPrint(main.stackAllocator.allocator, "127.0.0.1:{}", .{port}) catch unreachable;
+		const ipString = main.fmt.allocPrint(main.stackAllocator, "127.0.0.1:{}", .{port});
 		defer main.stackAllocator.free(ipString);
 		const user = User.initAndIncreaseRefCount(connectionManager, ipString) catch |err| {
 			std.log.err("Cannot create singleplayer user {s}", .{@errorName(err)});
@@ -799,7 +799,7 @@ fn sendRawMessage(msg: []const u8) void {
 
 var chatMutex: std.Thread.Mutex = .{};
 pub fn sendMessage(comptime fmt: []const u8, args: anytype) void {
-	const msg = std.fmt.allocPrint(main.stackAllocator.allocator, fmt, args) catch unreachable;
+	const msg = main.fmt.allocPrint(main.stackAllocator, fmt, args);
 	defer main.stackAllocator.free(msg);
 	sendRawMessage(msg);
 }

--- a/src/server/storage.zig
+++ b/src/server/storage.zig
@@ -40,7 +40,7 @@ pub const RegionFile = struct { // MARK: RegionFile
 			.saveFolder = main.globalAllocator.dupe(u8, saveFolder),
 		};
 
-		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/{}/{}/{}/{}.region", .{saveFolder, pos.voxelSize, pos.wx, pos.wy, pos.wz}) catch unreachable;
+		const path = main.fmt.allocPrint(main.stackAllocator, "{s}/{}/{}/{}/{}.region", .{saveFolder, pos.voxelSize, pos.wx, pos.wy, pos.wz});
 		defer main.stackAllocator.free(path);
 		const data = main.files.cubyzDir().read(main.stackAllocator, path) catch {
 			return self;
@@ -143,9 +143,9 @@ pub const RegionFile = struct { // MARK: RegionFile
 		}
 		std.debug.assert(writer.data.items.len == totalSize + headerSize);
 
-		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/{}/{}/{}/{}.region", .{self.saveFolder, self.pos.voxelSize, self.pos.wx, self.pos.wy, self.pos.wz}) catch unreachable;
+		const path = main.fmt.allocPrint(main.stackAllocator, "{s}/{}/{}/{}/{}.region", .{self.saveFolder, self.pos.voxelSize, self.pos.wx, self.pos.wy, self.pos.wz});
 		defer main.stackAllocator.free(path);
-		const folder = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/{}/{}/{}", .{self.saveFolder, self.pos.voxelSize, self.pos.wx, self.pos.wy}) catch unreachable;
+		const folder = main.fmt.allocPrint(main.stackAllocator, "{s}/{}/{}/{}", .{self.saveFolder, self.pos.voxelSize, self.pos.wx, self.pos.wy});
 		defer main.stackAllocator.free(folder);
 
 		main.files.cubyzDir().makePath(folder) catch |err| {
@@ -215,7 +215,7 @@ fn cacheInit(pos: chunk.ChunkPosition) *RegionFile {
 		return region;
 	}
 	hashMapMutex.unlock();
-	const path: []const u8 = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/chunks", .{server.world.?.path}) catch unreachable;
+	const path: []const u8 = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/chunks", .{server.world.?.path});
 	defer main.stackAllocator.free(path);
 	return RegionFile.init(pos, path);
 }

--- a/src/server/terrain/SurfaceMap.zig
+++ b/src/server/terrain/SurfaceMap.zig
@@ -133,10 +133,10 @@ pub const MapFragment = struct { // MARK: MapFragment
 	};
 
 	pub fn load(self: *MapFragment, biomePalette: *main.assets.Palette, originalHeightMap: ?*[mapSize][mapSize]i32) !NeighborInfo {
-		const saveFolder: []const u8 = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/maps", .{main.server.world.?.path}) catch unreachable;
+		const saveFolder: []const u8 = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/maps", .{main.server.world.?.path});
 		defer main.stackAllocator.free(saveFolder);
 
-		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/{}/{}/{}.surface", .{saveFolder, self.pos.voxelSize, self.pos.wx, self.pos.wy}) catch unreachable;
+		const path = main.fmt.allocPrint(main.stackAllocator, "{s}/{}/{}/{}.surface", .{saveFolder, self.pos.voxelSize, self.pos.wx, self.pos.wy});
 		defer main.stackAllocator.free(path);
 
 		const fullData = try main.files.cubyzDir().read(main.stackAllocator, path);
@@ -216,12 +216,12 @@ pub const MapFragment = struct { // MARK: MapFragment
 		outputWriter.writeInt(u8, @bitCast(header.neighborInfo));
 		outputWriter.writeSlice(compressedData);
 
-		const saveFolder: []const u8 = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/maps", .{main.server.world.?.path}) catch unreachable;
+		const saveFolder: []const u8 = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/maps", .{main.server.world.?.path});
 		defer main.stackAllocator.free(saveFolder);
 
-		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/{}/{}/{}.surface", .{saveFolder, self.pos.voxelSize, self.pos.wx, self.pos.wy}) catch unreachable;
+		const path = main.fmt.allocPrint(main.stackAllocator, "{s}/{}/{}/{}.surface", .{saveFolder, self.pos.voxelSize, self.pos.wx, self.pos.wy});
 		defer main.stackAllocator.free(path);
-		const folder = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/{}/{}", .{saveFolder, self.pos.voxelSize, self.pos.wx}) catch unreachable;
+		const folder = main.fmt.allocPrint(main.stackAllocator, "{s}/{}/{}", .{saveFolder, self.pos.voxelSize, self.pos.wx});
 		defer main.stackAllocator.free(folder);
 
 		main.files.cubyzDir().makePath(folder) catch |err| {
@@ -292,7 +292,7 @@ pub fn regenerateLOD(worldName: []const u8) !void { // MARK: regenerateLOD()
 	// Delete old LODs:
 	for (1..main.settings.highestSupportedLod + 1) |i| {
 		const lod = @as(u32, 1) << @intCast(i);
-		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/maps/{}", .{worldName, lod}) catch unreachable;
+		const path = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/maps/{}", .{worldName, lod});
 		defer main.stackAllocator.free(path);
 		main.files.cubyzDir().deleteTree(path) catch |err| {
 			if (err != error.FileNotFound) {
@@ -303,7 +303,7 @@ pub fn regenerateLOD(worldName: []const u8) !void { // MARK: regenerateLOD()
 	// Find all the stored maps:
 	var mapPositions = main.List(MapFragmentPosition).init(main.stackAllocator);
 	defer mapPositions.deinit();
-	const path = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/maps/1", .{worldName}) catch unreachable;
+	const path = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/maps/1", .{worldName});
 	defer main.stackAllocator.free(path);
 	{
 		var dirX = try main.files.cubyzDir().openIterableDir(path);

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -79,13 +79,13 @@ fn findValidFolderName(allocator: main.heap.NeverFailingAllocator, name: []const
 	defer main.stackAllocator.free(resultName);
 	var i: usize = 0;
 	while (true) {
-		const resultPath = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}", .{resultName}) catch unreachable;
+		const resultPath = main.fmt.allocPrint(main.stackAllocator, "saves/{s}", .{resultName});
 		defer main.stackAllocator.free(resultPath);
 
 		if (!main.files.cubyzDir().hasDir(resultPath)) break;
 
 		main.stackAllocator.free(resultName);
-		resultName = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}_{}", .{escapedName, i}) catch unreachable;
+		resultName = main.fmt.allocPrint(main.stackAllocator, "{s}_{}", .{escapedName, i});
 		i += 1;
 	}
 	return allocator.dupe(u8, resultName);
@@ -94,7 +94,7 @@ fn findValidFolderName(allocator: main.heap.NeverFailingAllocator, name: []const
 pub fn tryCreateWorld(worldName: []const u8, worldSettings: Settings, preset: ZonElement) !void {
 	const worldPath = findValidFolderName(main.stackAllocator, worldName);
 	defer main.stackAllocator.free(worldPath);
-	const saveFolder = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}", .{worldPath}) catch unreachable;
+	const saveFolder = main.fmt.allocPrint(main.stackAllocator, "saves/{s}", .{worldPath});
 	defer main.stackAllocator.free(saveFolder);
 	try main.files.cubyzDir().makePath(saveFolder);
 
@@ -105,7 +105,7 @@ pub fn tryCreateWorld(worldName: []const u8, worldSettings: Settings, preset: Zo
 	worldInfo.put("settings", worldSettings.toZon(main.stackAllocator));
 
 	{
-		const worldInfoPath = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/world.zig.zon", .{worldPath}) catch unreachable;
+		const worldInfoPath = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/world.zig.zon", .{worldPath});
 		defer main.stackAllocator.free(worldInfoPath);
 
 		worldInfo.put("name", worldName);
@@ -115,7 +115,7 @@ pub fn tryCreateWorld(worldName: []const u8, worldSettings: Settings, preset: Zo
 		try main.files.cubyzDir().writeZon(worldInfoPath, worldInfo);
 	}
 	{ // Make assets subfolder
-		const assetsPath = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/assets", .{worldPath}) catch unreachable;
+		const assetsPath = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/assets", .{worldPath});
 		defer main.stackAllocator.free(assetsPath);
 		try main.files.cubyzDir().makePath(assetsPath);
 	}
@@ -479,7 +479,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		const arena = main.stackAllocator.createArena();
 		defer main.stackAllocator.destroyArena(arena);
 
-		var dir = try files.cubyzDir().openDir(try std.fmt.allocPrint(arena.allocator, "saves/{s}", .{path}));
+		var dir = try files.cubyzDir().openDir(main.fmt.allocPrint(arena, "saves/{s}", .{path}));
 		defer dir.close();
 
 		self.blockPalette = try loadPalette(arena, path, "palette", "cubyz:air");
@@ -500,7 +500,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		try self.loadWorldConfig(arena, dir, worldData);
 		try self.loadPlayerLoginInfo(dir);
 
-		try main.assets.loadWorldAssets(try std.fmt.allocPrint(arena.allocator, "{s}/saves/{s}/assets/", .{files.cubyzDirStr(), path}), self.blockPalette, self.itemPalette, self.toolPalette, self.biomePalette);
+		try main.assets.loadWorldAssets(main.fmt.allocPrint(arena, "{s}/saves/{s}/assets/", .{files.cubyzDirStr(), path}), self.blockPalette, self.itemPalette, self.toolPalette, self.biomePalette);
 		// Store the block palette now that everything is loaded.
 		try dir.writeZon("palette.zig.zon", self.blockPalette.storeToZon(arena));
 		try dir.writeZon("item_palette.zig.zon", self.itemPalette.storeToZon(arena));
@@ -514,7 +514,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 	}
 
 	pub fn loadPalette(allocator: NeverFailingAllocator, worldName: []const u8, paletteName: []const u8, firstEntry: ?[]const u8) !*Palette {
-		const path = try std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/{s}.zig.zon", .{worldName, paletteName});
+		const path = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/{s}.zig.zon", .{worldName, paletteName});
 		defer main.stackAllocator.allocator.free(path);
 		const paletteZon = files.cubyzDir().readToZon(allocator, path) catch .null;
 		const palette = try main.assets.Palette.init(main.globalAllocator, paletteZon, firstEntry);
@@ -600,7 +600,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 			}
 
 			for (fileNames.items, 0..) |oldName, i| {
-				const newName = std.fmt.allocPrint(arena.allocator, "{}.zon", .{i}) catch unreachable;
+				const newName = main.fmt.allocPrint(arena, "{}.zon", .{i});
 				try playerDir.dir.rename(oldName, newName);
 			}
 
@@ -623,7 +623,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 	}
 
 	pub fn saveWorldConfig(self: *ServerWorld) !void {
-		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/world.zig.zon", .{self.path}) catch unreachable;
+		const path = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/world.zig.zon", .{self.path});
 		defer main.stackAllocator.free(path);
 		const worldData = try files.cubyzDir().readToZon(main.stackAllocator, path);
 		defer worldData.deinit(main.stackAllocator);
@@ -672,7 +672,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 						std.log.err("Couldn't read player file {s}. Skipping.", .{file.name});
 						continue;
 					};
-					const fullEntry = std.fmt.allocPrint(main.worldArena.allocator, "name:{s}", .{name}) catch unreachable;
+					const fullEntry = main.fmt.allocPrint(main.worldArena, "name:{s}", .{name});
 					self.playerDatabase.put(main.worldArena.allocator, fullEntry, index) catch unreachable;
 				}
 			}
@@ -751,7 +751,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 
 	fn regenerateLOD(self: *ServerWorld, newBiomeCheckSum: i64) !void {
 		std.log.info("Biomes have changed. Regenerating LODs... (this might take some time)", .{});
-		const mapsPath = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/maps", .{self.path}) catch unreachable;
+		const mapsPath = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/maps", .{self.path});
 		defer main.stackAllocator.free(mapsPath);
 		const hasSurfaceMaps = main.files.cubyzDir().hasDir(mapsPath);
 		if (hasSurfaceMaps) {
@@ -760,7 +760,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		// Delete old LODs:
 		for (1..main.settings.highestSupportedLod + 1) |i| {
 			const lod = @as(u32, 1) << @intCast(i);
-			const path = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/chunks/{}", .{self.path, lod}) catch unreachable;
+			const path = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/chunks/{}", .{self.path, lod});
 			defer main.stackAllocator.free(path);
 			main.files.cubyzDir().deleteTree(path) catch |err| {
 				if (err != error.FileNotFound) {
@@ -771,7 +771,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		// Find all the stored chunks:
 		var chunkPositions = main.List(ChunkPosition).init(main.stackAllocator);
 		defer chunkPositions.deinit();
-		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/chunks/1", .{self.path}) catch unreachable;
+		const path = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/chunks/1", .{self.path});
 		defer main.stackAllocator.free(path);
 		blk: {
 			var dirX = main.files.cubyzDir().openIterableDir(path) catch |err| {
@@ -894,7 +894,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		const newBiomeCheckSum: i64 = @bitCast(terrain.biomes.getBiomeCheckSum(self.settings.seed));
 		if (newBiomeCheckSum != self.biomeChecksum) {
 			if (self.settings.testingMode) {
-				const dir = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/maps", .{self.path}) catch unreachable;
+				const dir = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/maps", .{self.path});
 				defer main.stackAllocator.free(dir);
 				main.files.cubyzDir().deleteTree("maps") catch |err| {
 					std.log.err("Error while trying to remove maps folder of testingMode world: {s}", .{@errorName(err)});
@@ -907,7 +907,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		}
 		try self.saveWorldConfig();
 		loadItemDrops: {
-			const itemsPath = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/itemdrops.bin", .{self.path}) catch unreachable;
+			const itemsPath = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/itemdrops.bin", .{self.path});
 			defer main.stackAllocator.free(itemsPath);
 			const itemDropData: []const u8 = files.cubyzDir().read(main.stackAllocator, itemsPath) catch |err| {
 				if (err != error.FileNotFound) {
@@ -925,7 +925,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 	}
 
 	pub fn loadPlayer(self: *ServerWorld, user: *User) void {
-		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/players/{}.zon", .{self.path, user.playerIndex}) catch unreachable;
+		const path = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/players/{}.zon", .{self.path, user.playerIndex});
 		defer main.stackAllocator.free(path);
 
 		const playerData = files.cubyzDir().readToZon(main.stackAllocator, path) catch .null;
@@ -937,7 +937,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 			}
 		} else {
 			removeOld: {
-				const nameEntry = std.fmt.allocPrint(main.stackAllocator.allocator, "name:{s}", .{playerData.get(?[]const u8, "name", null) orelse break :removeOld}) catch unreachable;
+				const nameEntry = main.fmt.allocPrint(main.stackAllocator, "name:{s}", .{playerData.get(?[]const u8, "name", null) orelse break :removeOld});
 				defer main.stackAllocator.free(nameEntry);
 				std.debug.assert(self.playerDatabase.remove(nameEntry));
 			}
@@ -991,7 +991,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 	}
 
 	pub fn savePlayer(self: *ServerWorld, user: *User) !void {
-		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/players/{}.zon", .{self.path, user.playerIndex}) catch unreachable;
+		const path = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/players/{}.zon", .{self.path, user.playerIndex});
 		defer main.stackAllocator.free(path);
 
 		var playerZon: ZonElement = files.cubyzDir().readToZon(main.stackAllocator, path) catch .null;
@@ -1022,7 +1022,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 
 		playerZon.put("playerSpawnPos", user.spawnPos);
 
-		const playerPath = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/players", .{self.path}) catch unreachable;
+		const playerPath = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/players", .{self.path});
 		defer main.stackAllocator.free(playerPath);
 
 		try files.cubyzDir().makePath(playerPath);
@@ -1048,7 +1048,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		var itemDropData = main.utils.BinaryWriter.init(main.stackAllocator);
 		defer itemDropData.deinit();
 		self.itemDropManager.storeToBytes(&itemDropData);
-		const itemsPath = std.fmt.allocPrint(main.stackAllocator.allocator, "saves/{s}/itemdrops.bin", .{self.path}) catch unreachable;
+		const itemsPath = main.fmt.allocPrint(main.stackAllocator, "saves/{s}/itemdrops.bin", .{self.path});
 		defer main.stackAllocator.free(itemsPath);
 		try files.cubyzDir().write(itemsPath, itemDropData.data.items);
 	}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -2245,7 +2245,7 @@ test "SparseSet/reusing" {
 }
 
 pub fn panicWithMessage(comptime fmt: []const u8, args: anytype) noreturn {
-	const message = std.fmt.allocPrint(main.stackAllocator.allocator, fmt, args) catch unreachable;
+	const message = main.fmt.allocPrint(main.stackAllocator, fmt, args);
 	@panic(message);
 }
 

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -833,7 +833,7 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 				@panic("ThreadPool Creation Failed.");
 			};
 			var buf: [std.Thread.max_name_len]u8 = undefined;
-			thread.setName(std.fmt.bufPrint(&buf, "Worker {}", .{i + 1}) catch "Worker n") catch |err| std.log.err("Couldn't rename thread: {s}", .{@errorName(err)});
+			thread.setName(main.fmt.bufPrint(&buf, "Worker {}", .{i + 1}) catch "Worker n") catch |err| std.log.err("Couldn't rename thread: {s}", .{@errorName(err)});
 		}
 		return self;
 	}

--- a/src/utils/file_monitor.zig
+++ b/src/utils/file_monitor.zig
@@ -98,7 +98,7 @@ const LinuxImpl = struct { // MARK: LinuxImpl
 			return;
 		}) |entry| {
 			if (entry.kind == .directory) {
-				const subPath = std.fmt.allocPrintSentinel(main.stackAllocator.allocator, "{s}/{s}", .{path, entry.name}, 0) catch unreachable;
+				const subPath = main.fmt.allocPrintSentinel(main.stackAllocator, "{s}/{s}", .{path, entry.name}, 0);
 				defer main.stackAllocator.free(subPath);
 				addWatchDescriptor(info, subPath);
 				addWatchDescriptorsRecursive(info, subPath);


### PR DESCRIPTION
bufPrint and allocPrint at runtime

Should reduce compile time and binary size, and reduces `catch unreachable`

follow-up on #2792

Perfomance:
. | Before | After | Binary size
--- | --- | --- | ---
Debug + llvm | 13.75 s | 13.3 s | - 0.3 MB
Debug + x86_64 | 4.85 s | 4.75 s | + 12.4 MB (the whole binary is over 600 MB, probably for incremental)
ReleaseSafe | 82.8 s | 81.2 s | - 0.4 MB
ReleaseFast | 90.0 s | 85.5 s | - 0.8 MB

Remaining work:
- [x] Make performance comparisons
- [ ] Check if it catches mistakes at compile-time when running tests
- [ ] There is a problem with vectors and precision