### PR TITLE
Introduce a VertexArray struct to handle vertex and index data

### DIFF
--- a/src/block_entity.zig
+++ b/src/block_entity.zig
@@ -513,7 +513,7 @@ pub const BlockEntityTypes = struct {
 			c.glBindFramebuffer(c.GL_FRAMEBUFFER, @bitCast(oldFramebufferBinding));
 
 			pipeline.bind(null);
-			c.glBindVertexArray(main.renderer.chunk_meshing.vao);
+			main.renderer.chunk_meshing.vao.bind();
 
 			c.glUniform3f(uniforms.ambientLight, ambientLight[0], ambientLight[1], ambientLight[2]);
 			c.glUniformMatrix4fv(uniforms.projectionMatrix, 1, c.GL_TRUE, @ptrCast(&projectionMatrix));

--- a/src/client/entity_manager.zig
+++ b/src/client/entity_manager.zig
@@ -129,7 +129,7 @@ pub fn render(projMatrix: Mat4f, ambientLight: Vec3f, playerPos: Vec3d) void {
 	defer mutex.unlock();
 	update();
 	pipeline.bind(null);
-	c.glBindVertexArray(main.renderer.chunk_meshing.vao);
+	main.renderer.chunk_meshing.vao.bind();
 	c.glUniformMatrix4fv(uniforms.projectionMatrix, 1, c.GL_TRUE, @ptrCast(&projMatrix));
 	modelTexture.bindTo(0);
 	c.glUniform3fv(uniforms.ambientLight, 1, @ptrCast(&ambientLight));

--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -134,6 +134,18 @@ pub const draw = struct { // MARK: draw
 		clip = previousClip;
 	}
 
+	const SimpleVertex2D = struct {
+		pos: [2]f32,
+
+		pub const attributeDescriptions: []const c.VkVertexInputAttributeDescription = &.{
+			.{
+				.location = 0,
+				.format = c.VK_FORMAT_R32G32_SFLOAT,
+				.offset = @offsetOf(@This(), "pos"),
+			},
+		};
+	};
+
 	// ----------------------------------------------------------------------------
 	// MARK: fillRect()
 	var rectUniforms: struct {
@@ -143,8 +155,7 @@ pub const draw = struct { // MARK: draw
 		rectColor: c_int,
 	} = undefined;
 	var rectPipeline: Pipeline = undefined;
-	pub var rectVAO: c_uint = undefined;
-	var rectVBO: c_uint = undefined;
+	pub var rectVao: VertexArray = undefined;
 
 	fn initRect() void {
 		rectPipeline = Pipeline.init(
@@ -156,26 +167,19 @@ pub const draw = struct { // MARK: draw
 			.{.depthTest = false, .depthWrite = false},
 			.{.attachments = &.{.alphaBlending}},
 		);
-		const rawData = [_]f32{
-			0, 0,
-			0, 1,
-			1, 0,
-			1, 1,
+		const rawData = [_]SimpleVertex2D{
+			.{.pos = .{0, 0}},
+			.{.pos = .{0, 1}},
+			.{.pos = .{1, 0}},
+			.{.pos = .{1, 1}},
 		};
 
-		c.glGenVertexArrays(1, &rectVAO);
-		c.glBindVertexArray(rectVAO);
-		c.glGenBuffers(1, &rectVBO);
-		c.glBindBuffer(c.GL_ARRAY_BUFFER, rectVBO);
-		c.glBufferData(c.GL_ARRAY_BUFFER, rawData.len*@sizeOf(f32), &rawData, c.GL_STATIC_DRAW);
-		c.glVertexAttribPointer(0, 2, c.GL_FLOAT, c.GL_FALSE, 2*@sizeOf(f32), null);
-		c.glEnableVertexAttribArray(0);
+		rectVao = .init(SimpleVertex2D, &rawData, null);
 	}
 
 	fn deinitRect() void {
 		rectPipeline.deinit();
-		c.glDeleteVertexArrays(1, &rectVAO);
-		c.glDeleteBuffers(1, &rectVBO);
+		rectVao.deinit();
 	}
 
 	pub fn rect(_pos: Vec2f, _dim: Vec2f) void {
@@ -194,7 +198,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(rectUniforms.size, dim[0], dim[1]);
 		c.glUniform1i(rectUniforms.rectColor, @bitCast(color));
 
-		c.glBindVertexArray(rectVAO);
+		rectVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 	}
 
@@ -208,8 +212,7 @@ pub const draw = struct { // MARK: draw
 		lineWidth: c_int,
 	} = undefined;
 	var rectBorderPipeline: Pipeline = undefined;
-	var rectBorderVAO: c_uint = undefined;
-	var rectBorderVBO: c_uint = undefined;
+	var rectBorderVao: VertexArray = undefined;
 
 	fn initRectBorder() void {
 		rectBorderPipeline = Pipeline.init(
@@ -221,32 +224,36 @@ pub const draw = struct { // MARK: draw
 			.{.depthTest = false, .depthWrite = false},
 			.{.attachments = &.{.alphaBlending}},
 		);
-		const rawData = [_]f32{
-			0, 0, 0,  0,
-			0, 0, 1,  1,
-			0, 1, 0,  0,
-			0, 1, 1,  -1,
-			1, 1, 0,  0,
-			1, 1, -1, -1,
-			1, 0, 0,  0,
-			1, 0, -1, 1,
-			0, 0, 0,  0,
-			0, 0, 1,  1,
+		const RectBorderVertex = struct {
+			pos: [4]f32,
+
+			pub const attributeDescriptions: []const c.VkVertexInputAttributeDescription = &.{
+				.{
+					.location = 0,
+					.format = c.VK_FORMAT_R32G32B32A32_SFLOAT,
+					.offset = @offsetOf(@This(), "pos"),
+				},
+			};
+		};
+		const rawData = [_]RectBorderVertex{
+			.{.pos = .{0, 0, 0, 0}},
+			.{.pos = .{0, 0, 1, 1}},
+			.{.pos = .{0, 1, 0, 0}},
+			.{.pos = .{0, 1, 1, -1}},
+			.{.pos = .{1, 1, 0, 0}},
+			.{.pos = .{1, 1, -1, -1}},
+			.{.pos = .{1, 0, 0, 0}},
+			.{.pos = .{1, 0, -1, 1}},
+			.{.pos = .{0, 0, 0, 0}},
+			.{.pos = .{0, 0, 1, 1}},
 		};
 
-		c.glGenVertexArrays(1, &rectBorderVAO);
-		c.glBindVertexArray(rectBorderVAO);
-		c.glGenBuffers(1, &rectBorderVBO);
-		c.glBindBuffer(c.GL_ARRAY_BUFFER, rectBorderVBO);
-		c.glBufferData(c.GL_ARRAY_BUFFER, rawData.len*@sizeOf(f32), &rawData, c.GL_STATIC_DRAW);
-		c.glVertexAttribPointer(0, 4, c.GL_FLOAT, c.GL_FALSE, 4*@sizeOf(f32), null);
-		c.glEnableVertexAttribArray(0);
+		rectBorderVao = .init(RectBorderVertex, &rawData, null);
 	}
 
 	fn deinitRectBorder() void {
 		rectBorderPipeline.deinit();
-		c.glDeleteVertexArrays(1, &rectBorderVAO);
-		c.glDeleteBuffers(1, &rectBorderVBO);
+		rectBorderVao.deinit();
 	}
 
 	pub fn rectBorder(_pos: Vec2f, _dim: Vec2f, _width: f32) void {
@@ -268,7 +275,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform1i(rectBorderUniforms.rectColor, @bitCast(color));
 		c.glUniform1f(rectBorderUniforms.lineWidth, width);
 
-		c.glBindVertexArray(rectBorderVAO);
+		rectBorderVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 10);
 	}
 
@@ -281,8 +288,7 @@ pub const draw = struct { // MARK: draw
 		lineColor: c_int,
 	} = undefined;
 	var linePipeline: Pipeline = undefined;
-	var lineVAO: c_uint = undefined;
-	var lineVBO: c_uint = undefined;
+	var lineVao: VertexArray = undefined;
 
 	fn initLine() void {
 		linePipeline = Pipeline.init(
@@ -294,24 +300,17 @@ pub const draw = struct { // MARK: draw
 			.{.depthTest = false, .depthWrite = false},
 			.{.attachments = &.{.alphaBlending}},
 		);
-		const rawData = [_]f32{
-			0, 0,
-			1, 1,
+		const rawData = [_]SimpleVertex2D{
+			.{.pos = .{0, 0}},
+			.{.pos = .{1, 1}},
 		};
 
-		c.glGenVertexArrays(1, &lineVAO);
-		c.glBindVertexArray(lineVAO);
-		c.glGenBuffers(1, &lineVBO);
-		c.glBindBuffer(c.GL_ARRAY_BUFFER, lineVBO);
-		c.glBufferData(c.GL_ARRAY_BUFFER, rawData.len*@sizeOf(f32), &rawData, c.GL_STATIC_DRAW);
-		c.glVertexAttribPointer(0, 2, c.GL_FLOAT, c.GL_FALSE, 2*@sizeOf(f32), null);
-		c.glEnableVertexAttribArray(0);
+		lineVao = .init(SimpleVertex2D, &rawData, null);
 	}
 
 	fn deinitLine() void {
 		linePipeline.deinit();
-		c.glDeleteVertexArrays(1, &lineVAO);
-		c.glDeleteBuffers(1, &lineVBO);
+		lineVao.deinit();
 	}
 
 	pub fn line(_pos1: Vec2f, _pos2: Vec2f) void {
@@ -331,36 +330,8 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(lineUniforms.direction, pos2[0] - pos1[0], pos2[1] - pos1[1]);
 		c.glUniform1i(lineUniforms.lineColor, @bitCast(color));
 
-		c.glBindVertexArray(lineVAO);
+		lineVao.bind();
 		c.glDrawArrays(c.GL_LINE_STRIP, 0, 2);
-	}
-
-	// ----------------------------------------------------------------------------
-	// MARK: drawRect()
-	// Draw rect can use the same shader as drawline, because it essentially draws lines.
-	var drawRectVAO: c_uint = undefined;
-	var drawRectVBO: c_uint = undefined;
-
-	fn initDrawRect() void {
-		const rawData = [_]f32{
-			0, 0,
-			0, 1,
-			1, 1,
-			1, 0,
-		};
-
-		c.glGenVertexArrays(1, &drawRectVAO);
-		c.glBindVertexArray(drawRectVAO);
-		c.glGenBuffers(1, &drawRectVBO);
-		c.glBindBuffer(c.GL_ARRAY_BUFFER, drawRectVBO);
-		c.glBufferData(c.GL_ARRAY_BUFFER, rawData.len*@sizeOf(f32), &rawData, c.GL_STATIC_DRAW);
-		c.glVertexAttribPointer(0, 2, c.GL_FLOAT, c.GL_FALSE, 2*@sizeOf(f32), null);
-		c.glEnableVertexAttribArray(0);
-	}
-
-	fn deinitDrawRect() void {
-		c.glDeleteVertexArrays(1, &drawRectVAO);
-		c.glDeleteBuffers(1, &drawRectVBO);
 	}
 
 	pub fn rectOutline(_pos: Vec2f, _dim: Vec2f) void {
@@ -379,7 +350,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(lineUniforms.direction, dim[0] - 1, dim[1] - 1); // The height is a lot smaller because the inner edge of the rect is drawn.
 		c.glUniform1i(lineUniforms.lineColor, @bitCast(color));
 
-		c.glBindVertexArray(lineVAO);
+		lineVao.bind();
 		c.glDrawArrays(c.GL_LINE_LOOP, 0, 5);
 	}
 
@@ -392,8 +363,7 @@ pub const draw = struct { // MARK: draw
 		circleColor: c_int,
 	} = undefined;
 	var circlePipeline: Pipeline = undefined;
-	var circleVAO: c_uint = undefined;
-	var circleVBO: c_uint = undefined;
+	var circleVao: VertexArray = undefined;
 
 	fn initCircle() void {
 		circlePipeline = Pipeline.init(
@@ -405,26 +375,19 @@ pub const draw = struct { // MARK: draw
 			.{.depthTest = false, .depthWrite = false},
 			.{.attachments = &.{.alphaBlending}},
 		);
-		const rawData = [_]f32{
-			-1, -1,
-			-1, 1,
-			1,  -1,
-			1,  1,
+		const rawData = [_]SimpleVertex2D{
+			.{.pos = .{-1, -1}},
+			.{.pos = .{-1, 1}},
+			.{.pos = .{1, -1}},
+			.{.pos = .{1, 1}},
 		};
 
-		c.glGenVertexArrays(1, &circleVAO);
-		c.glBindVertexArray(circleVAO);
-		c.glGenBuffers(1, &circleVBO);
-		c.glBindBuffer(c.GL_ARRAY_BUFFER, circleVBO);
-		c.glBufferData(c.GL_ARRAY_BUFFER, rawData.len*@sizeOf(f32), &rawData, c.GL_STATIC_DRAW);
-		c.glVertexAttribPointer(0, 2, c.GL_FLOAT, c.GL_FALSE, 2*@sizeOf(f32), null);
-		c.glEnableVertexAttribArray(0);
+		circleVao = .init(SimpleVertex2D, &rawData, null);
 	}
 
 	fn deinitCircle() void {
 		circlePipeline.deinit();
-		c.glDeleteVertexArrays(1, &circleVAO);
-		c.glDeleteBuffers(1, &circleVBO);
+		circleVao.deinit();
 	}
 
 	pub fn circle(_center: Vec2f, _radius: f32) void {
@@ -442,7 +405,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform1f(circleUniforms.radius, radius); // The height is a lot smaller because the inner edge of the rect is drawn.
 		c.glUniform1i(circleUniforms.circleColor, @bitCast(color));
 
-		c.glBindVertexArray(circleVAO);
+		circleVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 	}
 
@@ -501,7 +464,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(imageUniforms.uvOffset, uvOffset[0], 1 - uvOffset[1] - uvDim[1]);
 		c.glUniform2f(imageUniforms.uvDim, uvDim[0], uvDim[1]);
 
-		c.glBindVertexArray(rectVAO);
+		rectVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 	}
 
@@ -523,7 +486,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(uniforms.uvOffset, 0, 0);
 		c.glUniform2f(uniforms.uvDim, 1, 1);
 
-		c.glBindVertexArray(rectVAO);
+		rectVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 	}
 
@@ -547,7 +510,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform1i(uniforms.color, @bitCast(color));
 		c.glUniform1f(uniforms.scale, scale);
 
-		c.glBindVertexArray(rectVAO);
+		rectVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 	}
 
@@ -1016,7 +979,7 @@ pub const TextBuffer = struct { // MARK: TextBuffer
 		c.glUniform1f(TextRendering.uniforms.alpha, @as(f32, @floatFromInt(draw.color >> 24))/255.0);
 		c.glActiveTexture(c.GL_TEXTURE0);
 		c.glBindTexture(c.GL_TEXTURE_2D, TextRendering.glyphTexture[0]);
-		c.glBindVertexArray(draw.rectVAO);
+		draw.rectVao.bind();
 		const lineWraps: []f32 = main.stackAllocator.alloc(f32, self.lineBreaks.items.len - 1);
 		defer main.stackAllocator.free(lineWraps);
 		var i: usize = 0;
@@ -1084,7 +1047,7 @@ pub const TextBuffer = struct { // MARK: TextBuffer
 		c.glUniform1f(TextRendering.uniforms.alpha, @as(f32, @floatFromInt(draw.color >> 24))/255.0);
 		c.glActiveTexture(c.GL_TEXTURE0);
 		c.glBindTexture(c.GL_TEXTURE_2D, TextRendering.glyphTexture[0]);
-		c.glBindVertexArray(draw.rectVAO);
+		draw.rectVao.bind();
 		const lineWraps: []f32 = main.stackAllocator.alloc(f32, self.lineBreaks.items.len - 1);
 		defer main.stackAllocator.free(lineWraps);
 		var i: usize = 0;
@@ -1291,7 +1254,6 @@ const TextRendering = struct { // MARK: TextRendering
 
 pub fn init() void { // MARK: init()
 	draw.initCircle();
-	draw.initDrawRect();
 	draw.initImage();
 	draw.initLine();
 	draw.initRect();
@@ -1305,7 +1267,6 @@ pub fn init() void { // MARK: init()
 
 pub fn deinit() void {
 	draw.deinitCircle();
-	draw.deinitDrawRect();
 	draw.deinitImage();
 	draw.deinitLine();
 	draw.deinitRect();
@@ -1819,6 +1780,69 @@ pub const ComputePipeline = struct { // MARK: ComputePipeline
 
 	pub fn bind(self: ComputePipeline) void {
 		self.shader.bind();
+	}
+};
+
+pub const VertexArray = struct { // MARK: VertexArray
+	vao: c_uint,
+	vbo: c_uint,
+	ibo: ?c_uint,
+
+	pub const EmptyVertex = struct {
+		pub const attributeDescriptions: []const c.VkVertexInputAttributeDescription = &.{};
+	};
+
+	pub fn init(T: type, data: []const T, indices_: ?[]const u32) VertexArray {
+		var result: VertexArray = undefined;
+		c.glGenVertexArrays(1, &result.vao);
+		c.glBindVertexArray(result.vao);
+		c.glGenBuffers(1, &result.vbo);
+		c.glBindBuffer(c.GL_ARRAY_BUFFER, result.vbo);
+		c.glBufferData(c.GL_ARRAY_BUFFER, @intCast(data.len*@sizeOf(T)), data.ptr, c.GL_STATIC_DRAW);
+		if (indices_) |indices| {
+			result.ibo = 0;
+			c.glGenBuffers(1, &result.ibo.?);
+			c.glBindBuffer(c.GL_ELEMENT_ARRAY_BUFFER, result.ibo.?);
+			c.glBufferData(c.GL_ELEMENT_ARRAY_BUFFER, @intCast(indices.len*@sizeOf(u32)), indices.ptr, c.GL_STATIC_DRAW);
+		} else {
+			result.ibo = null;
+		}
+
+		const attributeDescriptions: []const c.VkVertexInputAttributeDescription = T.attributeDescriptions;
+		inline for (attributeDescriptions) |desc| {
+			std.debug.assert(desc.binding == 0);
+			c.glEnableVertexAttribArray(desc.location);
+			const glType = comptime switch (desc.format) {
+				c.VK_FORMAT_R32_SFLOAT => c.GL_FLOAT,
+				c.VK_FORMAT_R32G32_SFLOAT => c.GL_FLOAT,
+				c.VK_FORMAT_R32G32B32_SFLOAT => c.GL_FLOAT,
+				c.VK_FORMAT_R32G32B32A32_SFLOAT => c.GL_FLOAT,
+				else => @compileError("Unrecognized format"),
+			};
+			const size = comptime switch (desc.format) {
+				c.VK_FORMAT_R32_SFLOAT => 1,
+				c.VK_FORMAT_R32G32_SFLOAT => 2,
+				c.VK_FORMAT_R32G32B32_SFLOAT => 3,
+				c.VK_FORMAT_R32G32B32A32_SFLOAT => 4,
+				else => @compileError("Unrecognized format"),
+			};
+			c.glVertexAttribPointer(desc.location, size, glType, c.GL_FALSE, @sizeOf(T), @ptrFromInt(desc.offset));
+		}
+
+		c.glBindVertexArray(0);
+		return result;
+	}
+
+	pub fn deinit(self: VertexArray) void {
+		c.glDeleteVertexArrays(1, &self.vao);
+		c.glDeleteBuffers(1, &self.vbo);
+		if (self.ibo != null) {
+			c.glDeleteBuffers(1, &self.ibo.?);
+		}
+	}
+
+	pub fn bind(self: VertexArray) void {
+		c.glBindVertexArray(self.vao);
 	}
 };
 
@@ -2704,7 +2728,7 @@ pub fn generateBlockTexture(blockType: u16) Texture {
 	c.glUniform1i(block_texture.uniforms.transparent, if (block.transparent()) c.GL_TRUE else c.GL_FALSE);
 	frameBuffer.bindTexture(c.GL_TEXTURE3);
 
-	c.glBindVertexArray(draw.rectVAO);
+	draw.rectVao.bind();
 	c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 
 	c.glBindFramebuffer(c.GL_FRAMEBUFFER, 0);

--- a/src/itemdrop.zig
+++ b/src/itemdrop.zig
@@ -733,7 +733,7 @@ pub const ItemDropRenderer = struct { // MARK: ItemDropRenderer
 
 	fn drawItem(vertices: u31, modelMatrix: Mat4f) void {
 		c.glUniformMatrix4fv(itemUniforms.modelMatrix, 1, c.GL_TRUE, @ptrCast(&modelMatrix));
-		c.glBindVertexArray(main.renderer.chunk_meshing.vao);
+		main.renderer.chunk_meshing.vao.bind();
 		c.glDrawElements(c.GL_TRIANGLES, vertices, c.GL_UNSIGNED_INT, null);
 	}
 

--- a/src/particles.zig
+++ b/src/particles.zig
@@ -338,7 +338,7 @@ pub const ParticleSystem = struct {
 		c.glActiveTexture(c.GL_TEXTURE1);
 		ParticleManager.emissionTextureArray.bind();
 
-		c.glBindVertexArray(chunk_meshing.vao);
+		chunk_meshing.vao.bind();
 
 		const maxQuads = chunk_meshing.maxQuadsInIndexBuffer;
 		const count = std.math.divCeil(u32, particleCount, maxQuads) catch unreachable;

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -119,7 +119,7 @@ fn initReflectionCubeMap() void {
 		c.glUniform3fv(fakeReflectionUniforms.upVector, 1, @ptrCast(&graphics.CubeMapTexture.faceUp(face)));
 		c.glUniform3fv(fakeReflectionUniforms.rightVector, 1, @ptrCast(&graphics.CubeMapTexture.faceRight(face)));
 		reflectionCubeMap.bindToFramebuffer(framebuffer, @intCast(face));
-		c.glBindVertexArray(graphics.draw.rectVAO);
+		graphics.draw.rectVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 	}
 }
@@ -318,7 +318,7 @@ pub fn renderWorld(world: *World, ambientLight: Vec3f, skyColor: Vec3f, playerPo
 
 	c.glBindFramebuffer(c.GL_FRAMEBUFFER, activeFrameBuffer);
 
-	c.glBindVertexArray(graphics.draw.rectVAO);
+	graphics.draw.rectVao.bind();
 	c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 
 	c.glBindFramebuffer(c.GL_FRAMEBUFFER, 0);
@@ -415,7 +415,7 @@ const Bloom = struct { // MARK: Bloom
 		c.glUniform1f(colorExtractUniforms.zNear, zNear);
 		c.glUniform1f(colorExtractUniforms.zFar, zFar);
 		c.glUniform2f(colorExtractUniforms.tanXY, 1.0/game.projectionMatrix.rows[0][0], 1.0/game.projectionMatrix.rows[1][2]);
-		c.glBindVertexArray(graphics.draw.rectVAO);
+		graphics.draw.rectVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 	}
 
@@ -423,7 +423,7 @@ const Bloom = struct { // MARK: Bloom
 		firstPassPipeline.bind(null);
 		buffer1.bindTexture(c.GL_TEXTURE3);
 		buffer2.bind();
-		c.glBindVertexArray(graphics.draw.rectVAO);
+		graphics.draw.rectVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 	}
 
@@ -431,7 +431,7 @@ const Bloom = struct { // MARK: Bloom
 		secondPassPipeline.bind(null);
 		buffer2.bindTexture(c.GL_TEXTURE3);
 		buffer1.bind();
-		c.glBindVertexArray(graphics.draw.rectVAO);
+		graphics.draw.rectVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 	}
 
@@ -473,8 +473,7 @@ pub const MenuBackGround = struct {
 		projectionMatrix: c_int,
 	} = undefined;
 
-	var vao: c_uint = undefined;
-	var vbos: [2]c_uint = undefined;
+	var vao: graphics.VertexArray = undefined;
 	var texture: graphics.Texture = undefined;
 
 	var angle: f32 = 0;
@@ -489,21 +488,38 @@ pub const MenuBackGround = struct {
 			.{.depthTest = false, .depthWrite = false},
 			.{.attachments = &.{.noBlending}},
 		);
+		const MenuBackgroundVertex = struct {
+			pos: [3]f32,
+			uv: [2]f32,
+
+			pub const attributeDescriptions: []const c.VkVertexInputAttributeDescription = &.{
+				.{
+					.location = 0,
+					.format = c.VK_FORMAT_R32G32B32_SFLOAT,
+					.offset = @offsetOf(@This(), "pos"),
+				},
+				.{
+					.location = 1,
+					.format = c.VK_FORMAT_R32G32_SFLOAT,
+					.offset = @offsetOf(@This(), "uv"),
+				},
+			};
+		};
 		// 4 sides of a simple cube with some panorama texture on it.
-		const rawData = [_]f32{
-			-1, 1,  -1, 1,    1,
-			-1, 1,  1,  1,    0,
-			-1, -1, -1, 0.75, 1,
-			-1, -1, 1,  0.75, 0,
-			1,  -1, -1, 0.5,  1,
-			1,  -1, 1,  0.5,  0,
-			1,  1,  -1, 0.25, 1,
-			1,  1,  1,  0.25, 0,
-			-1, 1,  -1, 0,    1,
-			-1, 1,  1,  0,    0,
+		const rawData = [_]MenuBackgroundVertex{
+			.{.pos = .{-1, 1, -1}, .uv = .{1, 1}},
+			.{.pos = .{-1, 1, 1}, .uv = .{1, 0}},
+			.{.pos = .{-1, -1, -1}, .uv = .{0.75, 1}},
+			.{.pos = .{-1, -1, 1}, .uv = .{0.75, 0}},
+			.{.pos = .{1, -1, -1}, .uv = .{0.5, 1}},
+			.{.pos = .{1, -1, 1}, .uv = .{0.5, 0}},
+			.{.pos = .{1, 1, -1}, .uv = .{0.25, 1}},
+			.{.pos = .{1, 1, 1}, .uv = .{0.25, 0}},
+			.{.pos = .{-1, 1, -1}, .uv = .{0, 1}},
+			.{.pos = .{-1, 1, 1}, .uv = .{0, 0}},
 		};
 
-		const indices = [_]c_int{
+		const indices = [_]u32{
 			0, 1, 2,
 			2, 3, 1,
 			2, 3, 4,
@@ -514,17 +530,7 @@ pub const MenuBackGround = struct {
 			8, 9, 7,
 		};
 
-		c.glGenVertexArrays(1, &vao);
-		c.glBindVertexArray(vao);
-		c.glGenBuffers(2, &vbos);
-		c.glBindBuffer(c.GL_ARRAY_BUFFER, vbos[0]);
-		c.glBufferData(c.GL_ARRAY_BUFFER, @intCast(rawData.len*@sizeOf(f32)), &rawData, c.GL_STATIC_DRAW);
-		c.glVertexAttribPointer(0, 3, c.GL_FLOAT, c.GL_FALSE, 5*@sizeOf(f32), null);
-		c.glVertexAttribPointer(1, 2, c.GL_FLOAT, c.GL_FALSE, 5*@sizeOf(f32), @ptrFromInt(3*@sizeOf(f32)));
-		c.glEnableVertexAttribArray(0);
-		c.glEnableVertexAttribArray(1);
-		c.glBindBuffer(c.GL_ELEMENT_ARRAY_BUFFER, vbos[1]);
-		c.glBufferData(c.GL_ELEMENT_ARRAY_BUFFER, @intCast(indices.len*@sizeOf(c_int)), &indices, c.GL_STATIC_DRAW);
+		vao = .init(MenuBackgroundVertex, &rawData, &indices);
 
 		const backgroundPath = chooseBackgroundImagePath(main.stackAllocator) catch |err| {
 			std.log.err("Couldn't open background path: {s}", .{@errorName(err)});
@@ -573,8 +579,7 @@ pub const MenuBackGround = struct {
 
 	pub fn deinit() void {
 		pipeline.deinit();
-		c.glDeleteVertexArrays(1, &vao);
-		c.glDeleteBuffers(2, &vbos);
+		vao.deinit();
 	}
 
 	pub fn hasImage() bool {
@@ -594,7 +599,7 @@ pub const MenuBackGround = struct {
 
 		texture.bindTo(0);
 
-		c.glBindVertexArray(vao);
+		vao.bind();
 		c.glDrawElements(c.GL_TRIANGLES, 24, c.GL_UNSIGNED_INT, null);
 	}
 
@@ -669,7 +674,7 @@ pub const Skybox = struct {
 		starOpacity: c_int,
 	} = undefined;
 
-	var starVao: c_uint = undefined;
+	var starVao: graphics.VertexArray = undefined;
 
 	var starSsbo: graphics.SSBO = undefined;
 
@@ -781,15 +786,13 @@ pub const Skybox = struct {
 
 		starSsbo = graphics.SSBO.initStatic(f32, &starData);
 
-		c.glGenVertexArrays(1, &starVao);
-		c.glBindVertexArray(starVao);
-		c.glEnableVertexAttribArray(0);
+		starVao = .init(graphics.VertexArray.EmptyVertex, &.{}, null);
 	}
 
 	pub fn deinit() void {
 		starPipeline.deinit();
 		starSsbo.deinit();
-		c.glDeleteVertexArrays(1, &starVao);
+		starVao.deinit();
 	}
 
 	pub fn render() void {
@@ -817,7 +820,7 @@ pub const Skybox = struct {
 			c.glUniform1f(starUniforms.starOpacity, starOpacity);
 			c.glUniformMatrix4fv(starUniforms.mvp, 1, c.GL_TRUE, @ptrCast(&starMatrix));
 
-			c.glBindVertexArray(starVao);
+			starVao.bind();
 			c.glDrawArrays(c.GL_TRIANGLES, 0, numStars*3);
 
 			c.glBindBuffer(c.GL_SHADER_STORAGE_BUFFER, 0);
@@ -1150,7 +1153,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 		c.glUniform3f(uniforms.upperBounds, max[0], max[1], max[2]);
 		c.glUniform1f(uniforms.lineSize, 1.0/128.0);
 
-		c.glBindVertexArray(main.renderer.chunk_meshing.vao);
+		main.renderer.chunk_meshing.vao.bind();
 		c.glDrawElements(c.GL_TRIANGLES, 12*6*6, c.GL_UNSIGNED_INT, null);
 	}
 

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -63,8 +63,7 @@ pub var occlusionTestUniforms: struct {
 	playerPositionInteger: c_int,
 	playerPositionFraction: c_int,
 } = undefined;
-pub var vao: c_uint = undefined;
-var vbo: c_uint = undefined;
+pub var vao: graphics.VertexArray = undefined;
 pub var faceBuffers: [settings.highestSupportedLod + 1]graphics.LargeBuffer(FaceData) = undefined;
 pub var lightBuffers: [settings.highestSupportedLod + 1]graphics.LargeBuffer(u32) = undefined;
 pub var chunkBuffer: graphics.LargeBuffer(ChunkData) = undefined;
@@ -127,12 +126,7 @@ pub fn init() void {
 		rawData[i] = @as(u32, @intCast(i))/6*4 + lut[i%6];
 	}
 
-	c.glGenVertexArrays(1, &vao);
-	c.glBindVertexArray(vao);
-	c.glGenBuffers(1, &vbo);
-	c.glBindBuffer(c.GL_ELEMENT_ARRAY_BUFFER, vbo);
-	c.glBufferData(c.GL_ELEMENT_ARRAY_BUFFER, rawData.len*@sizeOf(u32), &rawData, c.GL_STATIC_DRAW);
-	c.glBindVertexArray(0);
+	vao = .init(graphics.VertexArray.EmptyVertex, &.{}, &rawData);
 
 	for (0..settings.highestSupportedLod + 1) |i| {
 		faceBuffers[i].init(main.globalAllocator, 1 << 20, 3);
@@ -149,8 +143,7 @@ pub fn deinit() void {
 	transparentPipeline.deinit();
 	occlusionTestPipeline.deinit();
 	commandPipeline.deinit();
-	c.glDeleteVertexArrays(1, &vao);
-	c.glDeleteBuffers(1, &vbo);
+	vao.deinit();
 	for (0..settings.highestSupportedLod + 1) |i| {
 		faceBuffers[i].deinit();
 		lightBuffers[i].deinit();
@@ -205,7 +198,7 @@ pub fn bindShaderAndUniforms(projMatrix: Mat4f, ambient: Vec3f, playerPos: Vec3d
 
 	bindCommonUniforms(&uniforms, projMatrix, ambient, playerPos);
 
-	c.glBindVertexArray(vao);
+	vao.bind();
 }
 
 pub fn bindTransparentShaderAndUniforms(projMatrix: Mat4f, ambient: Vec3f, playerPos: Vec3d) void {
@@ -218,7 +211,7 @@ pub fn bindTransparentShaderAndUniforms(projMatrix: Mat4f, ambient: Vec3f, playe
 
 	bindCommonUniforms(&transparentUniforms, projMatrix, ambient, playerPos);
 
-	c.glBindVertexArray(vao);
+	vao.bind();
 }
 
 fn bindBuffers(lod: usize) void {
@@ -269,7 +262,7 @@ fn drawChunksOfLod(chunkIDs: []const u32, projMatrix: Mat4f, ambient: Vec3f, pla
 	c.glUniform3f(occlusionTestUniforms.playerPositionFraction, @floatCast(@mod(playerPos[0], 1)), @floatCast(@mod(playerPos[1], 1)), @floatCast(@mod(playerPos[2], 1)));
 	c.glUniformMatrix4fv(occlusionTestUniforms.projectionMatrix, 1, c.GL_TRUE, @ptrCast(&projMatrix));
 	c.glUniformMatrix4fv(occlusionTestUniforms.viewMatrix, 1, c.GL_TRUE, @ptrCast(&game.camera.viewMatrix));
-	c.glBindVertexArray(vao);
+	vao.bind();
 	c.glDrawElementsBaseVertex(c.GL_TRIANGLES, @intCast(6*6*chunkIDs.len), c.GL_UNSIGNED_INT, null, chunkIDAllocation.start*24);
 	c.glMemoryBarrier(c.GL_SHADER_STORAGE_BARRIER_BIT);
 


### PR DESCRIPTION
a small step towards #102, reducing OpenGL calls outside graphics.zig and introducing Vulkan types. (this is basically the next step after #1405)

This has the nice side-effect of enforcing explicit buffer structs.

Alongside I also removed unused drawRect variables