### PR TITLE
fix Ref Count when User is deinited by server closing

### DIFF
--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -556,7 +556,12 @@ fn init(name: []const u8, singlePlayerPort: ?u16) void { // MARK: init()
 fn deinit() void {
 	users.clearAndFree();
 	while (userDeinitList.popFront()) |user| {
-		user.deinit();
+		if (user.refCount.load(.monotonic) == 1) {
+			user.decreaseRefCount();
+		} else {
+			std.log.err("Leaked user {f}", .{user});
+			user.deinit();
+		}
 	}
 	userDeinitList.deinit();
 	userConnectList.deinit();


### PR DESCRIPTION
fixes: #2729 

It seems the `userDeinitList` keeps a reference (who would have guessed) and so increases the RefCount.
This is handeld if the player gets deinited through the update cycle of the server but not when the server is shuting down and there is still someone on the list.

This also explains why this bug only appears sometimes. You have to leave with the second instance and before the server can go through the cycle of clearing the `userDeinitList`, you need to also close the server itself.

I don't know exactly what we maybe want to do on else path, but I think there should be something there.

Also... why doesn't the bug happend when closing the game while someone else is on it? I don't quite understand how that doens't go through the same path and should create the same bug