### PR TITLE
Fix utf8 encoding bug in the authentication

### DIFF
--- a/src/network/authentication.zig
+++ b/src/network/authentication.zig
@@ -169,15 +169,14 @@ pub const AccountCode = struct {
 		defer std.crypto.secureZero(u8, result.items);
 
 		const trimmed = std.mem.trim(u8, text, &std.ascii.whitespace);
-		var unicodeIterator =
-			std.unicode.Utf8Iterator{.bytes = trimmed, .i = 0};
+		var unicodeIterator = std.unicode.Utf8View.initUnchecked(trimmed).iterator();
 
-		while (unicodeIterator.nextCodepoint()) |cp| {
-			if (cp > 0x7F) {
-				printInvalidCharError(failureText, cp);
+		while (unicodeIterator.nextCodepoint()) |codepoint| {
+			if (codepoint > 0x7F) {
+				printInvalidCharError(failureText, codepoint);
 				continue;
 			}
-			const char: u8 = @intCast(cp);
+			const char: u8 = @intCast(codepoint);
 			if (std.ascii.isAlphabetic(char)) {
 				result.appendAssumeCapacity(std.ascii.toLower(char));
 			} else if (std.ascii.isWhitespace(char)) {
@@ -185,7 +184,7 @@ pub const AccountCode = struct {
 					result.appendAssumeCapacity(' ');
 				}
 			} else {
-				printInvalidCharError(failureText, cp);
+				printInvalidCharError(failureText, codepoint);
 			}
 		}
 		if (result.items.len == 0) {

--- a/src/network/authentication.zig
+++ b/src/network/authentication.zig
@@ -159,14 +159,25 @@ pub const PublicKey = union(KeyTypeEnum) {
 pub const AccountCode = struct {
 	text: []u8,
 
+	fn printInvalidCharError(failureText: *main.List(u8), codepoint: u21) void {
+		failureText.print("Account Code contains invalid character '{u}' (U+{X}), only ASCII letters and whitespaces are allowed.\n", .{codepoint, codepoint});
+	}
+
 	pub fn initFromUserInput(text: []const u8, failureText: *main.List(u8)) AccountCode {
 		var result: main.ListUnmanaged(u8) = .initCapacity(main.stackAllocator, text.len);
 		defer result.deinit(main.stackAllocator);
 		defer std.crypto.secureZero(u8, result.items);
 
 		const trimmed = std.mem.trim(u8, text, &std.ascii.whitespace);
+		var unicodeIterator =
+			std.unicode.Utf8Iterator{.bytes = trimmed, .i = 0};
 
-		for (trimmed) |char| {
+		while (unicodeIterator.nextCodepoint()) |cp| {
+			if (cp > 0x7F) {
+				printInvalidCharError(failureText, cp);
+				continue;
+			}
+			const char: u8 = @intCast(cp);
 			if (std.ascii.isAlphabetic(char)) {
 				result.appendAssumeCapacity(std.ascii.toLower(char));
 			} else if (std.ascii.isWhitespace(char)) {
@@ -174,7 +185,7 @@ pub const AccountCode = struct {
 					result.appendAssumeCapacity(' ');
 				}
 			} else {
-				failureText.print("Account Code contains invalid character '{c}', only ASCII letters and whitespaces are allowed.\n", .{char});
+				printInvalidCharError(failureText, cp);
 			}
 		}
 		if (result.items.len == 0) {


### PR DESCRIPTION
The game crashes, when entering UTF8 chars in the Account Code field.
This is because the error text threats all chars as as one byte.
I replaced the byte iterator with an UTF8 iterator and a modified error message.

PS: This is basically my hello world in zig, so check extra carefully 