### PR TITLE
Introduce a parentEdgeDistance parameter for subbiomes.

### DIFF
--- a/assets/cubyz/biomes/tall_mountain/peak.zig.zon
+++ b/assets/cubyz/biomes/tall_mountain/peak.zig.zon
@@ -16,6 +16,7 @@
 		.{
 			.id = "cubyz:tall_mountain/slope6",
 			.chance = 1,
+			.parentEdgeDistance = 0,
 		},
 	},
 

--- a/assets/cubyz/biomes/tall_mountain/slope1.zig.zon
+++ b/assets/cubyz/biomes/tall_mountain/slope1.zig.zon
@@ -15,6 +15,7 @@
 		.{
 			.id = "cubyz:tall_mountain/base",
 			.chance = 1,
+			.parentEdgeDistance = 0,
 		},
 	},
 

--- a/assets/cubyz/biomes/tall_mountain/slope2.zig.zon
+++ b/assets/cubyz/biomes/tall_mountain/slope2.zig.zon
@@ -16,6 +16,7 @@
 		.{
 			.id = "cubyz:tall_mountain/slope1",
 			.chance = 1,
+			.parentEdgeDistance = 0,
 		},
 	},
 

--- a/assets/cubyz/biomes/tall_mountain/slope3.zig.zon
+++ b/assets/cubyz/biomes/tall_mountain/slope3.zig.zon
@@ -16,6 +16,7 @@
 		.{
 			.id = "cubyz:tall_mountain/slope2",
 			.chance = 1,
+			.parentEdgeDistance = 0,
 		},
 	},
 

--- a/assets/cubyz/biomes/tall_mountain/slope4.zig.zon
+++ b/assets/cubyz/biomes/tall_mountain/slope4.zig.zon
@@ -16,6 +16,7 @@
 		.{
 			.id = "cubyz:tall_mountain/slope3",
 			.chance = 1,
+			.parentEdgeDistance = 0,
 		},
 	},
 

--- a/assets/cubyz/biomes/tall_mountain/slope5.zig.zon
+++ b/assets/cubyz/biomes/tall_mountain/slope5.zig.zon
@@ -15,6 +15,7 @@
 		.{
 			.id = "cubyz:tall_mountain/slope4",
 			.chance = 1,
+			.parentEdgeDistance = 0,
 		},
 	},
 

--- a/assets/cubyz/biomes/tall_mountain/slope6.zig.zon
+++ b/assets/cubyz/biomes/tall_mountain/slope6.zig.zon
@@ -15,6 +15,7 @@
 		.{
 			.id = "cubyz:tall_mountain/slope5",
 			.chance = 1,
+			.parentEdgeDistance = 0,
 		},
 	},
 

--- a/assets/cubyz/biomes/volcano/peak.zig.zon
+++ b/assets/cubyz/biomes/volcano/peak.zig.zon
@@ -13,6 +13,7 @@
 		.{
 			.id = "cubyz:volcano/slope6",
 			.chance = 1,
+			.parentEdgeDistance = 16,
 		},
 	},
 

--- a/assets/cubyz/biomes/volcano/slope1.zig.zon
+++ b/assets/cubyz/biomes/volcano/slope1.zig.zon
@@ -15,6 +15,7 @@
 		.{
 			.id = "cubyz:volcano/base",
 			.chance = 1,
+			.parentEdgeDistance = 16,
 		},
 	},
 

--- a/assets/cubyz/biomes/volcano/slope2.zig.zon
+++ b/assets/cubyz/biomes/volcano/slope2.zig.zon
@@ -15,6 +15,7 @@
 		.{
 			.id = "cubyz:volcano/slope1",
 			.chance = 1,
+			.parentEdgeDistance = 16,
 		},
 	},
 

--- a/assets/cubyz/biomes/volcano/slope3.zig.zon
+++ b/assets/cubyz/biomes/volcano/slope3.zig.zon
@@ -16,6 +16,7 @@
 		.{
 			.id = "cubyz:volcano/slope2",
 			.chance = 1,
+			.parentEdgeDistance = 16,
 		},
 	},
 

--- a/assets/cubyz/biomes/volcano/slope4.zig.zon
+++ b/assets/cubyz/biomes/volcano/slope4.zig.zon
@@ -16,6 +16,7 @@
 		.{
 			.id = "cubyz:volcano/slope3",
 			.chance = 1,
+			.parentEdgeDistance = 16,
 		},
 	},
 

--- a/assets/cubyz/biomes/volcano/slope5.zig.zon
+++ b/assets/cubyz/biomes/volcano/slope5.zig.zon
@@ -15,6 +15,7 @@
 		.{
 			.id = "cubyz:volcano/slope4",
 			.chance = 1,
+			.parentEdgeDistance = 16,
 		},
 	},
 

--- a/assets/cubyz/biomes/volcano/slope6.zig.zon
+++ b/assets/cubyz/biomes/volcano/slope6.zig.zon
@@ -15,6 +15,7 @@
 		.{
 			.id = "cubyz:volcano/slope5",
 			.chance = 1,
+			.parentEdgeDistance = 16,
 		},
 	},
 

--- a/src/server/terrain/biomes.zig
+++ b/src/server/terrain/biomes.zig
@@ -248,7 +248,7 @@ pub const Biome = struct { // MARK: Biome
 	vegetationModels: []SimpleStructureModel = &.{},
 	caveSdfModels: []terrain.sdf.SdfModel = &.{},
 	stripes: []Stripe = &.{},
-	subBiomes: main.utils.AliasTable(*const Biome) = .{.items = &.{}, .aliasData = &.{}},
+	subBiomes: main.utils.AliasTable(SubBiomeData) = .{.items = &.{}, .aliasData = &.{}},
 	transitionBiomes: []TransitionBiome = &.{},
 	maxSubBiomeCount: f32,
 	subBiomeTotalChance: f32 = 0,
@@ -317,7 +317,11 @@ pub const Biome = struct { // MARK: Biome
 		const parentBiomeList = zon.getChild("parentBiomes");
 		for (parentBiomeList.toSlice()) |parent| {
 			const result = unfinishedSubBiomes.getOrPutValue(main.globalAllocator.allocator, parent.get([]const u8, "id", ""), .{}) catch unreachable;
-			result.value_ptr.append(main.globalAllocator, .{.biomeId = self.id, .chance = parent.get(f32, "chance", 1)});
+			result.value_ptr.append(main.globalAllocator, .{
+				.biomeId = self.id,
+				.chance = parent.get(f32, "chance", 1),
+				.parentEdgeDistance = parent.get(f32, "parentEdgeDistance", terrain.SurfaceMap.MapFragment.biomeSize),
+			});
 		}
 
 		const transitionBiomeList = zon.getChild("transitionBiomes").toSlice();
@@ -578,11 +582,17 @@ var biomesById: std.StringHashMapUnmanaged(*Biome) = .{};
 var biomesByIndex: main.ListUnmanaged(*Biome) = .{};
 pub var byTypeBiomes: *TreeNode = undefined;
 
+const SubBiomeData = struct {
+	biome: *const Biome,
+	parentEdgeDistance: f32,
+};
+
 const UnfinishedSubBiomeData = struct {
 	biomeId: []const u8,
 	chance: f32,
-	pub fn getItem(self: UnfinishedSubBiomeData) *const Biome {
-		return getById(self.biomeId);
+	parentEdgeDistance: f32,
+	pub fn getItem(self: UnfinishedSubBiomeData) SubBiomeData {
+		return .{.biome = getById(self.biomeId), .parentEdgeDistance = self.parentEdgeDistance};
 	}
 };
 var unfinishedSubBiomes: std.StringHashMapUnmanaged(main.ListUnmanaged(UnfinishedSubBiomeData)) = .{};

--- a/src/server/terrain/climategen/NoiseBasedVoronoi.zig
+++ b/src/server/terrain/climategen/NoiseBasedVoronoi.zig
@@ -351,11 +351,14 @@ const GenerationStructure = struct {
 		var fails: usize = 0;
 		while (i < biomeCount) : (i += 1) {
 			if (biomeCount - i < random.nextFloat(&seed)) break;
-			const subBiome = biome.biome.subBiomes.sample(&seed).*;
+			const subBiomeData = biome.biome.subBiomes.sample(&seed).*;
+			const subBiome = subBiomeData.biome;
 			const subRadius = subBiome.radius + subBiome.radiusVariation*random.nextFloatSigned(&seed);
 			var maxCenterOffset: f32 = biome.radius - subRadius;
 			if (radius == .unknown) {
 				maxCenterOffset += biome.radius/2;
+			} else {
+				maxCenterOffset -= subBiomeData.parentEdgeDistance;
 			}
 			if (maxCenterOffset < 0) {
 				maxCenterOffset = 0;


### PR DESCRIPTION
This can be used to control whether the biome can spawn right at the edge of a parent biome.

This is required to make island shelves behave more predictably for #2620
With the new restrictions it makes the island always spawn in the center of the shelf biome:
<img width="256" height="256" alt="test" src="https://github.com/user-attachments/assets/9c37052a-b3d4-49d4-ad24-260cb884f47e" />

I decided to make this a configurable parameter `parentEdgeDistance` (and it can also be negative) to allow mountains to remain their wacky shapes and bigger slopes.