### PR TITLE
Added /spawn world command for changing the default world spawn. #2484

### DIFF
--- a/src/server/command/spawn.zig
+++ b/src/server/command/spawn.zig
@@ -5,44 +5,44 @@ const User = main.server.User;
 
 const command = @import("_command.zig");
 
-pub const description = 
+pub const description =
     \\Get or set the player / world spawn point
     \\Note: when setting the world spawn point, the change will only apply to new players. Players who where already once on the server retain their old spawn point
 ;
 pub const usage =
-	\\/spawn
-	\\/spawn <x> <y> <z>
-	\\/spawn world
-	\\/spawn world <x> <y> <z>
+    \\/spawn
+    \\/spawn <x> <y> <z>
+    \\/spawn world
+    \\/spawn world <x> <y> <z>
 ;
 
 pub fn execute(args: []const u8, source: *User) void {
-	var split = std.mem.splitScalar(u8, args, ' ');
-	if (split.peek().?.len > 0) {
-		if (std.mem.eql(u8, split.peek().?, "world")) {
-			_ = split.next();
-			if (split.peek() == null or split.peek().?.len == 0) {
-				const world = main.server.world.?;
-				source.sendMessage("#ffff00World spawn: {}", .{world.spawn});
-				return;
-			}
-			const pos = command.parseCoordinates(&split, source) catch return;
-			if (split.next()) |_| {
-				source.sendMessage("#ff0000Too many arguments for command /spawn", .{});
-				return;
-			}
-			const world = main.server.world.?;
-			world.spawn = @intFromFloat(pos);
-			return;
-		}
+    var split = std.mem.splitScalar(u8, args, ' ');
+    if (split.peek().?.len > 0) {
+        if (std.mem.eql(u8, split.peek().?, "world")) {
+            _ = split.next();
+            if (split.peek() == null or split.peek().?.len == 0) {
+                const world = main.server.world.?;
+                source.sendMessage("#ffff00World spawn: {}", .{world.spawn});
+                return;
+            }
+            const pos = command.parseCoordinates(&split, source) catch return;
+            if (split.next()) |_| {
+                source.sendMessage("#ff0000Too many arguments for command /spawn", .{});
+                return;
+            }
+            const world = main.server.world.?;
+            world.spawn = @intFromFloat(pos);
+            return;
+        }
 
-		const pos = command.parseCoordinates(&split, source) catch return;
-		if (split.next()) |_| {
-			source.sendMessage("#ff0000Too many arguments for command /spawn", .{});
-			return;
-		}
-		source.spawnPos = pos;
-	} else {
-		source.sendMessage("#ffff00{}", .{source.spawnPos});
-	}
+        const pos = command.parseCoordinates(&split, source) catch return;
+        if (split.next()) |_| {
+            source.sendMessage("#ff0000Too many arguments for command /spawn", .{});
+            return;
+        }
+        source.spawnPos = pos;
+    } else {
+        source.sendMessage("#ffff00{}", .{source.spawnPos});
+    }
 }

--- a/src/server/command/spawn.zig
+++ b/src/server/command/spawn.zig
@@ -5,9 +5,7 @@ const User = main.server.User;
 
 const command = @import("_command.zig");
 
-pub const description =
-	\\Get or set the player / world spawn point
-	\\Note: when setting the world spawn point, the change will only apply to new players. Players who where already once on the server retain their old spawn point
+pub const description = "Get or set the player / world spawn point"
 ;
 pub const usage =
 	\\/spawn

--- a/src/server/command/spawn.zig
+++ b/src/server/command/spawn.zig
@@ -5,7 +5,10 @@ const User = main.server.User;
 
 const command = @import("_command.zig");
 
-pub const description = "Get or set the player spawn point";
+pub const description = 
+    \\Get or set the player / world spawn point
+    \\Note: when setting the world spawn point, the change will only apply to new players. Players who where already once on the server retain their old spawn point
+;
 pub const usage =
 	\\/spawn
 	\\/spawn <x> <y> <z>

--- a/src/server/command/spawn.zig
+++ b/src/server/command/spawn.zig
@@ -9,13 +9,37 @@ pub const description = "Get or set the player spawn point";
 pub const usage =
 	\\/spawn
 	\\/spawn <x> <y> <z>
+	\\/spawn world
+	\\/spawn world <x> <y> <z>
 ;
 
 pub fn execute(args: []const u8, source: *User) void {
 	var split = std.mem.splitScalar(u8, args, ' ');
 	if (split.peek().?.len > 0) {
-		const pos = command.parseCoordinates(&split, source) catch return;
-		if (split.next()) |_| {
+		const first = split.next().?;
+		if (std.mem.eql(u8, first, "world")) {
+			if (split.peek() == null or split.peek().?.len == 0) {
+				const world = main.server.world.?;
+				source.sendMessage("#ffff00World spawn: {}", .{world.spawn});
+				return;
+			}
+			const pos = command.parseCoordinates(&split, source) catch return;
+			if (split.next()) |_| {
+				source.sendMessage("#ff0000Too many arguments for command /spawn", .{});
+				return;
+			}
+			const world = main.server.world.?;
+			world.spawn = .{
+				@intFromFloat(pos[0]),
+				@intFromFloat(pos[1]),
+				@intFromFloat(pos[2]),
+			};
+			return;
+		}
+
+		var newSplit = std.mem.splitScalar(u8, args, ' ');
+		const pos = command.parseCoordinates(&newSplit, source) catch return;
+		if (newSplit.next()) |_| {
 			source.sendMessage("#ff0000Too many arguments for command /spawn", .{});
 			return;
 		}

--- a/src/server/command/spawn.zig
+++ b/src/server/command/spawn.zig
@@ -16,8 +16,8 @@ pub const usage =
 pub fn execute(args: []const u8, source: *User) void {
 	var split = std.mem.splitScalar(u8, args, ' ');
 	if (split.peek().?.len > 0) {
-		const first = split.next().?;
-		if (std.mem.eql(u8, first, "world")) {
+		if (std.mem.eql(u8, split.peek().?, "world")) {
+			_ = split.next();
 			if (split.peek() == null or split.peek().?.len == 0) {
 				const world = main.server.world.?;
 				source.sendMessage("#ffff00World spawn: {}", .{world.spawn});

--- a/src/server/command/spawn.zig
+++ b/src/server/command/spawn.zig
@@ -6,43 +6,43 @@ const User = main.server.User;
 const command = @import("_command.zig");
 
 pub const description =
-    \\Get or set the player / world spawn point
-    \\Note: when setting the world spawn point, the change will only apply to new players. Players who where already once on the server retain their old spawn point
+	\\Get or set the player / world spawn point
+	\\Note: when setting the world spawn point, the change will only apply to new players. Players who where already once on the server retain their old spawn point
 ;
 pub const usage =
-    \\/spawn
-    \\/spawn <x> <y> <z>
-    \\/spawn world
-    \\/spawn world <x> <y> <z>
+	\\/spawn
+	\\/spawn <x> <y> <z>
+	\\/spawn world
+	\\/spawn world <x> <y> <z>
 ;
 
 pub fn execute(args: []const u8, source: *User) void {
-    var split = std.mem.splitScalar(u8, args, ' ');
-    if (split.peek().?.len > 0) {
-        if (std.mem.eql(u8, split.peek().?, "world")) {
-            _ = split.next();
-            if (split.peek() == null or split.peek().?.len == 0) {
-                const world = main.server.world.?;
-                source.sendMessage("#ffff00World spawn: {}", .{world.spawn});
-                return;
-            }
-            const pos = command.parseCoordinates(&split, source) catch return;
-            if (split.next()) |_| {
-                source.sendMessage("#ff0000Too many arguments for command /spawn", .{});
-                return;
-            }
-            const world = main.server.world.?;
-            world.spawn = @intFromFloat(pos);
-            return;
-        }
+	var split = std.mem.splitScalar(u8, args, ' ');
+	if (split.peek().?.len > 0) {
+		if (std.mem.eql(u8, split.peek().?, "world")) {
+			_ = split.next();
+			if (split.peek() == null or split.peek().?.len == 0) {
+				const world = main.server.world.?;
+				source.sendMessage("#ffff00World spawn: {}", .{world.spawn});
+				return;
+			}
+			const pos = command.parseCoordinates(&split, source) catch return;
+			if (split.next()) |_| {
+				source.sendMessage("#ff0000Too many arguments for command /spawn", .{});
+				return;
+			}
+			const world = main.server.world.?;
+			world.spawn = @intFromFloat(pos);
+			return;
+		}
 
-        const pos = command.parseCoordinates(&split, source) catch return;
-        if (split.next()) |_| {
-            source.sendMessage("#ff0000Too many arguments for command /spawn", .{});
-            return;
-        }
-        source.spawnPos = pos;
-    } else {
-        source.sendMessage("#ffff00{}", .{source.spawnPos});
-    }
+		const pos = command.parseCoordinates(&split, source) catch return;
+		if (split.next()) |_| {
+			source.sendMessage("#ff0000Too many arguments for command /spawn", .{});
+			return;
+		}
+		source.spawnPos = pos;
+	} else {
+		source.sendMessage("#ffff00{}", .{source.spawnPos});
+	}
 }

--- a/src/server/command/spawn.zig
+++ b/src/server/command/spawn.zig
@@ -29,11 +29,7 @@ pub fn execute(args: []const u8, source: *User) void {
 				return;
 			}
 			const world = main.server.world.?;
-			world.spawn = .{
-				@intFromFloat(pos[0]),
-				@intFromFloat(pos[1]),
-				@intFromFloat(pos[2]),
-			};
+			world.spawn = @intFromFloat(pos)
 			return;
 		}
 

--- a/src/server/command/spawn.zig
+++ b/src/server/command/spawn.zig
@@ -37,9 +37,8 @@ pub fn execute(args: []const u8, source: *User) void {
 			return;
 		}
 
-		var newSplit = std.mem.splitScalar(u8, args, ' ');
-		const pos = command.parseCoordinates(&newSplit, source) catch return;
-		if (newSplit.next()) |_| {
+		const pos = command.parseCoordinates(&split, source) catch return;
+		if (split.next()) |_| {
 			source.sendMessage("#ff0000Too many arguments for command /spawn", .{});
 			return;
 		}

--- a/src/server/command/spawn.zig
+++ b/src/server/command/spawn.zig
@@ -5,8 +5,7 @@ const User = main.server.User;
 
 const command = @import("_command.zig");
 
-pub const description = "Get or set the player / world spawn point"
-;
+pub const description = "Get or set the player / world spawn point";
 pub const usage =
 	\\/spawn
 	\\/spawn <x> <y> <z>

--- a/src/server/command/spawn.zig
+++ b/src/server/command/spawn.zig
@@ -32,7 +32,7 @@ pub fn execute(args: []const u8, source: *User) void {
 				return;
 			}
 			const world = main.server.world.?;
-			world.spawn = @intFromFloat(pos)
+			world.spawn = @intFromFloat(pos);
 			return;
 		}
 


### PR DESCRIPTION
Use:-
`/spawn world <x> <y> <z>`
to set the default world spawn for new players.
The /spawn still works and this command does not overwrite that.

Use:-
`/spawn world` - to see the world spawn coords

fixes: #2484