### PR TITLE
Round tool stats display to 1 decimal

### DIFF
--- a/src/items.zig
+++ b/src/items.zig
@@ -844,8 +844,8 @@ pub const Tool = struct { // MARK: Tool
 		self.tooltip.clearRetainingCapacity();
 		self.tooltip.print(
 			\\{s}
-			\\{d:.2} swings/s
-			\\Damage: {d:.2}
+			\\{d:.1} swings/s
+			\\Damage: {d:.1}
 			\\Durability: {}/{}
 		, .{
 			self.type.id(),


### PR DESCRIPTION
This PR replaces #2871 which fixes #2696 
The previous PR contained unrelated changes, so it was closed.
This version only includes the formatting changes.