### PR TITLE
Use Vec3i for BlockUpdate and UpdateBlock

### DIFF
--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -477,9 +477,7 @@ pub const blockUpdate = struct { // MARK: blockUpdate
 	fn clientReceive(_: *Connection, reader: *utils.BinaryReader) !void {
 		while (reader.remaining.len != 0) {
 			renderer.mesh_storage.updateBlock(.{
-				.x = try reader.readInt(i32),
-				.y = try reader.readInt(i32),
-				.z = try reader.readInt(i32),
+				.pos = try reader.readVec(Vec3i),
 				.newBlock = Block.fromInt(try reader.readInt(u32)),
 				.blockEntityData = try reader.readSlice(try reader.readInt(usize)),
 			});
@@ -490,9 +488,7 @@ pub const blockUpdate = struct { // MARK: blockUpdate
 		defer writer.deinit();
 
 		for (updates) |update| {
-			writer.writeInt(i32, update.x);
-			writer.writeInt(i32, update.y);
-			writer.writeInt(i32, update.z);
+			writer.writeVec(Vec3i, update.pos);
 			writer.writeInt(u32, update.newBlock.toInt());
 			writer.writeInt(usize, update.blockEntityData.len);
 			writer.writeSlice(update.blockEntityData);
@@ -944,7 +940,7 @@ pub const blockEntityUpdate = struct { // MARK: blockEntityUpdate
 		defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, users);
 
 		for (users) |user| {
-			blockUpdate.send(user.conn, &.{.{.x = pos[0], .y = pos[1], .z = pos[2], .newBlock = block, .blockEntityData = writer.data.items}});
+			blockUpdate.send(user.conn, &.{.{.pos = pos, .newBlock = block, .blockEntityData = writer.data.items}});
 		}
 	}
 

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -991,13 +991,13 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 							const relPos: Vec3f = @floatCast(lastPos - @as(Vec3d, @floatFromInt(selectedPos)));
 							if (rotationMode.generateData(main.game.world.?, selectedPos, relPos, lastDir, neighborDir, null, &block, .{.typ = 0, .data = 0}, false)) {
 								if (!canPlaceBlock(selectedPos, block)) return;
-								updateBlockAndSendUpdate(inventory, slot, selectedPos[0], selectedPos[1], selectedPos[2], oldBlock, block);
+								updateBlockAndSendUpdate(inventory, slot, selectedPos, oldBlock, block);
 								return;
 							}
 						} else {
 							if (rotationMode.modifyBlock(&block, itemBlock)) {
 								if (!canPlaceBlock(selectedPos, block)) return;
-								updateBlockAndSendUpdate(inventory, slot, selectedPos[0], selectedPos[1], selectedPos[2], oldBlock, block);
+								updateBlockAndSendUpdate(inventory, slot, selectedPos, oldBlock, block);
 								return;
 							}
 						}
@@ -1011,7 +1011,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 						if (block.typ == itemBlock) {
 							if (rotationMode.generateData(main.game.world.?, neighborPos, relPos, lastDir, neighborDir, neighborOfSelection, &block, neighborBlock, false)) {
 								if (!canPlaceBlock(neighborPos, block)) return;
-								updateBlockAndSendUpdate(inventory, slot, neighborPos[0], neighborPos[1], neighborPos[2], oldBlock, block);
+								updateBlockAndSendUpdate(inventory, slot, neighborPos, oldBlock, block);
 								return;
 							}
 						} else {
@@ -1020,7 +1020,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 							block.data = 0;
 							if (rotationMode.generateData(main.game.world.?, neighborPos, relPos, lastDir, neighborDir, neighborOfSelection, &block, neighborBlock, true)) {
 								if (!canPlaceBlock(neighborPos, block)) return;
-								updateBlockAndSendUpdate(inventory, slot, neighborPos[0], neighborPos[1], neighborPos[2], oldBlock, block);
+								updateBlockAndSendUpdate(inventory, slot, neighborPos, oldBlock, block);
 								return;
 							}
 						}
@@ -1117,16 +1117,16 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 			main.sync.ClientSide.mutex.unlock();
 
 			if (newBlock != block) {
-				updateBlockAndSendUpdate(inventory, slot, selectedPos[0], selectedPos[1], selectedPos[2], block, newBlock);
+				updateBlockAndSendUpdate(inventory, slot, selectedPos, block, newBlock);
 			}
 		}
 	}
 
-	fn updateBlockAndSendUpdate(source: main.items.Inventory.ClientInventory, slot: u32, x: i32, y: i32, z: i32, oldBlock: blocks.Block, newBlock: blocks.Block) void {
+	fn updateBlockAndSendUpdate(source: main.items.Inventory.ClientInventory, slot: u32, pos: Vec3i, oldBlock: blocks.Block, newBlock: blocks.Block) void {
 		main.sync.ClientSide.executeCommand(.{
 			.updateBlock = .{
 				.source = .{.inv = source.super, .slot = slot},
-				.pos = .{x, y, z},
+				.pos = pos,
 				.dropLocation = .{
 					.dir = selectionFace,
 					.min = selectionMin,
@@ -1136,7 +1136,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 				.newBlock = newBlock,
 			},
 		});
-		mesh_storage.updateBlock(.{.x = x, .y = y, .z = z, .newBlock = newBlock, .blockEntityData = &.{}});
+		mesh_storage.updateBlock(.{.pos = pos, .newBlock = newBlock, .blockEntityData = &.{}});
 	}
 
 	pub fn drawCube(projectionMatrix: Mat4f, viewMatrix: Mat4f, relativePositionToPlayer: Vec3d, min: Vec3f, max: Vec3f) void {

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -1153,17 +1153,17 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 		}
 	}
 
-	pub fn updateBlock(self: *ChunkMesh, _x: i32, _y: i32, _z: i32, _newBlock: Block, blockEntityData: []const u8, lightRefreshList: *main.List(chunk.ChunkPosition), regenerateMeshList: *main.List(*ChunkMesh)) void {
-		const blockPos = chunk.BlockPos.fromWorldCoords(_x, _y, _z);
-		var newBlock = _newBlock;
+	pub fn updateBlock(self: *ChunkMesh, blockUpdate: mesh_storage.BlockUpdate, lightRefreshList: *main.List(chunk.ChunkPosition), regenerateMeshList: *main.List(*ChunkMesh)) void {
+		const blockPos = chunk.BlockPos.fromWorldCoords(blockUpdate.pos[0], blockUpdate.pos[1], blockUpdate.pos[2]);
+		var newBlock = blockUpdate.newBlock;
 		self.mutex.lock();
 		const oldBlock = self.chunk.data.getValue(blockPos.toIndex());
 
 		if (oldBlock == newBlock) {
 			if (newBlock.blockEntity()) |blockEntity| {
-				var reader = main.utils.BinaryReader.init(blockEntityData);
-				blockEntity.updateClientData(.{_x, _y, _z}, self.chunk, .{.update = &reader}) catch |err| {
-					std.log.err("Got error {s} while trying to apply block entity data {any} in position {} for block {s}", .{@errorName(err), blockEntityData, Vec3i{_x, _y, _z}, newBlock.id()});
+				var reader = main.utils.BinaryReader.init(blockUpdate.blockEntityData);
+				blockEntity.updateClientData(blockUpdate.pos, self.chunk, .{.update = &reader}) catch |err| {
+					std.log.err("Got error {s} while trying to apply block entity data {any} in position {} for block {s}", .{@errorName(err), blockUpdate.blockEntityData, blockUpdate.pos, newBlock.id()});
 				};
 			}
 			self.mutex.unlock();
@@ -1172,8 +1172,8 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 		self.mutex.unlock();
 
 		if (oldBlock.blockEntity()) |blockEntity| {
-			blockEntity.updateClientData(.{_x, _y, _z}, self.chunk, .remove) catch |err| {
-				std.log.err("Got error {s} while trying to remove entity data in position {} for block {s}", .{@errorName(err), Vec3i{_x, _y, _z}, oldBlock.id()});
+			blockEntity.updateClientData(blockUpdate.pos, self.chunk, .remove) catch |err| {
+				std.log.err("Got error {s} while trying to remove entity data in position {} for block {s}", .{@errorName(err), blockUpdate.pos, oldBlock.id()});
 			};
 		}
 

--- a/src/renderer/mesh_storage.zig
+++ b/src/renderer/mesh_storage.zig
@@ -45,21 +45,17 @@ var lastRD: u16 = 0;
 var mutex: std.Thread.Mutex = .{};
 
 pub const BlockUpdate = struct {
-	x: i32,
-	y: i32,
-	z: i32,
+	pos: Vec3i,
 	newBlock: blocks.Block,
 	blockEntityData: []const u8,
 
 	pub fn init(pos: Vec3i, block: blocks.Block, blockEntityData: []const u8) BlockUpdate {
-		return .{.x = pos[0], .y = pos[1], .z = pos[2], .newBlock = block, .blockEntityData = blockEntityData};
+		return .{.pos = pos, .newBlock = block, .blockEntityData = blockEntityData};
 	}
 
 	pub fn initManaged(allocator: main.heap.NeverFailingAllocator, template: BlockUpdate) BlockUpdate {
 		return .{
-			.x = template.x,
-			.y = template.y,
-			.z = template.z,
+			.pos = template.pos,
 			.newBlock = template.newBlock,
 			.blockEntityData = allocator.dupe(u8, template.blockEntityData),
 		};
@@ -796,9 +792,9 @@ fn batchUpdateBlocks() void {
 	// First of all process all the block updates:
 	while (blockUpdateList.popFront()) |blockUpdate| {
 		defer blockUpdate.deinitManaged(main.globalAllocator);
-		const pos = chunk.ChunkPosition{.wx = blockUpdate.x, .wy = blockUpdate.y, .wz = blockUpdate.z, .voxelSize = 1};
+		const pos = chunk.ChunkPosition{.wx = blockUpdate.pos[0], .wy = blockUpdate.pos[1], .wz = blockUpdate.pos[2], .voxelSize = 1};
 		if (getMesh(pos)) |mesh| {
-			mesh.updateBlock(blockUpdate.x, blockUpdate.y, blockUpdate.z, blockUpdate.newBlock, blockUpdate.blockEntityData, &lightRefreshList, &regenerateMeshList);
+			mesh.updateBlock(blockUpdate, &lightRefreshList, &regenerateMeshList);
 		} // TODO: It seems like we simply ignore the block update if we don't have the mesh yet.
 	}
 	for (regenerateMeshList.items) |mesh| {

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -1257,7 +1257,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		defer server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
 
 		for (userList) |user| {
-			main.network.protocols.blockUpdate.send(user.conn, &.{.{.x = wx, .y = wy, .z = wz, .newBlock = newBlock, .blockEntityData = &.{}}});
+			main.network.protocols.blockUpdate.send(user.conn, &.{.{.pos = .{wx, wy, wz}, .newBlock = newBlock, .blockEntityData = &.{}}});
 		}
 		// onBreak event
 		if (oldBlock) |block| {


### PR DESCRIPTION
Preparation for some work on block update messages;

Reduces side of block update signatures and calls by using Vec3i instead of 3 separate integers. No negative impact is expected and there is less code to write and read.

Apparantly I also merged part of `chunk_meshing.updateBlock` signature from separate parameters into `mesh_storage.BlockUpdate` for the same reason.