### PR TITLE
ECS Patch 1 | name freeing when Entity.clone

### DIFF
--- a/src/server/Entity.zig
+++ b/src/server/Entity.zig
@@ -38,9 +38,7 @@ pub fn loadFrom(self: *@This(), id: u32, zon: ZonElement, comptime side: main.sy
 }
 pub fn clone(self: *@This(), copy: *@This()) void {
 	const originalID = copy.id;
-	if (copy.name) |name| {
-		main.globalAllocator.free(name);
-	}
+	std.debug.assert(copy.name == null);
 	copy.* = self.*;
 	copy.name = if (self.name) |name| main.globalAllocator.dupe(u8, name) else null;
 	copy.id = originalID;

--- a/src/server/Entity.zig
+++ b/src/server/Entity.zig
@@ -38,6 +38,9 @@ pub fn loadFrom(self: *@This(), id: u32, zon: ZonElement, comptime side: main.sy
 }
 pub fn clone(self: *@This(), copy: *@This()) void {
 	const originalID = copy.id;
+	if (copy.name) |name| {
+		main.globalAllocator.free(name);
+	}
 	copy.* = self.*;
 	copy.name = if (self.name) |name| main.globalAllocator.dupe(u8, name) else null;
 	copy.id = originalID;


### PR DESCRIPTION
When splitting up a big PR, mini mistakes are going to happen.
Because it's hard to see what PR part contains what part of the code.
In this Patch series, i correct them.

This is PR deleted the old name of the Entity when it is set to be equal to another, and copying it's name