### PR TITLE
ECS Patch 2 | load and unload components on clientside

### DIFF
--- a/src/client/Entity.zig
+++ b/src/client/Entity.zig
@@ -32,7 +32,7 @@ id: u32,
 name: []const u8,
 playerIndex: usize, // TODO extract into own component #2760
 
-pub fn init(self: *@This(), zon: ZonElement, allocator: NeverFailingAllocator) void {
+pub fn init(self: *@This(), zon: ZonElement, allocator: NeverFailingAllocator) !void {
 	self.* = @This(){
 		.id = zon.get(u32, "id", std.math.maxInt(u32)),
 		.width = zon.get(f64, "width", 1),
@@ -50,9 +50,14 @@ pub fn init(self: *@This(), zon: ZonElement, allocator: NeverFailingAllocator) v
 	};
 	self._interpolationVel = @splat(0);
 	self.interpolatedValues.init(&self._interpolationPos, &self._interpolationVel);
+
+	if (zon.getChildOrNull("components")) |components| {
+		try main.entity.loadComponentsFromBase64(components.as([]const u8, ""), self.id, .client);
+	}
 }
 
 pub fn deinit(self: @This(), allocator: NeverFailingAllocator) void {
+	main.entity.client.removeAllComponents(self.id);
 	allocator.free(self.name);
 }
 

--- a/src/client/entity_manager.zig
+++ b/src/client/entity_manager.zig
@@ -154,11 +154,11 @@ pub fn render(projMatrix: Mat4f, ambientLight: Vec3f, playerPos: Vec3d) void {
 	}
 }
 
-pub fn addEntity(zon: ZonElement) void {
+pub fn addEntity(zon: ZonElement) !void {
 	mutex.lock();
 	defer mutex.unlock();
 	var ent = entities.addOne();
-	ent.init(zon, main.globalAllocator);
+	try ent.init(zon, main.globalAllocator);
 }
 
 pub fn removeEntity(id: u32) void {

--- a/src/entity.zig
+++ b/src/entity.zig
@@ -81,6 +81,12 @@ pub const client = struct {
 		}
 		main.client.entity_manager.clear();
 	}
+	pub fn removeAllComponents(id: u32) void {
+		const list = main.entity.components;
+		inline for (@typeInfo(list).@"struct".decls) |decl| {
+			@field(list, decl.name).client.unload(id);
+		}
+	}
 };
 pub const server = struct {
 	pub fn init() void {

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -515,7 +515,7 @@ pub const entity = struct { // MARK: entity
 					main.client.entity_manager.removeEntity(elem.as(u32, 0));
 				},
 				.object => {
-					main.client.entity_manager.addEntity(elem);
+					try main.client.entity_manager.addEntity(elem);
 				},
 				.null => {
 					i += 1;


### PR DESCRIPTION
When splitting up a big PR, mini mistakes are going to happen.
Because it's hard to see what PR part contains what part of the code.
In this Patch series, i correct them.

This is PR loads and unloads components on clientSide