### PR TITLE
[AAA] Part 2 properties

### DIFF
--- a/src/gui/components/ItemSlot.zig
+++ b/src/gui/components/ItemSlot.zig
@@ -148,7 +148,7 @@ pub fn render(self: *ItemSlot, _: Vec2f) void {
 		}
 		if (item == .proceduralItem) {
 			const proceduralItem = item.proceduralItem;
-			const durabilityPercentage = @as(f32, @floatFromInt(proceduralItem.durability))/proceduralItem.maxDurability;
+			const durabilityPercentage = @as(f32, @floatFromInt(proceduralItem.durability))/proceduralItem.getProperty(.maxDurability);
 
 			if (durabilityPercentage < 1) {
 				const width = durabilityPercentage*(self.size[0] - 2*border);

--- a/src/gui/windows/workbench.zig
+++ b/src/gui/windows/workbench.zig
@@ -124,9 +124,9 @@ pub fn render() void {
 	const offsetY = 4*ItemSlot.sizeWithBorder;
 	const fontSize = 16;
 
-	main.graphics.draw.print("{s}{} durability", .{if (currentResult.proceduralItem.maxDurability != 0) "#ffffff" else "#ff0000", @as(usize, @intFromFloat(currentResult.proceduralItem.maxDurability))}, offsetX, offsetY, fontSize, .left);
-	main.graphics.draw.print("#ffffff{d:.1} swings/s", .{currentResult.proceduralItem.swingSpeed}, offsetX, offsetY + fontSize, fontSize, .left);
-	main.graphics.draw.print("#ffffff{d:.1} damage", .{currentResult.proceduralItem.damage}, offsetX, offsetY + 2*fontSize, fontSize, .left);
+	main.graphics.draw.print("{s}{} durability", .{if (currentResult.proceduralItem.getProperty(.maxDurability) != 0) "#ffffff" else "#ff0000", @as(usize, @intFromFloat(currentResult.proceduralItem.getProperty(.maxDurability)))}, offsetX, offsetY, fontSize, .left);
+	main.graphics.draw.print("#ffffff{d:.1} swings/s", .{currentResult.proceduralItem.getProperty(.swingSpeed)}, offsetX, offsetY + fontSize, fontSize, .left);
+	main.graphics.draw.print("#ffffff{d:.1} damage", .{currentResult.proceduralItem.getProperty(.damage)}, offsetX, offsetY + 2*fontSize, fontSize, .left);
 }
 
 pub fn onOpen() void {

--- a/src/items.zig
+++ b/src/items.zig
@@ -629,7 +629,7 @@ pub const ProceduralItemType = struct { // MARK: ProceduralItemType
 const ProceduralItemProperty = enum {
 	damage,
 	maxDurability,
-	/// swings per second
+	/// how long it takes before the next swing happens
 	swingSpeed,
 
 	fn fromString(string: []const u8) ?ProceduralItemProperty {

--- a/src/items.zig
+++ b/src/items.zig
@@ -513,7 +513,7 @@ const ProceduralItemPhysics = struct { // MARK: ProceduralItemPhysics
 			proceduralItem.setProperty(.maxDurability, 0);
 			proceduralItem.durability = 1;
 		}
-		proceduralItem.finished = true;
+		proceduralItem.finishedPropertyEvaluation = true;
 	}
 
 	fn checkConnectivity(proceduralItem: *ProceduralItem) bool {
@@ -652,7 +652,7 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 	texture: ?graphics.Texture,
 	seed: u32,
 	type: ProceduralItemTypeIndex,
-	finished: bool = false,
+	finishedPropertyEvaluation: bool = false,
 
 	properties: [@typeInfo(ProceduralItemProperty).@"enum".fields.len]f32 = @splat(0),
 
@@ -842,7 +842,7 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 	}
 
 	pub fn setProperty(self: *ProceduralItem, prop: ProceduralItemProperty, value: f32) void {
-		std.debug.assert(!self.finished);
+		std.debug.assert(!self.finishedPropertyEvaluation);
 		self.properties[@intFromEnum(prop)] = value;
 	}
 

--- a/src/items.zig
+++ b/src/items.zig
@@ -624,11 +624,11 @@ pub const ProceduralItemType = struct { // MARK: ProceduralItemType
 	pixelSourcesOverlay: [16][16]u8,
 };
 
-const ProceduralItemProperty = enum(u8) {
-	maxDurability = 0,
-	damage = 1,
+const ProceduralItemProperty = enum {
+	maxDurability,
+	damage,
 	/// swings per second
-	swingSpeed = 2,
+	swingSpeed,
 
 	fn fromString(string: []const u8) ?ProceduralItemProperty {
 		return std.meta.stringToEnum(ProceduralItemProperty, string) orelse {

--- a/src/items.zig
+++ b/src/items.zig
@@ -625,8 +625,8 @@ pub const ProceduralItemType = struct { // MARK: ProceduralItemType
 };
 
 const ProceduralItemProperty = enum {
-	maxDurability,
 	damage,
+	maxDurability,
 	/// swings per second
 	swingSpeed,
 

--- a/src/items.zig
+++ b/src/items.zig
@@ -458,9 +458,7 @@ const TextureGenerator = struct { // MARK: TextureGenerator
 const ProceduralItemPhysics = struct { // MARK: ProceduralItemPhysics
 	/// Determines all the basic properties of the proceduralItem.
 	pub fn evaluateProceduralItem(proceduralItem: *ProceduralItem) void {
-		inline for (comptime std.meta.fieldNames(ProceduralItemProperty)) |name| {
-			@field(proceduralItem, name) = 0;
-		}
+		proceduralItem.properties = @splat(0);
 		var tempModifiers: main.List(Modifier) = .init(main.stackAllocator);
 		defer tempModifiers.deinit();
 		for (proceduralItem.type.properties()) |property| {
@@ -479,10 +477,10 @@ const ProceduralItemPhysics = struct { // MARK: ProceduralItemPhysics
 				},
 			}
 			sum *= property.resultScale;
-			proceduralItem.getProperty(property.destination orelse continue).* += sum;
+			proceduralItem.getPropertyPtr(property.destination orelse continue).* += sum;
 		}
-		if (proceduralItem.damage < 1) proceduralItem.damage = 1/(2 - proceduralItem.damage);
-		if (proceduralItem.swingSpeed < 1) proceduralItem.swingSpeed = 1/(2 - proceduralItem.swingSpeed);
+		if (proceduralItem.getProperty(.damage) < 1) proceduralItem.getPropertyPtr(.damage).* = 1/(2 - proceduralItem.getProperty(.damage));
+		if (proceduralItem.getProperty(.swingSpeed) < 1) proceduralItem.getPropertyPtr(.swingSpeed).* = 1/(2 - proceduralItem.getProperty(.swingSpeed));
 		for (0..25) |i| {
 			const material = (proceduralItem.craftingGrid[i] orelse continue).material() orelse continue;
 			outer: for (material.modifiers) |newMod| {
@@ -506,12 +504,12 @@ const ProceduralItemPhysics = struct { // MARK: ProceduralItemPhysics
 			mod.changeProceduralItemParameters(proceduralItem);
 		}
 
-		proceduralItem.maxDurability = @round(proceduralItem.maxDurability);
-		if (proceduralItem.maxDurability < 1) proceduralItem.maxDurability = 1;
-		proceduralItem.durability = std.math.lossyCast(u32, proceduralItem.maxDurability);
+		proceduralItem.getPropertyPtr(.maxDurability).* = @round(proceduralItem.getProperty(.maxDurability));
+		if (proceduralItem.getProperty(.maxDurability) < 1) proceduralItem.getPropertyPtr(.maxDurability).* = 1;
+		proceduralItem.durability = std.math.lossyCast(u32, proceduralItem.getProperty(.maxDurability));
 
 		if (!checkConnectivity(proceduralItem)) {
-			proceduralItem.maxDurability = 0;
+			proceduralItem.getPropertyPtr(.maxDurability).* = 0;
 			proceduralItem.durability = 1;
 		}
 	}
@@ -697,10 +695,8 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 			.texture = null,
 			.seed = self.seed,
 			.type = self.type,
-			.damage = self.damage,
+			.properties = self.properties,
 			.durability = self.durability,
-			.maxDurability = self.maxDurability,
-			.swingSpeed = self.swingSpeed,
 			.handlePosition = self.handlePosition,
 			.inertiaHandle = self.inertiaHandle,
 			.centerOfMass = self.centerOfMass,
@@ -753,7 +749,7 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 			std.log.err("Couldn't find procedural item with type {s}. Replacing it with cubyz:pickaxe", .{zon.get([]const u8, "type", "cubyz:pickaxe")});
 			break :blk ProceduralItemTypeIndex.fromId("cubyz:pickaxe") orelse @panic("cubyz:pickaxe procedural item not found. Did you load the game with the correct assets?");
 		});
-		self.durability = zon.get(u32, "durability", std.math.lossyCast(u32, self.maxDurability));
+		self.durability = zon.get(u32, "durability", std.math.lossyCast(u32, self.getProperty(.maxDurability)));
 		return self;
 	}
 
@@ -838,7 +834,11 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 		return self.craftingGrid[@intCast(x + y*5)];
 	}
 
-	fn getProperty(self: *ProceduralItem, prop: ProceduralItemProperty) *f32 {
+	pub fn getProperty(self: *ProceduralItem, prop: ProceduralItemProperty) f32 {
+		return self.properties[@intFromEnum(prop)];
+	}
+
+	pub fn getPropertyPtr(self: *ProceduralItem, prop: ProceduralItemProperty) *f32 {
 		return &self.properties[@intFromEnum(prop)];
 	}
 
@@ -859,10 +859,10 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 			\\Durability: {}/{}
 		, .{
 			self.type.id(),
-			self.swingSpeed,
-			self.damage,
+			self.getProperty(.swingSpeed),
+			self.getProperty(.damage),
 			self.durability,
-			std.math.lossyCast(u32, self.maxDurability),
+			std.math.lossyCast(u32, self.getProperty(.maxDurability)),
 		});
 		if (self.modifiers.len != 0) {
 			self.tooltip.appendSlice("\nModifiers:\n");
@@ -885,7 +885,7 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 	}
 
 	pub fn getBlockDamage(self: *ProceduralItem, block: main.blocks.Block) f32 {
-		var damage = self.getProperty(.damage).*;
+		var damage = self.getProperty(.damage);
 		for (self.modifiers) |modifier| {
 			damage = modifier.changeBlockDamage(damage, block);
 		}

--- a/src/items.zig
+++ b/src/items.zig
@@ -462,6 +462,7 @@ const ProceduralItemPhysics = struct { // MARK: ProceduralItemPhysics
 		var tempModifiers: main.List(Modifier) = .init(main.stackAllocator);
 		defer tempModifiers.deinit();
 		for (proceduralItem.type.properties()) |property| {
+			if (property.destination == null) continue;
 			var sum: f32 = 0;
 			var weight: f32 = 0;
 			for (0..25) |i| {
@@ -477,10 +478,10 @@ const ProceduralItemPhysics = struct { // MARK: ProceduralItemPhysics
 				},
 			}
 			sum *= property.resultScale;
-			proceduralItem.getPropertyPtr(property.destination orelse continue).* += sum;
+			proceduralItem.setProperty(property.destination.?, proceduralItem.getProperty(property.destination.?) + sum);
 		}
-		if (proceduralItem.getProperty(.damage) < 1) proceduralItem.getPropertyPtr(.damage).* = 1/(2 - proceduralItem.getProperty(.damage));
-		if (proceduralItem.getProperty(.swingSpeed) < 1) proceduralItem.getPropertyPtr(.swingSpeed).* = 1/(2 - proceduralItem.getProperty(.swingSpeed));
+		if (proceduralItem.getProperty(.damage) < 1) proceduralItem.setProperty(.damage, 1/(2 - proceduralItem.getProperty(.damage)));
+		if (proceduralItem.getProperty(.swingSpeed) < 1) proceduralItem.setProperty(.swingSpeed, 1/(2 - proceduralItem.getProperty(.swingSpeed)));
 		for (0..25) |i| {
 			const material = (proceduralItem.craftingGrid[i] orelse continue).material() orelse continue;
 			outer: for (material.modifiers) |newMod| {
@@ -504,14 +505,15 @@ const ProceduralItemPhysics = struct { // MARK: ProceduralItemPhysics
 			mod.changeProceduralItemParameters(proceduralItem);
 		}
 
-		proceduralItem.getPropertyPtr(.maxDurability).* = @round(proceduralItem.getProperty(.maxDurability));
-		if (proceduralItem.getProperty(.maxDurability) < 1) proceduralItem.getPropertyPtr(.maxDurability).* = 1;
+		proceduralItem.setProperty(.maxDurability, @round(proceduralItem.getProperty(.maxDurability)));
+		if (proceduralItem.getProperty(.maxDurability) < 1) proceduralItem.setProperty(.maxDurability, 1);
 		proceduralItem.durability = std.math.lossyCast(u32, proceduralItem.getProperty(.maxDurability));
 
 		if (!checkConnectivity(proceduralItem)) {
-			proceduralItem.getPropertyPtr(.maxDurability).* = 0;
+			proceduralItem.setProperty(.maxDurability, 0);
 			proceduralItem.durability = 1;
 		}
+		proceduralItem.finished = true;
 	}
 
 	fn checkConnectivity(proceduralItem: *ProceduralItem) bool {
@@ -650,6 +652,7 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 	texture: ?graphics.Texture,
 	seed: u32,
 	type: ProceduralItemTypeIndex,
+	finished: bool = false,
 
 	properties: [@typeInfo(ProceduralItemProperty).@"enum".fields.len]f32 = @splat(0),
 
@@ -838,8 +841,9 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 		return self.properties[@intFromEnum(prop)];
 	}
 
-	pub fn getPropertyPtr(self: *ProceduralItem, prop: ProceduralItemProperty) *f32 {
-		return &self.properties[@intFromEnum(prop)];
+	pub fn setProperty(self: *ProceduralItem, prop: ProceduralItemProperty, value: f32) void {
+		std.debug.assert(!self.finished);
+		self.properties[@intFromEnum(prop)] = value;
 	}
 
 	fn getTexture(self: *ProceduralItem) graphics.Texture {

--- a/src/items.zig
+++ b/src/items.zig
@@ -626,10 +626,11 @@ pub const ProceduralItemType = struct { // MARK: ProceduralItemType
 	pixelSourcesOverlay: [16][16]u8,
 };
 
-const ProceduralItemProperty = enum {
-	damage,
-	maxDurability,
-	swingSpeed,
+const ProceduralItemProperty = enum(u8) {
+	maxDurability = 0,
+	damage = 1,
+	/// swings per second
+	swingSpeed = 2,
 
 	fn fromString(string: []const u8) ?ProceduralItemProperty {
 		return std.meta.stringToEnum(ProceduralItemProperty, string) orelse {
@@ -652,13 +653,9 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 	seed: u32,
 	type: ProceduralItemTypeIndex,
 
-	damage: f32,
+	properties: [@typeInfo(ProceduralItemProperty).@"enum".fields.len]f32 = @splat(0),
 
 	durability: u32,
-	maxDurability: f32,
-
-	/// swings per second
-	swingSpeed: f32,
 
 	mass: f32,
 
@@ -845,9 +842,7 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 	}
 
 	fn getProperty(self: *ProceduralItem, prop: ProceduralItemProperty) *f32 {
-		switch (prop) {
-			inline else => |field| return &@field(self, @tagName(field)),
-		}
+		return &self.properties[@intFromEnum(prop)];
 	}
 
 	fn getTexture(self: *ProceduralItem) graphics.Texture {
@@ -893,7 +888,7 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 	}
 
 	pub fn getBlockDamage(self: *ProceduralItem, block: main.blocks.Block) f32 {
-		var damage = self.damage;
+		var damage = self.getProperty(.damage).*;
 		for (self.modifiers) |modifier| {
 			damage = modifier.changeBlockDamage(damage, block);
 		}

--- a/src/items.zig
+++ b/src/items.zig
@@ -657,8 +657,6 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 
 	durability: u32,
 
-	mass: f32,
-
 	///  Where the player holds the procedural Item.
 	handlePosition: Vec2f,
 	/// Moment of inertia relative to the handle.
@@ -703,7 +701,6 @@ pub const ProceduralItem = struct { // MARK: ProceduralItem
 			.durability = self.durability,
 			.maxDurability = self.maxDurability,
 			.swingSpeed = self.swingSpeed,
-			.mass = self.mass,
 			.handlePosition = self.handlePosition,
 			.inertiaHandle = self.inertiaHandle,
 			.centerOfMass = self.centerOfMass,

--- a/src/proceduralItem/modifiers/durable.zig
+++ b/src/proceduralItem/modifiers/durable.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.maxDurability *= 1 + data.strength;
+	proceduralItem.getPropertyPtr(.maxDurability).* *= 1 + data.strength;
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/durable.zig
+++ b/src/proceduralItem/modifiers/durable.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.getPropertyPtr(.maxDurability).* *= 1 + data.strength;
+	proceduralItem.setProperty(.maxDurability, proceduralItem.getProperty(.maxDurability)*(1 + data.strength));
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/fragile.zig
+++ b/src/proceduralItem/modifiers/fragile.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.getPropertyPtr(.maxDurability).* *= 1 - data.strength;
+	proceduralItem.setProperty(.maxDurability, proceduralItem.getProperty(.maxDurability)*(1 - data.strength));
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/fragile.zig
+++ b/src/proceduralItem/modifiers/fragile.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.maxDurability *= 1 - data.strength;
+	proceduralItem.getPropertyPtr(.maxDurability).* *= 1 - data.strength;
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/heavy.zig
+++ b/src/proceduralItem/modifiers/heavy.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.swingSpeed *= 1 - data.strength;
+	proceduralItem.getPropertyPtr(.swingSpeed).* *= 1 - data.strength;
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/heavy.zig
+++ b/src/proceduralItem/modifiers/heavy.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.getPropertyPtr(.swingSpeed).* *= 1 - data.strength;
+	proceduralItem.setProperty(.swingSpeed, proceduralItem.getProperty(.swingSpeed)*(1 - data.strength));
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/light.zig
+++ b/src/proceduralItem/modifiers/light.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.setPropertyPtr(.swingSpeed, proceduralItem.getProperty(.swingSpeed)*(1 + data.strength));
+	proceduralItem.setProperty(.swingSpeed, proceduralItem.getProperty(.swingSpeed)*(1 + data.strength));
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/light.zig
+++ b/src/proceduralItem/modifiers/light.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.swingSpeed *= 1 + data.strength;
+	proceduralItem.getPropertyPtr(.swingSpeed).* *= 1 + data.strength;
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/light.zig
+++ b/src/proceduralItem/modifiers/light.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.getPropertyPtr(.swingSpeed).* *= 1 + data.strength;
+	proceduralItem.setPropertyPtr(.swingSpeed, proceduralItem.getProperty(.swingSpeed)*(1 + data.strength));
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/powerful.zig
+++ b/src/proceduralItem/modifiers/powerful.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.damage *= 1 + data.strength;
+	proceduralItem.getPropertyPtr(.damage).* *= 1 + data.strength;
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/powerful.zig
+++ b/src/proceduralItem/modifiers/powerful.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.getPropertyPtr(.damage).* *= 1 + data.strength;
+	proceduralItem.setProperty(.damage, proceduralItem.getProperty(.damage)*(1 + data.strength));
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/single_use.zig
+++ b/src/proceduralItem/modifiers/single_use.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.maxDurability = data.strength;
+	proceduralItem.getPropertyPtr(.maxDurability).* = data.strength;
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/single_use.zig
+++ b/src/proceduralItem/modifiers/single_use.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.getPropertyPtr(.maxDurability).* = data.strength;
+	proceduralItem.setProperty(.maxDurability, data.strength);
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/weak.zig
+++ b/src/proceduralItem/modifiers/weak.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.damage *= 1 - data.strength;
+	proceduralItem.getPropertyPtr(.damage).* *= 1 - data.strength;
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/proceduralItem/modifiers/weak.zig
+++ b/src/proceduralItem/modifiers/weak.zig
@@ -16,7 +16,7 @@ pub fn combineModifiers(data1: Data, data2: Data) ?Data {
 }
 
 pub fn changeProceduralItemParameters(proceduralItem: *ProceduralItem, data: Data) void {
-	proceduralItem.getPropertyPtr(.damage).* *= 1 - data.strength;
+	proceduralItem.setProperty(.damage, proceduralItem.getProperty(.damage)*(1 - data.strength));
 }
 
 pub fn printTooltip(outString: *main.List(u8), data: Data) void {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -1071,7 +1071,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 				}
 				damage -= block.blockResistance();
 				if (damage > 0) {
-					const swingTime = if (isProceduralItem and stack.item.proceduralItem.isEffectiveOn(block)) 1.0/stack.item.proceduralItem.swingSpeed else 0.5;
+					const swingTime = if (isProceduralItem and stack.item.proceduralItem.isEffectiveOn(block)) 1.0/stack.item.proceduralItem.getProperty(.swingSpeed) else 0.5;
 					if (currentSwingTime > swingTime) {
 						currentSwingProgress = 0;
 						currentSwingTime = 0;


### PR DESCRIPTION
Instead of saving the properties directly in the struct. we save it inside an array of `f32` this allows easy adding of new values (for example through modding)

you can get the value by using `getProperty(ProceduralItemProperty)`
and you can modify a value by using `setProperty(ProceduralItemProperty, value)` (can only be used in and before the `evaluateProceduralItem` step