### PR TITLE
Fix control binding the escape key.

### DIFF
--- a/src/graphics/Window.zig
+++ b/src/graphics/Window.zig
@@ -649,6 +649,11 @@ pub fn setNextGamepadListener(listener: ?*const fn (?GamepadAxis, c_int) void) !
 	nextGamepadListener = listener;
 }
 
+pub fn resetNextInputListenters() void {
+	nextGamepadListener = null;
+	nextKeypressListener = null;
+}
+
 fn updateCursor() void {
 	if (grabbed) {
 		c.glfwSetInputMode(window, c.GLFW_CURSOR, c.GLFW_CURSOR_DISABLED);

--- a/src/graphics/Window.zig
+++ b/src/graphics/Window.zig
@@ -80,7 +80,7 @@ pub const Gamepad = struct {
 					if ((newState.buttons[btn] == 0) and (oldState.buttons[btn] != 0)) {
 						nextGamepadListener.?(null, @intCast(btn));
 						nextGamepadListener = null;
-						break;
+						return;
 					}
 				}
 			}
@@ -91,7 +91,7 @@ pub const Gamepad = struct {
 					if (newAxis != 0 and oldAxis == 0) {
 						nextGamepadListener.?(.{.axis = @intCast(axis), .positive = newState.axes[axis] > 0}, -1);
 						nextGamepadListener = null;
-						break;
+						return;
 					}
 				}
 			}

--- a/src/graphics/Window.zig
+++ b/src/graphics/Window.zig
@@ -489,7 +489,6 @@ pub const Key = struct { // MARK: Key
 	}
 
 	fn action(self: *Key, typ: enum { press, release, repeat }, isGrabbed: bool, mods: Modifiers, textKeyPressedInTextField: bool) void {
-		if (hasNextInputListenter()) return;
 		if (typ == .press) self.grabbedOnPress = isGrabbed;
 		if (!self.notifyRequirement.met(self.grabbedOnPress)) return;
 		if (!self.requiredModifiers.satisfiedBy(mods)) return;
@@ -511,17 +510,18 @@ pub const GLFWCallbacks = struct { // MARK: GLFWCallbacks
 		const textKeyPressedInTextField = main.gui.selectedTextInput != null and c.glfwGetKeyName(glfw_key, scancode) != null;
 		const isGrabbed = grabbed;
 		if (action == c.GLFW_PRESS or action == c.GLFW_RELEASE) {
+			if (action == c.GLFW_PRESS) {
+				if (nextKeypressListener) |listener| {
+					listener(glfw_key, -1, scancode);
+					nextKeypressListener = null;
+					return;
+				}
+			}
 			for (&main.KeyBoard.keys) |*key| {
 				if (glfw_key == key.key) {
 					if (glfw_key != c.GLFW_KEY_UNKNOWN or scancode == key.scancode) {
 						key.setPressed(action == c.GLFW_PRESS, isGrabbed, mods, textKeyPressedInTextField);
 					}
-				}
-			}
-			if (action == c.GLFW_PRESS) {
-				if (nextKeypressListener) |listener| {
-					listener(glfw_key, -1, scancode);
-					nextKeypressListener = null;
 				}
 			}
 		} else if (action == c.GLFW_REPEAT) {
@@ -584,15 +584,16 @@ pub const GLFWCallbacks = struct { // MARK: GLFWCallbacks
 		const mods: Key.Modifiers = @bitCast(@as(u6, @intCast(_mods)));
 		const isGrabbed = grabbed;
 		if (action == c.GLFW_PRESS or action == c.GLFW_RELEASE) {
-			for (&main.KeyBoard.keys) |*key| {
-				if (button == key.mouseButton) {
-					key.setPressed(action == c.GLFW_PRESS, isGrabbed, mods, false);
-				}
-			}
 			if (action == c.GLFW_PRESS) {
 				if (nextKeypressListener) |listener| {
 					listener(c.GLFW_KEY_UNKNOWN, button, 0);
 					nextKeypressListener = null;
+					return;
+				}
+			}
+			for (&main.KeyBoard.keys) |*key| {
+				if (button == key.mouseButton) {
+					key.setPressed(action == c.GLFW_PRESS, isGrabbed, mods, false);
 				}
 			}
 		}
@@ -646,10 +647,6 @@ var nextGamepadListener: ?*const fn (?GamepadAxis, c_int) void = null;
 pub fn setNextGamepadListener(listener: ?*const fn (?GamepadAxis, c_int) void) !void {
 	if (nextGamepadListener != null) return error.AlreadyUsed;
 	nextGamepadListener = listener;
-}
-
-fn hasNextInputListenter() bool {
-	return (nextKeypressListener != null or nextGamepadListener != null);
 }
 
 fn updateCursor() void {

--- a/src/graphics/Window.zig
+++ b/src/graphics/Window.zig
@@ -647,6 +647,10 @@ pub fn setNextGamepadListener(listener: ?*const fn (?GamepadAxis, c_int) void) !
 	nextGamepadListener = listener;
 }
 
+pub fn hasNextInputListenter() bool {
+	return (nextKeypressListener != null or nextGamepadListener != null);
+}
+
 fn updateCursor() void {
 	if (grabbed) {
 		c.glfwSetInputMode(window, c.GLFW_CURSOR, c.GLFW_CURSOR_DISABLED);

--- a/src/graphics/Window.zig
+++ b/src/graphics/Window.zig
@@ -489,6 +489,7 @@ pub const Key = struct { // MARK: Key
 	}
 
 	fn action(self: *Key, typ: enum { press, release, repeat }, isGrabbed: bool, mods: Modifiers, textKeyPressedInTextField: bool) void {
+		if (hasNextInputListenter()) return;
 		if (typ == .press) self.grabbedOnPress = isGrabbed;
 		if (!self.notifyRequirement.met(self.grabbedOnPress)) return;
 		if (!self.requiredModifiers.satisfiedBy(mods)) return;
@@ -647,7 +648,7 @@ pub fn setNextGamepadListener(listener: ?*const fn (?GamepadAxis, c_int) void) !
 	nextGamepadListener = listener;
 }
 
-pub fn hasNextInputListenter() bool {
+fn hasNextInputListenter() bool {
 	return (nextKeypressListener != null or nextGamepadListener != null);
 }
 

--- a/src/gui/windows/controls.zig
+++ b/src/gui/windows/controls.zig
@@ -113,7 +113,11 @@ pub fn onOpen() void {
 	}
 	for (&main.KeyBoard.keys) |*key| {
 		const label = Label.init(.{0, 0}, keybindButtonWidth, key.name, .left);
-		const button = if (key == selectedKey) (Button.initText(.{16, 0}, keybindButtonWidth, "...", .{})) else (Button.initText(.{16, 0}, keybindButtonWidth, if (editingKeyboard) key.getName() else key.getGamepadName(), if (editingKeyboard) .initWithPtr(keyFunction, key) else .initWithPtr(gamepadFunction, key)));
+		const button = if (key == selectedKey)
+			Button.initText(.{16, 0}, keybindButtonWidth, "...", .{})
+		else
+			Button.initText(.{16, 0}, keybindButtonWidth, if (editingKeyboard) key.getName() else key.getGamepadName(), if (editingKeyboard) .initWithPtr(keyFunction, key) else .initWithPtr(gamepadFunction, key));
+
 		const unbindBtn = Button.initText(.{16, 0}, unbindButtonWidth, "Unbind", .initWithPtr(unbindKey, key));
 		const row = HorizontalList.init();
 		row.add(label);

--- a/src/gui/windows/controls.zig
+++ b/src/gui/windows/controls.zig
@@ -80,6 +80,8 @@ fn sensitivityFormatter(allocator: main.heap.NeverFailingAllocator, value: f32) 
 
 fn toggleKeyboard() void {
 	editingKeyboard = !editingKeyboard;
+	selectedKey = null;
+	main.Window.resetNextInputListenters();
 	needsUpdate = true;
 }
 fn unbindKey(keyPtr: usize) void {

--- a/src/gui/windows/controls.zig
+++ b/src/gui/windows/controls.zig
@@ -78,12 +78,17 @@ fn sensitivityFormatter(allocator: main.heap.NeverFailingAllocator, value: f32) 
 	return std.fmt.allocPrint(allocator.allocator, "{s} Sensitivity: {d:.0}%", .{if (editingKeyboard) "Mouse" else "Controller", value*100}) catch unreachable;
 }
 
-fn toggleKeyboard() void {
-	editingKeyboard = !editingKeyboard;
+fn abortBindingProcess() void {
 	selectedKey = null;
 	main.Window.resetNextInputListenters();
 	needsUpdate = true;
 }
+
+fn toggleKeyboard() void {
+	editingKeyboard = !editingKeyboard;
+	abortBindingProcess();
+}
+
 fn unbindKey(keyPtr: usize) void {
 	var key: ?*main.Window.Key = @ptrFromInt(keyPtr);
 	if (editingKeyboard) {
@@ -97,7 +102,7 @@ fn unbindKey(keyPtr: usize) void {
 	needsUpdate = true;
 }
 
-pub fn onOpen() void {
+pub fn initWindow() void {
 	const controlsListWidth: u32 = 256;
 	const keybindButtonWidth: u32 = 160;
 	const unbindButtonWidth: u32 = 64;
@@ -132,18 +137,28 @@ pub fn onOpen() void {
 	gui.updateWindowPositions();
 }
 
-pub fn onClose() void {
+pub fn deinitWindow() void {
 	if (window.rootComponent) |*comp| {
 		comp.deinit();
 	}
+}
+
+pub fn onOpen() void {
+	abortBindingProcess();
+	initWindow();
+}
+
+pub fn onClose() void {
+	abortBindingProcess();
+	deinitWindow();
 }
 
 pub fn render() void {
 	if (needsUpdate) {
 		needsUpdate = false;
 		const oldScroll = window.rootComponent.?.verticalList.scrollBar.currentState;
-		onClose();
-		onOpen();
+		deinitWindow();
+		initWindow();
 		window.rootComponent.?.verticalList.scrollBar.currentState = oldScroll;
 	}
 }

--- a/src/gui/windows/controls.zig
+++ b/src/gui/windows/controls.zig
@@ -102,7 +102,7 @@ fn unbindKey(keyPtr: usize) void {
 	needsUpdate = true;
 }
 
-pub fn initWindow() void {
+fn initWindow() void {
 	const controlsListWidth: u32 = 256;
 	const keybindButtonWidth: u32 = 160;
 	const unbindButtonWidth: u32 = 64;
@@ -137,7 +137,7 @@ pub fn initWindow() void {
 	gui.updateWindowPositions();
 }
 
-pub fn deinitWindow() void {
+fn deinitWindow() void {
 	if (window.rootComponent) |*comp| {
 		comp.deinit();
 	}

--- a/src/main.zig
+++ b/src/main.zig
@@ -201,7 +201,6 @@ fn logToStdErr(comptime format: []const u8, args: anytype) void {
 
 // MARK: Callbacks
 fn escape(mods: Window.Key.Modifiers) void {
-	if (Window.hasNextInputListenter()) return;
 	if (gui.selectedTextInput != null) gui.setSelectedTextInput(null);
 	inventory(mods);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -201,6 +201,7 @@ fn logToStdErr(comptime format: []const u8, args: anytype) void {
 
 // MARK: Callbacks
 fn escape(mods: Window.Key.Modifiers) void {
+	if (Window.hasNextInputListenter()) return;
 	if (gui.selectedTextInput != null) gui.setSelectedTextInput(null);
 	inventory(mods);
 }


### PR DESCRIPTION
When pressing the escape key while in a control binding process, then the control should get bound to escape and the settings window should still be open.
This commit disables closing the settings window while binding a key.

fixes: #2257