### PR TITLE
Async those block updates (conquering the flicker biome addon)

### DIFF
--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -632,6 +632,8 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 	lightListNeedsUpload: bool = false,
 	lightAllocation: graphics.SubAllocation = .{.start = 0, .len = 0},
 
+	blockUpdateQueue: main.utils.CircularBufferQueue(Vec3i) = undefined,
+
 	lastNeighborsSameLod: [6]?*const ChunkMesh = @splat(null),
 	lastNeighborsHigherLod: [6]?*const ChunkMesh = @splat(null),
 	isNeighborLod: [6]bool = @splat(false),
@@ -664,6 +666,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 			.transparentMesh = .{
 				.lod = @intCast(std.math.log2_int(u32, pos.voxelSize)),
 			},
+			.blockUpdateQueue = .init(main.globalAllocator, 8),
 			.chunk = ch,
 			.lightingData = .{
 				lighting.ChannelChunk.init(ch, false),
@@ -689,6 +692,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 		main.globalAllocator.free(self.blockBreakingFacesSortingData);
 		main.globalAllocator.free(self.lightList);
 		lightBuffers[std.math.log2_int(u32, self.pos.voxelSize)].free(self.lightAllocation);
+		self.blockUpdateQueue.deinit();
 		mesh_storage.meshMemoryPool.destroy(self);
 	}
 
@@ -1153,32 +1157,13 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 		}
 	}
 
-	pub fn updateBlock(self: *ChunkMesh, blockUpdate: mesh_storage.BlockUpdate, lightRefreshList: *main.List(chunk.ChunkPosition), regenerateMeshList: *main.List(*ChunkMesh)) void {
-		const blockPos = chunk.BlockPos.fromWorldCoords(blockUpdate.pos[0], blockUpdate.pos[1], blockUpdate.pos[2]);
-		var newBlock = blockUpdate.newBlock;
+	fn updateBlockLightAndMesh(self: *ChunkMesh, blockUpdatePos: Vec3i, lightRefreshList: *main.List(chunk.ChunkPosition), regenerateMeshList: *main.List(*ChunkMesh)) void {
+		const blockPos = chunk.BlockPos.fromWorldCoords(blockUpdatePos[0], blockUpdatePos[1], blockUpdatePos[2]);
 		self.mutex.lock();
-		const oldBlock = self.chunk.data.getValue(blockPos.toIndex());
-
-		if (oldBlock == newBlock) {
-			if (newBlock.blockEntity()) |blockEntity| {
-				var reader = main.utils.BinaryReader.init(blockUpdate.blockEntityData);
-				blockEntity.updateClientData(blockUpdate.pos, self.chunk, .{.update = &reader}) catch |err| {
-					std.log.err("Got error {s} while trying to apply block entity data {any} in position {} for block {s}", .{@errorName(err), blockUpdate.blockEntityData, blockUpdate.pos, newBlock.id()});
-				};
-			}
-			self.mutex.unlock();
-			return;
-		}
+		var newBlock = self.chunk.data.getValue(blockPos.toIndex());
 		self.mutex.unlock();
 
-		if (oldBlock.blockEntity()) |blockEntity| {
-			blockEntity.updateClientData(blockUpdate.pos, self.chunk, .remove) catch |err| {
-				std.log.err("Got error {s} while trying to remove entity data in position {} for block {s}", .{@errorName(err), blockUpdate.pos, oldBlock.id()});
-			};
-		}
-
-		var neighborBlocks: [6]Block = undefined;
-		@memset(&neighborBlocks, .{.typ = 0, .data = 0});
+		var neighborBlocks: [6]Block = @splat(.{.typ = 0, .data = 0});
 
 		for (chunk.Neighbor.iterable) |neighbor| {
 			const neighborPos, const chunkLocation = blockPos.neighbor(neighbor);
@@ -1214,9 +1199,6 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 				_ = newBlock.mode().updateData(&newBlock, neighbor, neighborBlocks[neighbor.toInt()]);
 			}
 		}
-		self.mutex.lock();
-		self.chunk.data.setValue(blockPos.toIndex(), newBlock);
-		self.mutex.unlock();
 
 		self.updateBlockLight(blockPos, newBlock, lightRefreshList);
 
@@ -1256,6 +1238,103 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 		}
 		list.append(mesh);
 	}
+
+	pub fn updateBlock(self: *ChunkMesh, blockUpdate: mesh_storage.BlockUpdate) void {
+		const blockPos = chunk.BlockPos.fromWorldCoords(blockUpdate.pos[0], blockUpdate.pos[1], blockUpdate.pos[2]);
+		var newBlock = blockUpdate.newBlock;
+		self.mutex.lock();
+		const oldBlock = self.chunk.data.getValue(blockPos.toIndex());
+
+		if (oldBlock == newBlock) {
+			if (newBlock.blockEntity()) |blockEntity| {
+				var reader = main.utils.BinaryReader.init(blockUpdate.blockEntityData);
+				blockEntity.updateClientData(blockUpdate.pos, self.chunk, .{.update = &reader}) catch |err| {
+					std.log.err("Got error {s} while trying to apply block entity data {any} in position {} for block {s}", .{@errorName(err), blockUpdate.blockEntityData, blockUpdate.pos, newBlock.id()});
+				};
+			}
+			self.mutex.unlock();
+			return;
+		}
+
+		if (oldBlock.blockEntity()) |blockEntity| {
+			blockEntity.updateClientData(blockUpdate.pos, self.chunk, .remove) catch |err| {
+				std.log.err("Got error {s} while trying to remove entity data in position {} for block {s}", .{@errorName(err), blockUpdate.pos, oldBlock.id()});
+			};
+		}
+
+		self.chunk.data.setValue(blockPos.toIndex(), newBlock);
+
+		self.blockUpdateQueue.pushBack(blockUpdate.pos);
+		if (self.blockUpdateQueue.len == 1) {
+			BlockUpdateTask.schedule(self.pos);
+		}
+		self.mutex.unlock();
+	}
+	const BlockUpdateTask = struct {
+		pos: chunk.ChunkPosition,
+
+		pub const vtable = main.utils.ThreadPool.VTable{
+			.getPriority = main.meta.castFunctionSelfToAnyopaque(getPriority),
+			.isStillNeeded = main.meta.castFunctionSelfToAnyopaque(isStillNeeded),
+			.run = main.meta.castFunctionSelfToAnyopaque(run),
+			.clean = main.meta.castFunctionSelfToAnyopaque(clean),
+			.taskType = .blockUpdate,
+		};
+
+		pub fn schedule(pos: chunk.ChunkPosition) void {
+			const task = main.globalAllocator.create(BlockUpdateTask);
+			task.* = .{
+				.pos = pos,
+			};
+			main.threadPool.addTask(task, &vtable);
+		}
+
+		pub fn getPriority(self: *BlockUpdateTask) f32 {
+			return 1000000 + self.pos.getPriority(game.Player.getPosBlocking()); // TODO: This is called in loop, find a way to do this without calling the mutex every time.
+		}
+
+		pub fn isStillNeeded(_: *BlockUpdateTask) bool {
+			return true;
+		}
+
+		pub fn run(self: *BlockUpdateTask) void {
+			defer main.globalAllocator.destroy(self);
+
+			var lightRefreshList = main.List(chunk.ChunkPosition).init(main.stackAllocator);
+			defer lightRefreshList.deinit();
+
+			var regenerateMeshList = main.List(*ChunkMesh).init(main.stackAllocator);
+			defer regenerateMeshList.deinit();
+
+			{
+				const mesh = mesh_storage.getMesh(self.pos) orelse return;
+
+				while (true) {
+					const blockUpdatePos = blk: {
+						mesh.mutex.lock();
+						defer mesh.mutex.unlock();
+						break :blk mesh.blockUpdateQueue.popFront() orelse break;
+					};
+
+					mesh.updateBlockLightAndMesh(blockUpdatePos, &lightRefreshList, &regenerateMeshList);
+				}
+			}
+
+			for (regenerateMeshList.items) |mesh| {
+				mesh.generateMesh(&lightRefreshList);
+			}
+			for (lightRefreshList.items) |pos| {
+				ChunkMesh.scheduleLightRefresh(pos);
+			}
+			for (regenerateMeshList.items) |mesh| {
+				mesh_storage.addToUpdateList(mesh);
+			}
+		}
+
+		pub fn clean(self: *BlockUpdateTask) void {
+			main.globalAllocator.destroy(self);
+		}
+	};
 
 	fn clearNeighborA(self: *ChunkMesh, neighbor: chunk.Neighbor, comptime isLod: bool) void {
 		self.opaqueMesh.clearNeighbor(neighbor, isLod);

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -1327,6 +1327,9 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 				mesh.generateMesh(&lightRefreshList);
 			}
 			for (lightRefreshList.items) |pos| {
+				if (mesh_storage.getMesh(pos)) |mesh| {
+					mesh.needsLightRefresh.store(true, .release);
+				}
 				ChunkMesh.scheduleLightRefresh(pos);
 			}
 			for (regenerateMeshList.items) |mesh| {

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -350,6 +350,7 @@ pub const PrimitiveMesh = struct { // MARK: PrimitiveMesh
 		}
 	};
 	completeList: main.MultiArray(FaceData, FaceGroups) = .{},
+	finishedLighting: bool = false,
 	lock: main.utils.ReadWriteLock = .{},
 	bufferAllocation: graphics.SubAllocation = .{.start = 0, .len = 0},
 	vertexCount: u31 = 0,
@@ -366,6 +367,7 @@ pub const PrimitiveMesh = struct { // MARK: PrimitiveMesh
 
 	fn replaceRange(self: *PrimitiveMesh, group: FaceGroups, items: []const FaceData) void {
 		self.lock.lockWrite();
+		self.finishedLighting = false;
 		self.completeList.replaceRange(main.globalAllocator, group, items);
 		self.lock.unlockWrite();
 	}
@@ -374,7 +376,7 @@ pub const PrimitiveMesh = struct { // MARK: PrimitiveMesh
 		self.min = @splat(std.math.floatMax(f32));
 		self.max = @splat(-std.math.floatMax(f32));
 
-		self.lock.lockRead();
+		self.lock.lockWrite();
 		for (self.completeList.getEverything()) |*face| {
 			const light = getLight(parent, .{face.position.x, face.position.y, face.position.z}, face.blockAndQuad.texture, face.blockAndQuad.quadIndex);
 			const result = lightMap.getOrPut(light) catch unreachable;
@@ -393,7 +395,8 @@ pub const PrimitiveMesh = struct { // MARK: PrimitiveMesh
 				self.max = @max(self.max, basePos + cornerPos);
 			}
 		}
-		self.lock.unlockRead();
+		self.finishedLighting = true;
+		self.lock.unlockWrite();
 	}
 
 	const LightVector = @Vector(8, u16);
@@ -535,8 +538,8 @@ pub const PrimitiveMesh = struct { // MARK: PrimitiveMesh
 	}
 
 	fn uploadData(self: *PrimitiveMesh, isNeighborLod: [6]bool) void {
-		self.lock.lockRead();
-		defer self.lock.unlockRead();
+		self.lock.assertLockedRead();
+		std.debug.assert(self.finishedLighting); // Needs to be checked on the outside
 		var len: usize = 0;
 		const coreList = self.completeList.getRange(.core);
 		len += coreList.len;
@@ -1361,15 +1364,23 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 	}
 
 	pub fn uploadData(self: *ChunkMesh) void {
-		self.opaqueMesh.uploadData(self.isNeighborLod);
-		self.transparentMesh.uploadData(self.isNeighborLod);
-
 		self.mutex.lock();
+		defer self.mutex.unlock();
+		{
+			self.opaqueMesh.lock.lockRead();
+			defer self.opaqueMesh.lock.unlockRead();
+			self.transparentMesh.lock.lockRead();
+			defer self.transparentMesh.lock.unlockRead();
+			if (!self.opaqueMesh.finishedLighting or !self.transparentMesh.finishedLighting) return;
+			self.opaqueMesh.uploadData(self.isNeighborLod);
+			self.transparentMesh.uploadData(self.isNeighborLod);
+			self.updateTransparencyDataAfterMeshUpload();
+		}
+
 		if (self.lightListNeedsUpload) {
 			self.lightListNeedsUpload = false;
 			lightBuffers[std.math.log2_int(u32, self.pos.voxelSize)].uploadData(self.lightList, &self.lightAllocation);
 		}
-		self.mutex.unlock();
 
 		self.uploadChunkPosition();
 	}
@@ -1574,39 +1585,40 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 		quadsDrawn += self.opaqueMesh.vertexCount/6;
 	}
 
+	fn updateTransparencyDataAfterMeshUpload(self: *ChunkMesh) void {
+		self.transparentMesh.lock.assertLockedRead();
+		var len: usize = 0;
+		const coreList = self.transparentMesh.completeList.getRange(.core);
+		len += coreList.len;
+		var list: [6][]FaceData = undefined;
+		for (0..6) |i| {
+			if (!self.isNeighborLod[i]) {
+				list[i] = self.transparentMesh.completeList.getRange(.neighbor(@enumFromInt(i)));
+			} else {
+				list[i] = self.transparentMesh.completeList.getRange(.neighborLod(@enumFromInt(i)));
+			}
+			len += list[i].len;
+		}
+		self.currentSorting = main.globalAllocator.realloc(self.currentSorting, len);
+		self.sortingOutputBuffer = main.globalAllocator.realloc(self.sortingOutputBuffer, len + self.blockBreakingFaces.items.len);
+		for (0..coreList.len) |i| {
+			self.currentSorting[i].face = coreList[i];
+		}
+		var offset = coreList.len;
+		for (0..6) |n| {
+			for (0..list[n].len) |i| {
+				self.currentSorting[offset + i].face = list[n][i];
+			}
+			offset += list[n].len;
+		}
+	}
+
 	pub fn prepareTransparentRendering(self: *ChunkMesh, playerPosition: Vec3d, chunkLists: *[main.settings.highestSupportedLod + 1]main.List(u32)) void {
 		if (self.transparentMesh.vertexCount == 0 and self.blockBreakingFaces.items.len == 0) return;
 
 		var needsUpdate: bool = false;
 		if (self.transparentMesh.wasChanged) {
 			self.transparentMesh.wasChanged = false;
-			self.transparentMesh.lock.lockRead();
-			defer self.transparentMesh.lock.unlockRead();
-			var len: usize = 0;
-			const coreList = self.transparentMesh.completeList.getRange(.core);
-			len += coreList.len;
-			var list: [6][]FaceData = undefined;
-			for (0..6) |i| {
-				if (!self.isNeighborLod[i]) {
-					list[i] = self.transparentMesh.completeList.getRange(.neighbor(@enumFromInt(i)));
-				} else {
-					list[i] = self.transparentMesh.completeList.getRange(.neighborLod(@enumFromInt(i)));
-				}
-				len += list[i].len;
-			}
-			self.currentSorting = main.globalAllocator.realloc(self.currentSorting, len);
-			self.sortingOutputBuffer = main.globalAllocator.realloc(self.sortingOutputBuffer, len + self.blockBreakingFaces.items.len);
-			for (0..coreList.len) |i| {
-				self.currentSorting[i].face = coreList[i];
-			}
-			var offset = coreList.len;
-			for (0..6) |n| {
-				for (0..list[n].len) |i| {
-					self.currentSorting[offset + i].face = list[n][i];
-				}
-				offset += list[n].len;
-			}
-
 			needsUpdate = true;
 		}
 

--- a/src/renderer/lighting.zig
+++ b/src/renderer/lighting.zig
@@ -163,10 +163,7 @@ pub const ChannelChunk = struct {
 				return;
 			}
 		}
-		if (mesh_storage.getMesh(self.ch.pos)) |mesh| {
-			mesh.needsLightRefresh.store(true, .release);
-			lightRefreshList.append(self.ch.pos);
-		}
+		lightRefreshList.append(self.ch.pos);
 	}
 
 	fn propagateDestructive(self: *ChannelChunk, lightQueue: *main.utils.CircularBufferQueue(Entry), constructiveEntries: *main.ListUnmanaged(ChunkEntries), isFirstBlock: bool, lightRefreshList: *main.List(chunk.ChunkPosition)) main.ListUnmanaged(BlockPos) {

--- a/src/renderer/mesh_storage.zig
+++ b/src/renderer/mesh_storage.zig
@@ -66,13 +66,10 @@ pub const BlockUpdate = struct {
 	}
 };
 
-var blockUpdateList: main.utils.ConcurrentQueue(BlockUpdate) = undefined;
-
 pub var meshMemoryPool: main.heap.MemoryPool(chunk_meshing.ChunkMesh) = undefined;
 
 pub fn init() void { // MARK: init()
 	lastRD = 0;
-	blockUpdateList = .init(main.globalAllocator, 16);
 	meshMemoryPool = .init(main.globalAllocator);
 	for (&storageLists) |*storageList| {
 		storageList.* = main.globalAllocator.create([storageSize*storageSize*storageSize]ChunkMeshNode);
@@ -111,10 +108,6 @@ pub fn deinit() void {
 	}
 	mapUpdatableList.deinit();
 	priorityMeshUpdateList.deinit();
-	while (blockUpdateList.popFront()) |blockUpdate| {
-		blockUpdate.deinitManaged(main.globalAllocator);
-	}
-	blockUpdateList.deinit();
 	meshList.clearAndFree();
 	main.heap.GarbageCollection.waitForFreeCompletion();
 	meshMemoryPool.deinit();
@@ -717,8 +710,6 @@ pub noinline fn updateAndGetRenderChunks(conn: *network.Connection, frustum: *co
 }
 
 pub fn updateMeshes(targetTime: std.Io.Timestamp) void { // MARK: updateMeshes()
-	if (!blockUpdateList.isEmpty()) batchUpdateBlocks();
-
 	mutex.lock();
 	defer mutex.unlock();
 	while (priorityMeshUpdateList.popFront()) |pos| {
@@ -779,32 +770,6 @@ pub fn updateMeshes(targetTime: std.Io.Timestamp) void { // MARK: updateMeshes()
 			mesh.uploadData();
 		}
 		if (targetTime.durationTo(main.timestamp()).nanoseconds >= 0) break; // Update at least one mesh.
-	}
-}
-
-fn batchUpdateBlocks() void {
-	var lightRefreshList = main.List(chunk.ChunkPosition).init(main.stackAllocator);
-	defer lightRefreshList.deinit();
-
-	var regenerateMeshList = main.List(*ChunkMesh).init(main.stackAllocator);
-	defer regenerateMeshList.deinit();
-
-	// First of all process all the block updates:
-	while (blockUpdateList.popFront()) |blockUpdate| {
-		defer blockUpdate.deinitManaged(main.globalAllocator);
-		const pos = chunk.ChunkPosition{.wx = blockUpdate.pos[0], .wy = blockUpdate.pos[1], .wz = blockUpdate.pos[2], .voxelSize = 1};
-		if (getMesh(pos)) |mesh| {
-			mesh.updateBlock(blockUpdate, &lightRefreshList, &regenerateMeshList);
-		} // TODO: It seems like we simply ignore the block update if we don't have the mesh yet.
-	}
-	for (regenerateMeshList.items) |mesh| {
-		mesh.generateMesh(&lightRefreshList);
-	}
-	for (lightRefreshList.items) |pos| {
-		ChunkMesh.scheduleLightRefresh(pos);
-	}
-	for (regenerateMeshList.items) |mesh| {
-		mesh.uploadData();
 	}
 }
 
@@ -885,8 +850,11 @@ pub const MeshGenerationTask = struct { // MARK: MeshGenerationTask
 
 // MARK: updaters
 
-pub fn updateBlock(update: BlockUpdate) void {
-	blockUpdateList.pushBack(BlockUpdate.initManaged(main.globalAllocator, update));
+pub fn updateBlock(blockUpdate: BlockUpdate) void {
+	const pos = chunk.ChunkPosition{.wx = blockUpdate.pos[0], .wy = blockUpdate.pos[1], .wz = blockUpdate.pos[2], .voxelSize = 1};
+	if (getMesh(pos)) |mesh| {
+		mesh.updateBlock(blockUpdate);
+	} // TODO: It seems like we simply ignore the block update if we don't have the mesh yet.
 }
 
 pub fn updateChunkMesh(mesh: *chunk.Chunk) void {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -752,6 +752,7 @@ pub fn ConcurrentMaxHeap(comptime T: type) type { // MARK: ConcurrentMaxHeap
 
 pub const ThreadPool = struct { // MARK: ThreadPool
 	pub const TaskType = enum(usize) {
+		blockUpdate,
 		chunkgen,
 		meshgenAndLighting,
 		misc,


### PR DESCRIPTION
This is done by converting the global block update queue into a per chunk block update queue.
The actual block updates are also done on the network thread, so they still appear right away, just not visually.
As for the visuals, I have not seen noticable delays when placing blocks in release modes, even with background noise from the flicker addon, in debug mode the story is different though, but we had the same amount of lag before, it's just not freezing the render thread anymore.


https://github.com/user-attachments/assets/8cfba26f-340c-46ee-aa4c-b650aefcdaf4

Should help with #2585
fixes #277 (the lag still exists, and causes a noticable delay, but it doesn't freeze the interface, so you can keep working which is what we care about)

Remaining issues:
- [x] There is some flickering in the light updates, I think we need to find a way to avoid uploading the mesh if the light was updated in the mean-time (how can we test this?)
- [x] verify that we are allowed to update blocks from the network thread without causing race conditions
- [x] actually test for correctness with some light blocks