### PR TITLE
Fix leak in world edit history

### DIFF
--- a/src/server/command/worldedit/redo.zig
+++ b/src/server/command/worldedit/redo.zig
@@ -15,6 +15,8 @@ pub fn execute(args: []const u8, source: *User) void {
 		return;
 	}
 	if (source.worldEditData.redoHistory.pop()) |action| {
+		defer action.deinit();
+
 		const undo = Blueprint.capture(main.globalAllocator, action.position, .{
 			action.position[0] + @as(i32, @intCast(action.blueprint.blocks.width)) - 1,
 			action.position[1] + @as(i32, @intCast(action.blueprint.blocks.depth)) - 1,

--- a/src/server/command/worldedit/undo.zig
+++ b/src/server/command/worldedit/undo.zig
@@ -15,6 +15,8 @@ pub fn execute(args: []const u8, source: *User) void {
 		return;
 	}
 	if (source.worldEditData.undoHistory.pop()) |action| {
+		defer action.deinit();
+
 		const redo = Blueprint.capture(main.globalAllocator, action.position, .{
 			action.position[0] + @as(i32, @intCast(action.blueprint.blocks.width)) - 1,
 			action.position[1] + @as(i32, @intCast(action.blueprint.blocks.depth)) - 1,


### PR DESCRIPTION
Memory leak was caused by not deiniting original undo history entry after poping it to move it to redo history. Original entry is not used, as redo history has to contain inverse snapshot, so new entry is initialized and the original one goes out of scope without being deinited.

Added missing defer deinit.

Resolves: #2905