### PR TITLE
ECS Patch 3 | moved entityModel reset to main thread

### DIFF
--- a/src/assets.zig
+++ b/src/assets.zig
@@ -786,7 +786,6 @@ pub fn unloadAssets() void { // MARK: unloadAssets()
 	main.particles.ParticleManager.reset();
 	main.rotation.reset();
 	main.Tag.resetTags();
-	main.entityModel.reset();
 
 	// Remove paths from asset hot reloading:
 	var dir = main.files.cwd().openIterableDir("assets") catch |err| {

--- a/src/game.zig
+++ b/src/game.zig
@@ -670,6 +670,7 @@ pub const World = struct { // MARK: World
 		self.entityModelPalette.deinit();
 		self.manager.deinit();
 		main.server.stop();
+		main.entityModel.reset();
 
 		Player.super.deinit(.client);
 


### PR DESCRIPTION
(maybe) fixes #2906

moves the entityModel reset to main thread.