### PR TITLE
Rename `__init` to `globalInit`

### DIFF
--- a/src/gui/GuiWindow.zig
+++ b/src/gui/GuiWindow.zig
@@ -106,7 +106,7 @@ pub var borderUniforms: struct {
 	effectLength: c_int,
 } = undefined;
 
-pub fn __init() void {
+pub fn globalInit() void {
 	pipeline = graphics.Pipeline.init(
 		"assets/cubyz/shaders/ui/button.vert",
 		"assets/cubyz/shaders/ui/button.frag",

--- a/src/gui/components/Button.zig
+++ b/src/gui/components/Button.zig
@@ -59,7 +59,7 @@ hovered: bool = false,
 onAction: main.callbacks.SimpleCallback,
 child: GuiComponent,
 
-pub fn __init() void {
+pub fn globalInit() void {
 	pipeline = graphics.Pipeline.init(
 		"assets/cubyz/shaders/ui/button.vert",
 		"assets/cubyz/shaders/ui/button.frag",

--- a/src/gui/components/CheckBox.zig
+++ b/src/gui/components/CheckBox.zig
@@ -35,7 +35,7 @@ hovered: bool = false,
 onAction: *const fn (bool) void,
 label: *Label,
 
-pub fn __init() void {
+pub fn globalInit() void {
 	textureCheckedNormal = Texture.initFromFile("assets/cubyz/ui/checked_box.png");
 	textureCheckedHovered = Texture.initFromFile("assets/cubyz/ui/checked_box_hovered.png");
 	textureCheckedPressed = Texture.initFromFile("assets/cubyz/ui/checked_box_pressed.png");

--- a/src/gui/components/ContinuousSlider.zig
+++ b/src/gui/components/ContinuousSlider.zig
@@ -34,7 +34,7 @@ label: *Label,
 button: *Button,
 mouseAnchor: f32 = undefined,
 
-pub fn __init() void {
+pub fn globalInit() void {
 	texture = Texture.initFromFile("assets/cubyz/ui/slider.png");
 }
 

--- a/src/gui/components/DiscreteSlider.zig
+++ b/src/gui/components/DiscreteSlider.zig
@@ -32,7 +32,7 @@ label: *Label,
 button: *Button,
 mouseAnchor: f32 = undefined,
 
-pub fn __init() void {
+pub fn globalInit() void {
 	texture = Texture.initFromFile("assets/cubyz/ui/slider.png");
 }
 

--- a/src/gui/components/ItemSlot.zig
+++ b/src/gui/components/ItemSlot.zig
@@ -57,7 +57,7 @@ const TextureParamType = union(enum) {
 	}
 };
 
-pub fn __init() void {
+pub fn globalInit() void {
 	defaultTexture = Texture.initFromFile("assets/cubyz/ui/inventory/slot.png");
 	immutableTexture = Texture.initFromFile("assets/cubyz/ui/inventory/immutable_slot.png");
 	craftingResultTexture = Texture.initFromFile("assets/cubyz/ui/inventory/crafting_result_slot.png");

--- a/src/gui/components/ScrollBar.zig
+++ b/src/gui/components/ScrollBar.zig
@@ -26,7 +26,7 @@ currentState: f32,
 button: *Button,
 mouseAnchor: f32 = undefined,
 
-pub fn __init() void {
+pub fn globalInit() void {
 	texture = Texture.initFromFile("assets/cubyz/ui/scrollbar.png");
 }
 

--- a/src/gui/components/TextInput.zig
+++ b/src/gui/components/TextInput.zig
@@ -38,7 +38,7 @@ callbacks: Callbacks,
 lastBlinkTime: std.Io.Timestamp = .fromNanoseconds(0),
 showCusor: bool = true,
 
-pub fn __init() void {
+pub fn globalInit() void {
 	texture = Texture.initFromFile("assets/cubyz/ui/text_input.png");
 }
 

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -136,14 +136,14 @@ pub fn init() void { // MARK: init()
 			windowStruct.init();
 		}
 	}
-	GuiWindow.__init();
-	Button.__init();
-	CheckBox.__init();
-	ItemSlot.__init();
-	ScrollBar.__init();
-	ContinuousSlider.__init();
-	DiscreteSlider.__init();
-	TextInput.__init();
+	GuiWindow.globalInit();
+	Button.globalInit();
+	CheckBox.globalInit();
+	ItemSlot.globalInit();
+	ScrollBar.globalInit();
+	ContinuousSlider.globalInit();
+	DiscreteSlider.globalInit();
+	TextInput.globalInit();
 	load();
 	GamepadCursor.init();
 }


### PR DESCRIPTION
`__init` comes for code that is quite old. Currently we prefer `globalInit` for initialization done at application startup.