### PR TITLE
Unlock those mesh uploads (conquering the evil leaf decay flatlands)

### DIFF
--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -635,6 +635,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 	opaqueMesh: PrimitiveMesh,
 	transparentMesh: PrimitiveMesh,
 	lightList: []u32 = &.{},
+	lightListMutex: main.utils.Mutex = .{},
 	lightListNeedsUpload: bool = false,
 	lightAllocation: graphics.SubAllocation = .{.start = 0, .len = 0},
 
@@ -1361,21 +1362,23 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 		self.opaqueMesh.finish(self, &lightList, &lightMap);
 		self.transparentMesh.finish(self, &lightList, &lightMap);
 
-		self.lightList = main.globalAllocator.realloc(self.lightList, lightList.items.len);
-		@memcpy(self.lightList, lightList.items);
-		self.lightListNeedsUpload = true;
+		{
+			self.lightListMutex.lock();
+			defer self.lightListMutex.unlock();
+			self.lightList = main.globalAllocator.realloc(self.lightList, lightList.items.len);
+			@memcpy(self.lightList, lightList.items);
+			self.lightListNeedsUpload = true;
+		}
 
 		self.min = @min(self.opaqueMesh.min, self.transparentMesh.min);
 		self.max = @max(self.opaqueMesh.max, self.transparentMesh.max);
 	}
 
 	pub fn uploadData(self: *ChunkMesh) void {
-		self.mutex.lock();
-		defer self.mutex.unlock();
 		{
-			self.opaqueMesh.lock.lockRead();
+			if (!self.opaqueMesh.lock.tryLockRead()) return;
 			defer self.opaqueMesh.lock.unlockRead();
-			self.transparentMesh.lock.lockRead();
+			if (!self.transparentMesh.lock.tryLockRead()) return;
 			defer self.transparentMesh.lock.unlockRead();
 			if (!self.opaqueMesh.finishedLighting or !self.transparentMesh.finishedLighting) return;
 			self.opaqueMesh.uploadData(self.isNeighborLod);
@@ -1383,9 +1386,13 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 			self.updateTransparencyDataAfterMeshUpload();
 		}
 
-		if (self.lightListNeedsUpload) {
-			self.lightListNeedsUpload = false;
-			lightBuffers[std.math.log2_int(u32, self.pos.voxelSize)].uploadData(self.lightList, &self.lightAllocation);
+		{
+			self.lightListMutex.lock();
+			defer self.lightListMutex.unlock();
+			if (self.lightListNeedsUpload) {
+				self.lightListNeedsUpload = false;
+				lightBuffers[std.math.log2_int(u32, self.pos.voxelSize)].uploadData(self.lightList, &self.lightAllocation);
+			}
 		}
 
 		self.uploadChunkPosition();

--- a/src/renderer/mesh_storage.zig
+++ b/src/renderer/mesh_storage.zig
@@ -697,8 +697,8 @@ pub noinline fn updateAndGetRenderChunks(conn: *network.Connection, frustum: *co
 		const mesh = node.mesh.load(.acquire).?; // no other thread is allowed to overwrite the mesh (unless it's null).
 
 		if (mesh.needsMeshUpdate) {
-			mesh.uploadData();
 			mesh.needsMeshUpdate = false;
+			mesh.uploadData();
 		}
 		// Remove empty meshes.
 		if (!mesh.isEmpty()) {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1665,6 +1665,13 @@ pub const ReadWriteLock = struct { // MARK: ReadWriteLock
 	mutex: main.utils.Mutex = .{},
 	readers: u32 = 0,
 
+	pub fn tryLockRead(self: *ReadWriteLock) bool {
+		if (!self.mutex.tryLock()) return false;
+		self.readers += 1;
+		self.mutex.unlock();
+		return true;
+	}
+
 	pub fn lockRead(self: *ReadWriteLock) void {
 		self.mutex.lock();
 		self.readers += 1;


### PR DESCRIPTION
- the lightList now gets it's own mutex, so we don't need to lock the mesh mutex.
- for light updates `tryLock` is used to avoid doing stuff when another thread will trigger a new light update soon anyways

This does produce some visible seems when large volumes of blocks are updated at once, but I think this is better than the lag we currently have, and it generally shouldn't happen on normal block updates.