### PR TITLE
Make it possible to only select block if using the right tools

### DIFF
--- a/assets/cubyz/blocks/air.zig.zon
+++ b/assets/cubyz/blocks/air.zig.zon
@@ -11,5 +11,6 @@
 	.collide = false,
 
 	.drops = .{},
+	.selectionRule = .never,
 	.model = .none,
 }

--- a/assets/cubyz/blocks/fog/_defaults.zig.zon
+++ b/assets/cubyz/blocks/fog/_defaults.zig.zon
@@ -2,6 +2,7 @@
 	.tags = .{.air},
 	.blockHealth = 2,
 	.drops = .{},
+	.selectionRule = .never,
 	.degradable = true,
 	.transparent = true,
 	.hasBackFace = true,

--- a/assets/cubyz/blocks/lava.zig.zon
+++ b/assets/cubyz/blocks/lava.zig.zon
@@ -1,6 +1,7 @@
 .{
 	.tags = .{.fluid, .hot},
 	.drops = .{},
+	.selectionRule = .toolEffective,
 	.replaceable = true,
 	.degradable = true,
 	.transparent = true,

--- a/assets/cubyz/blocks/lava.zig.zon
+++ b/assets/cubyz/blocks/lava.zig.zon
@@ -1,7 +1,6 @@
 .{
 	.tags = .{.fluid, .hot},
 	.drops = .{},
-	.selectionRule = .none,
 	.replaceable = true,
 	.degradable = true,
 	.transparent = true,

--- a/assets/cubyz/blocks/lava.zig.zon
+++ b/assets/cubyz/blocks/lava.zig.zon
@@ -1,7 +1,7 @@
 .{
 	.tags = .{.fluid, .hot},
 	.drops = .{},
-	.selectable = false,
+	.selectionRule = .none,
 	.replaceable = true,
 	.degradable = true,
 	.transparent = true,

--- a/assets/cubyz/blocks/water.zig.zon
+++ b/assets/cubyz/blocks/water.zig.zon
@@ -1,6 +1,7 @@
 .{
 	.tags = .{.fluid},
 	.drops = .{},
+	.selectionRule = .toolEffective,
 	.replaceable = true,
 	.degradable = true,
 	.transparent = true,

--- a/assets/cubyz/blocks/water.zig.zon
+++ b/assets/cubyz/blocks/water.zig.zon
@@ -1,7 +1,6 @@
 .{
 	.tags = .{.fluid},
 	.drops = .{},
-	.selectionRule = .none,
 	.replaceable = true,
 	.degradable = true,
 	.transparent = true,

--- a/assets/cubyz/blocks/water.zig.zon
+++ b/assets/cubyz/blocks/water.zig.zon
@@ -1,7 +1,7 @@
 .{
 	.tags = .{.fluid},
 	.drops = .{},
-	.selectable = false,
+	.selectionRule = .none,
 	.replaceable = true,
 	.degradable = true,
 	.transparent = true,

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -68,7 +68,7 @@ pub const Ore = struct {
 	seed: u64,
 };
 
-const SelectionRule = enum { always, toolEffective, none };
+const SelectionRule = enum { always, toolEffective, never };
 
 var _transparent: [maxBlockCount]bool = undefined;
 var _collide: [maxBlockCount]bool = undefined;
@@ -539,7 +539,7 @@ pub const Block = packed struct(u32) { // MARK: Block
 		return switch (self.selectionRule()) {
 			.always => true,
 			.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(self),
-			.none => false,
+			.never => false,
 		};
 	}
 };

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -139,7 +139,7 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 	_light[size] = zon.get(u32, "emittedLight", 0);
 	_absorption[size] = zon.get(u32, "absorbedLight", 0xffffff);
 	_degradable[size] = zon.get(bool, "degradable", false);
-	_selectionRule[size] = zon.get(SelectionRule, "selectionRule", SelectionRule.always);
+	_selectionRule[size] = zon.get(SelectionRule, "selectionRule", .always);
 	_replaceable[size] = zon.get(bool, "replaceable", false);
 	_transparent[size] = zon.get(bool, "transparent", false);
 	_collide[size] = zon.get(bool, "collide", true);

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -530,7 +530,6 @@ pub const Block = packed struct(u32) { // MARK: Block
 	pub fn isSelectableByItem(self: Block, item: Item) bool {
 		if (item == .baseItem and item.baseItem.block() == self.typ) return true;
 
-		if (self.hasTag(.air)) return false;
 		if (self.hasTag(.fluid)) {
 			const fluidPlaceable = item == .baseItem and item.baseItem.hasTag(.fluidPlaceable);
 			return fluidPlaceable;

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -526,6 +526,22 @@ pub const Block = packed struct(u32) { // MARK: Block
 	pub fn canBeChangedInto(self: Block, newBlock: Block, item: main.items.ItemStack, shouldDropSourceBlockOnSuccess: *bool) main.rotation.RotationMode.CanBeChangedInto {
 		return newBlock.mode().canBeChangedInto(self, newBlock, item, shouldDropSourceBlockOnSuccess);
 	}
+
+	pub fn isSelectableByItem(self: Block, item: Item) bool {
+		if (item == .baseItem and item.baseItem.block() == self.typ) return true;
+
+		if (self.hasTag(.air)) return false;
+		if (self.hasTag(.fluid)) {
+			const fluidPlaceable = item == .baseItem and item.baseItem.hasTag(.fluidPlaceable);
+			return fluidPlaceable;
+		}
+
+		return switch (self.selectionRule()) {
+			.always => true,
+			.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(self),
+			.none => false,
+		};
+	}
 };
 
 pub const meshes = struct { // MARK: meshes

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -68,6 +68,8 @@ pub const Ore = struct {
 	seed: u64,
 };
 
+const SelectionRule = enum { always, toolEffective, none };
+
 var _transparent: [maxBlockCount]bool = undefined;
 var _collide: [maxBlockCount]bool = undefined;
 var _id: [maxBlockCount][]u8 = undefined;
@@ -77,7 +79,7 @@ var _blockResistance: [maxBlockCount]f32 = undefined;
 
 /// Whether you can replace it with another block, mainly used for fluids/gases
 var _replaceable: [maxBlockCount]bool = undefined;
-var _selectable: [maxBlockCount]bool = undefined;
+var _selectionRule: [maxBlockCount]SelectionRule = undefined;
 var _blockDrops: [maxBlockCount][]const BlockDrop = undefined;
 /// Meaning undegradable parts of trees or other structures can grow through this block.
 var _degradable: [maxBlockCount]bool = undefined;
@@ -137,9 +139,8 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 	_light[size] = zon.get(u32, "emittedLight", 0);
 	_absorption[size] = zon.get(u32, "absorbedLight", 0xffffff);
 	_degradable[size] = zon.get(bool, "degradable", false);
-	_selectable[size] = zon.get(bool, "selectable", true);
+	_selectionRule[size] = zon.get(SelectionRule, "selectionRule", SelectionRule.always);
 	_replaceable[size] = zon.get(bool, "replaceable", false);
-
 	_transparent[size] = zon.get(bool, "transparent", false);
 	_collide[size] = zon.get(bool, "collide", true);
 	_alwaysViewThrough[size] = zon.get(bool, "alwaysViewThrough", false);
@@ -414,8 +415,8 @@ pub const Block = packed struct(u32) { // MARK: Block
 		return _replaceable[self.typ];
 	}
 
-	pub inline fn selectable(self: Block) bool {
-		return _selectable[self.typ];
+	pub inline fn selectionRule(self: Block) SelectionRule {
+		return _selectionRule[self.typ];
 	}
 
 	pub inline fn blockDrops(self: Block) []const BlockDrop {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -933,10 +933,24 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 		while (total_tMax < closestDistance) {
 			const block = mesh_storage.getBlockFromRenderThread(voxelPos[0], voxelPos[1], voxelPos[2]) orelse break;
 			if (block.typ != 0) blk: {
-				const fluidPlaceable = item == .baseItem and item.baseItem.hasTag(.fluidPlaceable);
-				const holdingTargetedBlock = item == .baseItem and item.baseItem.block() == block.typ;
-				if (block.hasTag(.air) and !holdingTargetedBlock) break :blk;
-				if (block.hasTag(.fluid) and !fluidPlaceable and !holdingTargetedBlock) break :blk; // TODO: Buckets could select fluids
+				const isSelectable: bool = rules: {
+					const holdingTargetedBlock = item == .baseItem and item.baseItem.block() == block.typ;
+					if (holdingTargetedBlock) break :rules true;
+
+					if (block.hasTag(.air)) break :rules false;
+					if (block.hasTag(.fluid)) {
+						const fluidPlaceable = item == .baseItem and item.baseItem.hasTag(.fluidPlaceable);
+						break :rules fluidPlaceable;
+					}
+
+					break :rules switch (block.selectionRule()) {
+						.always => true,
+						.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(block),
+						.none => false,
+					};
+				};
+				if (!isSelectable) break :blk;
+
 				const relativePlayerPos: Vec3f = @floatCast(pos - @as(Vec3d, @floatFromInt(voxelPos)));
 				if (block.mode().rayIntersection(block, item, relativePlayerPos, _dir)) |intersection| {
 					if (intersection.distance <= closestDistance) {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -933,22 +933,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 		while (total_tMax < closestDistance) {
 			const block = mesh_storage.getBlockFromRenderThread(voxelPos[0], voxelPos[1], voxelPos[2]) orelse break;
 			if (block.typ != 0) blk: {
-				const isSelectable: bool = rules: {
-					if (item == .baseItem and item.baseItem.block() == block.typ) break :rules true;
-
-					if (block.hasTag(.air)) break :rules false;
-					if (block.hasTag(.fluid)) {
-						const fluidPlaceable = item == .baseItem and item.baseItem.hasTag(.fluidPlaceable);
-						break :rules fluidPlaceable;
-					}
-
-					break :rules switch (block.selectionRule()) {
-						.always => true,
-						.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(block),
-						.none => false,
-					};
-				};
-				if (!isSelectable) break :blk;
+				if (!block.isSelectableByItem(item)) break :blk;
 
 				const relativePlayerPos: Vec3f = @floatCast(pos - @as(Vec3d, @floatFromInt(voxelPos)));
 				if (block.mode().rayIntersection(block, item, relativePlayerPos, _dir)) |intersection| {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -934,8 +934,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 			const block = mesh_storage.getBlockFromRenderThread(voxelPos[0], voxelPos[1], voxelPos[2]) orelse break;
 			if (block.typ != 0) blk: {
 				const isSelectable: bool = rules: {
-					const holdingTargetedBlock = item == .baseItem and item.baseItem.block() == block.typ;
-					if (holdingTargetedBlock) break :rules true;
+					if (item == .baseItem and item.baseItem.block() == block.typ) break :rules true;
 
 					if (block.hasTag(.air)) break :rules false;
 					if (block.hasTag(.fluid)) {


### PR DESCRIPTION
Replaces the block field `.selectable` with `.selectionRule`

This to make `.selectionRule = .toolEffective` possible, which only selects the block if the used tool is effective on it :)

Fixes #2941

Progress towards #1558
Progress towards #627