### PR TITLE
Simplify the locking situation for meshes and remove the self-hosted ReadWriteLock

### DIFF
--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -330,34 +330,33 @@ pub const IndirectData = extern struct {
 	baseInstance: u32,
 };
 
+const FaceGroups = enum(u32) {
+	core,
+	neighbor0,
+	neighbor1,
+	neighbor2,
+	neighbor3,
+	neighbor4,
+	neighbor5,
+	neighborLod0,
+	neighborLod1,
+	neighborLod2,
+	neighborLod3,
+	neighborLod4,
+	neighborLod5,
+	optional,
+
+	pub fn neighbor(n: main.chunk.Neighbor) FaceGroups {
+		return @enumFromInt(@intFromEnum(FaceGroups.neighbor0) + @intFromEnum(n));
+	}
+
+	pub fn neighborLod(n: main.chunk.Neighbor) FaceGroups {
+		return @enumFromInt(@intFromEnum(FaceGroups.neighborLod0) + @intFromEnum(n));
+	}
+};
+
 const PrimitiveMesh = struct { // MARK: PrimitiveMesh
-	const FaceGroups = enum(u32) {
-		core,
-		neighbor0,
-		neighbor1,
-		neighbor2,
-		neighbor3,
-		neighbor4,
-		neighbor5,
-		neighborLod0,
-		neighborLod1,
-		neighborLod2,
-		neighborLod3,
-		neighborLod4,
-		neighborLod5,
-		optional,
-
-		pub fn neighbor(n: main.chunk.Neighbor) FaceGroups {
-			return @enumFromInt(@intFromEnum(FaceGroups.neighbor0) + @intFromEnum(n));
-		}
-
-		pub fn neighborLod(n: main.chunk.Neighbor) FaceGroups {
-			return @enumFromInt(@intFromEnum(FaceGroups.neighborLod0) + @intFromEnum(n));
-		}
-	};
 	completeList: main.MultiArray(FaceData, FaceGroups) = .{},
-	finishedLighting: bool = false,
-	lock: main.utils.ReadWriteLock = .{},
 	bufferAllocation: graphics.SubAllocation = .{.start = 0, .len = 0},
 	vertexCount: u31 = 0,
 	byNormalCount: [14]u32 = @splat(0),
@@ -372,17 +371,13 @@ const PrimitiveMesh = struct { // MARK: PrimitiveMesh
 	}
 
 	fn replaceRange(self: *PrimitiveMesh, group: FaceGroups, items: []const FaceData) void {
-		self.lock.lockWrite();
-		self.finishedLighting = false;
 		self.completeList.replaceRange(main.globalAllocator, group, items);
-		self.lock.unlockWrite();
 	}
 
 	fn finish(self: *PrimitiveMesh, parent: *ChunkMesh, lightList: *main.List(u32), lightMap: *std.AutoHashMap([4]u32, u16)) void {
 		self.min = @splat(std.math.floatMax(f32));
 		self.max = @splat(-std.math.floatMax(f32));
 
-		self.lock.lockWrite();
 		for (self.completeList.getEverything()) |*face| {
 			const light = lighting.getLight(parent, .{face.position.x, face.position.y, face.position.z}, face.blockAndQuad.texture, face.blockAndQuad.quadIndex);
 			const result = lightMap.getOrPut(light) catch unreachable;
@@ -401,13 +396,9 @@ const PrimitiveMesh = struct { // MARK: PrimitiveMesh
 				self.max = @max(self.max, basePos + cornerPos);
 			}
 		}
-		self.finishedLighting = true;
-		self.lock.unlockWrite();
 	}
 
 	fn uploadData(self: *PrimitiveMesh, isNeighborLod: [6]bool) void {
-		self.lock.assertLockedRead();
-		std.debug.assert(self.finishedLighting); // Needs to be checked on the outside
 		var len: usize = 0;
 		const coreList = self.completeList.getRange(.core);
 		len += coreList.len;
@@ -501,11 +492,11 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 
 	opaqueMesh: PrimitiveMesh,
 	transparentMesh: PrimitiveMesh,
+	meshUploadMutex: main.utils.Mutex = .{},
+	finishedLightingMeshData: bool = false,
 	chunkAllocation: graphics.SubAllocation = .{.start = 0, .len = 0},
 
 	lightList: []u32 = &.{},
-	lightListMutex: main.utils.Mutex = .{},
-	lightListNeedsUpload: bool = false,
 	lightAllocation: graphics.SubAllocation = .{.start = 0, .len = 0},
 
 	blockUpdateQueue: main.utils.CircularBufferQueue(Vec3i) = undefined,
@@ -685,6 +676,14 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 	fn appendNeighborFacingQuads(block: Block, neighbor: chunk.Neighbor, pos: chunk.BlockPos, comptime backFace: bool, list: *main.ListUnmanaged(FaceData), allocator: main.heap.NeverFailingAllocator) void {
 		const model = blocks.meshes.model(block).model();
 		model.appendNeighborFacingQuadsToList(list, allocator, block, neighbor, pos, backFace);
+	}
+
+	fn replaceRanges(self: *ChunkMesh, group: FaceGroups, opaqueFaces: []const FaceData, transparentFaces: []const FaceData) void {
+		self.meshUploadMutex.lock();
+		defer self.meshUploadMutex.unlock();
+		self.opaqueMesh.replaceRange(group, opaqueFaces);
+		self.transparentMesh.replaceRange(group, transparentFaces);
+		self.finishedLightingMeshData = false;
 	}
 
 	pub fn generateMesh(self: *ChunkMesh, lightRefreshList: *main.List(chunk.ChunkPosition)) void {
@@ -978,11 +977,8 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 
 		self.mutex.unlock();
 
-		self.opaqueMesh.replaceRange(.core, opaqueCore.items);
-		self.opaqueMesh.replaceRange(.optional, opaqueOptional.items);
-
-		self.transparentMesh.replaceRange(.core, transparentCore.items);
-		self.transparentMesh.replaceRange(.optional, transparentOptional.items);
+		self.replaceRanges(.core, opaqueCore.items, transparentCore.items);
+		self.replaceRanges(.optional, opaqueOptional.items, transparentOptional.items);
 
 		self.finishNeighbors(lightRefreshList);
 	}
@@ -1057,10 +1053,8 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 						}
 					}
 				}
-				self.opaqueMesh.replaceRange(.neighbor(neighbor), opaqueSelf.items);
-				self.transparentMesh.replaceRange(.neighbor(neighbor), transparentSelf.items);
-				neighborMesh.opaqueMesh.replaceRange(.neighbor(neighbor.reverse()), opaqueNeighbor.items);
-				neighborMesh.transparentMesh.replaceRange(.neighbor(neighbor.reverse()), transparentNeighbor.items);
+				self.replaceRanges(.neighbor(neighbor), opaqueSelf.items, transparentSelf.items);
+				neighborMesh.replaceRanges(.neighbor(neighbor.reverse()), opaqueNeighbor.items, transparentNeighbor.items);
 
 				_ = neighborMesh.needsLightRefresh.store(true, .release);
 				lightRefreshList.append(neighborMesh.pos);
@@ -1068,8 +1062,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 				self.mutex.lock();
 				defer self.mutex.unlock();
 				if (self.lastNeighborsSameLod[neighbor.toInt()] != null) {
-					self.opaqueMesh.replaceRange(.neighbor(neighbor), &.{});
-					self.transparentMesh.replaceRange(.neighbor(neighbor), &.{});
+					self.replaceRanges(.neighbor(neighbor), &.{}, &.{});
 					self.lastNeighborsSameLod[neighbor.toInt()] = null;
 				}
 			}
@@ -1079,8 +1072,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 				self.mutex.lock();
 				defer self.mutex.unlock();
 				if (self.lastNeighborsHigherLod[neighbor.toInt()] != null) {
-					self.opaqueMesh.replaceRange(.neighborLod(neighbor), &.{});
-					self.transparentMesh.replaceRange(.neighborLod(neighbor), &.{});
+					self.replaceRanges(.neighborLod(neighbor), &.{}, &.{});
 					self.lastNeighborsHigherLod[neighbor.toInt()] = null;
 				}
 				continue;
@@ -1143,8 +1135,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 					}
 				}
 			}
-			self.opaqueMesh.replaceRange(.neighborLod(neighbor), opaqueSelf.items);
-			self.transparentMesh.replaceRange(.neighborLod(neighbor), transparentSelf.items);
+			self.replaceRanges(.neighborLod(neighbor), opaqueSelf.items, transparentSelf.items);
 		}
 		self.mutex.lock();
 		defer self.mutex.unlock();
@@ -1416,15 +1407,15 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 		var lightMap = std.AutoHashMap([4]u32, u16).init(main.stackAllocator.allocator);
 		defer lightMap.deinit();
 
-		self.opaqueMesh.finish(self, &lightList, &lightMap);
-		self.transparentMesh.finish(self, &lightList, &lightMap);
-
 		{
-			self.lightListMutex.lock();
-			defer self.lightListMutex.unlock();
+			self.meshUploadMutex.lock();
+			defer self.meshUploadMutex.unlock();
+			self.opaqueMesh.finish(self, &lightList, &lightMap);
+			self.transparentMesh.finish(self, &lightList, &lightMap);
+
 			self.lightList = main.globalAllocator.realloc(self.lightList, lightList.items.len);
 			@memcpy(self.lightList, lightList.items);
-			self.lightListNeedsUpload = true;
+			self.finishedLightingMeshData = true;
 		}
 
 		self.min = @min(self.opaqueMesh.min, self.transparentMesh.min);
@@ -1436,25 +1427,15 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 	// --------------------------------------------------------------------------------------------
 
 	pub fn uploadData(self: *ChunkMesh) void {
-		{
-			if (!self.opaqueMesh.lock.tryLockRead()) return;
-			defer self.opaqueMesh.lock.unlockRead();
-			if (!self.transparentMesh.lock.tryLockRead()) return;
-			defer self.transparentMesh.lock.unlockRead();
-			if (!self.opaqueMesh.finishedLighting or !self.transparentMesh.finishedLighting) return;
-			self.opaqueMesh.uploadData(self.isNeighborLod);
-			self.transparentMesh.uploadData(self.isNeighborLod);
-			self.updateTransparencyDataAfterMeshUpload();
-		}
+		if (!self.meshUploadMutex.tryLock()) return;
+		defer self.meshUploadMutex.unlock();
+		if (!self.finishedLightingMeshData) return;
 
-		{
-			self.lightListMutex.lock();
-			defer self.lightListMutex.unlock();
-			if (self.lightListNeedsUpload) {
-				self.lightListNeedsUpload = false;
-				lightBuffers[std.math.log2_int(u32, self.pos.voxelSize)].uploadData(self.lightList, &self.lightAllocation);
-			}
-		}
+		self.opaqueMesh.uploadData(self.isNeighborLod);
+		self.transparentMesh.uploadData(self.isNeighborLod);
+		self.updateTransparencyDataAfterMeshUpload();
+
+		lightBuffers[std.math.log2_int(u32, self.pos.voxelSize)].uploadData(self.lightList, &self.lightAllocation);
 
 		self.uploadChunkPosition();
 	}
@@ -1488,7 +1469,7 @@ pub const ChunkMesh = struct { // MARK: ChunkMesh
 	}
 
 	fn updateTransparencyDataAfterMeshUpload(self: *ChunkMesh) void {
-		self.transparentMesh.lock.assertLockedRead();
+		main.utils.assertLocked(&self.meshUploadMutex);
 		var len: usize = 0;
 		const coreList = self.transparentMesh.completeList.getRange(.core);
 		len += coreList.len;

--- a/src/renderer/mesh_storage.zig
+++ b/src/renderer/mesh_storage.zig
@@ -843,9 +843,9 @@ fn addBreakingAnimationFace(pos: Vec3i, quadIndex: main.models.QuadIndex, textur
 	mesh.mutex.lock();
 	defer mesh.mutex.unlock();
 	const lightIndex = blk: {
+		mesh.meshUploadMutex.lock();
+		defer mesh.meshUploadMutex.unlock();
 		const meshData = if (isTransparent) &mesh.transparentMesh else &mesh.opaqueMesh;
-		meshData.lock.lockRead();
-		defer meshData.lock.unlockRead();
 		for (meshData.completeList.getEverything()) |face| {
 			if (face.position.x == relPos[0] and face.position.y == relPos[1] and face.position.z == relPos[2] and face.blockAndQuad.quadIndex == quadIndex) {
 				break :blk face.position.lightIndex;

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1659,63 +1659,9 @@ pub const Mutex = struct { // MARK: Mutex
 	}
 };
 
-/// A read-write lock with read priority.
-pub const ReadWriteLock = struct { // MARK: ReadWriteLock
-	condition: Condition = .{},
-	mutex: main.utils.Mutex = .{},
-	readers: u32 = 0,
-
-	pub fn tryLockRead(self: *ReadWriteLock) bool {
-		if (!self.mutex.tryLock()) return false;
-		self.readers += 1;
-		self.mutex.unlock();
-		return true;
-	}
-
-	pub fn lockRead(self: *ReadWriteLock) void {
-		self.mutex.lock();
-		self.readers += 1;
-		self.mutex.unlock();
-	}
-
-	pub fn unlockRead(self: *ReadWriteLock) void {
-		self.mutex.lock();
-		self.readers -= 1;
-		if (self.readers == 0) {
-			self.condition.broadcast();
-		}
-		self.mutex.unlock();
-	}
-
-	pub fn lockWrite(self: *ReadWriteLock) void {
-		self.mutex.lock();
-		while (self.readers != 0) {
-			self.condition.wait(&self.mutex);
-		}
-	}
-
-	pub fn unlockWrite(self: *ReadWriteLock) void {
-		self.mutex.unlock();
-	}
-
-	pub fn assertLockedWrite(self: *ReadWriteLock) void {
-		if (builtin.mode == .Debug) {
-			std.debug.assert(!self.mutex.tryLock());
-		}
-	}
-
-	pub fn assertLockedRead(self: *ReadWriteLock) void {
-		if (builtin.mode == .Debug and !builtin.sanitize_thread) {
-			if (self.readers == 0) {
-				std.debug.assert(!self.mutex.tryLock());
-			}
-		}
-	}
-};
-
 const endian: std.builtin.Endian = .big;
 
-pub const BinaryReader = struct {
+pub const BinaryReader = struct { // MARK: BinaryReader
 	remaining: []const u8,
 
 	pub const AllErrors = error{ OutOfBounds, IntOutOfBounds, InvalidEnumTag, InvalidFloat };
@@ -1802,7 +1748,7 @@ pub const BinaryReader = struct {
 	}
 };
 
-pub const BinaryWriter = struct {
+pub const BinaryWriter = struct { // MARK: BinaryWriter
 	data: main.List(u8),
 
 	pub fn init(allocator: NeverFailingAllocator) BinaryWriter {


### PR DESCRIPTION
Mainly done for simplification, but should also give a small reduction in memory usage.

follow-up on #2957