### PR TITLE
Allow blocks to define that they are only selectable when item can be placed on it

### DIFF
--- a/assets/cubyz/blocks/duckweed.zig.zon
+++ b/assets/cubyz/blocks/duckweed.zig.zon
@@ -1,5 +1,6 @@
 .{
 	.tags = .{.cuttable},
+	.placementTags = .{.fluid},
 	.blockHealth = 0.1,
 	.drops = .{
 		.{.items = .{.auto}},
@@ -19,7 +20,6 @@
 	.texture3 = "cubyz:duckweed/3",
 	.item = .{
 		.texture = "duckweed.png",
-		.placementTags = .{.fluid},
 	},
 	.lodReplacement = "cubyz:air",
 }

--- a/assets/cubyz/blocks/duckweed.zig.zon
+++ b/assets/cubyz/blocks/duckweed.zig.zon
@@ -1,6 +1,5 @@
 .{
-	.tags = .{.cuttable},
-	.placementTags = .{.fluid},
+	.tags = .{.cuttable, .fluidPlaceable},
 	.blockHealth = 0.1,
 	.drops = .{
 		.{.items = .{.auto}},

--- a/assets/cubyz/blocks/duckweed.zig.zon
+++ b/assets/cubyz/blocks/duckweed.zig.zon
@@ -19,7 +19,7 @@
 	.texture3 = "cubyz:duckweed/3",
 	.item = .{
 		.texture = "duckweed.png",
-		.tags = .{.fluidPlaceable},
+		.placementTags = .{.fluid},
 	},
 	.lodReplacement = "cubyz:air",
 }

--- a/assets/cubyz/blocks/lava.zig.zon
+++ b/assets/cubyz/blocks/lava.zig.zon
@@ -1,7 +1,7 @@
 .{
 	.tags = .{.fluid, .hot},
 	.drops = .{},
-	.selectionRule = .toolEffective,
+	.selectionRule = .placeable,
 	.replaceable = true,
 	.degradable = true,
 	.transparent = true,

--- a/assets/cubyz/blocks/lava.zig.zon
+++ b/assets/cubyz/blocks/lava.zig.zon
@@ -1,5 +1,5 @@
 .{
-	.tags = .{.fluid, .hot},
+	.tags = .{.fluid, .fluidPlaceable, .hot},
 	.drops = .{},
 	.selectionRule = .placeable,
 	.replaceable = true,

--- a/assets/cubyz/blocks/lily_pad.zig.zon
+++ b/assets/cubyz/blocks/lily_pad.zig.zon
@@ -12,7 +12,7 @@
 	.texture = "cubyz:lily_pad",
 	.item = .{
 		.texture = "lily_pad.png",
-		.tags = .{.fluidPlaceable},
+		.placementTags = .{.fluid},
 	},
 	.lodReplacement = "cubyz:air",
 }

--- a/assets/cubyz/blocks/lily_pad.zig.zon
+++ b/assets/cubyz/blocks/lily_pad.zig.zon
@@ -1,6 +1,5 @@
 .{
-	.tags = .{.cuttable},
-	.placementTags = .{.fluid},
+	.tags = .{.cuttable, .fluidPlaceable},
 	.blockHealth = 0.2,
 	.drops = .{
 		.{.items = .{.auto}},

--- a/assets/cubyz/blocks/lily_pad.zig.zon
+++ b/assets/cubyz/blocks/lily_pad.zig.zon
@@ -1,5 +1,6 @@
 .{
 	.tags = .{.cuttable},
+	.placementTags = .{.fluid},
 	.blockHealth = 0.2,
 	.drops = .{
 		.{.items = .{.auto}},
@@ -12,7 +13,6 @@
 	.texture = "cubyz:lily_pad",
 	.item = .{
 		.texture = "lily_pad.png",
-		.placementTags = .{.fluid},
 	},
 	.lodReplacement = "cubyz:air",
 }

--- a/assets/cubyz/blocks/water.zig.zon
+++ b/assets/cubyz/blocks/water.zig.zon
@@ -1,5 +1,5 @@
 .{
-	.tags = .{.fluid},
+	.tags = .{.fluid, .fluidPlaceable},
 	.drops = .{},
 	.selectionRule = .placeable,
 	.replaceable = true,

--- a/assets/cubyz/blocks/water.zig.zon
+++ b/assets/cubyz/blocks/water.zig.zon
@@ -1,7 +1,7 @@
 .{
 	.tags = .{.fluid},
 	.drops = .{},
-	.selectionRule = .toolEffective,
+	.selectionRule = .placeable,
 	.replaceable = true,
 	.degradable = true,
 	.transparent = true,

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -87,6 +87,7 @@ var _viewThrough: [maxBlockCount]bool = undefined;
 var _alwaysViewThrough: [maxBlockCount]bool = undefined;
 var _hasBackFace: [maxBlockCount]bool = undefined;
 var _tags: [maxBlockCount][]Tag = undefined;
+var _placementTags: [maxBlockCount][]Tag = undefined;
 var _light: [maxBlockCount]u32 = undefined;
 /// How much light this block absorbs if it is transparent
 var _absorption: [maxBlockCount]u32 = undefined;
@@ -136,6 +137,7 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 		}
 	}
 
+	_placementTags[size] = Tag.loadTagsFromZon(main.stackAllocator, zon.getChild("placementTags"));
 	_light[size] = zon.get(u32, "emittedLight", 0);
 	_absorption[size] = zon.get(u32, "absorbedLight", 0xffffff);
 	_degradable[size] = zon.get(bool, "degradable", false);
@@ -449,6 +451,21 @@ pub const Block = packed struct(u32) { // MARK: Block
 		return std.mem.containsAtLeastScalar(Tag, self.tags(), 1, tag);
 	}
 
+	pub inline fn placementTags(self: Block) []const Tag {
+		return _placementTags[self.typ];
+	}
+
+	pub inline fn hasPlacementTag(self: Block, tag: Tag) bool {
+		return std.mem.containsAtLeastScalar(Tag, self.placementTags(), 1, tag);
+	}
+
+	pub inline fn isPlaceableOn(self: Block, block: Block) bool {
+		for (block.tags()) |tag| {
+			if (self.hasPlacementTag(tag)) return true;
+		}
+		return false;
+	}
+
 	pub inline fn light(self: Block) u32 {
 		return _light[self.typ];
 	}
@@ -528,13 +545,21 @@ pub const Block = packed struct(u32) { // MARK: Block
 	}
 
 	pub fn isSelectableByItem(self: Block, item: Item) bool {
-		if (item == .baseItem and item.baseItem.block() == self.typ) return true;
+		const rule = self.selectionRule();
+		if (rule == .always) return true;
+		if (rule == .never) return false;
 
-		return switch (self.selectionRule()) {
-			.always => true,
-			.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(self),
-			.placeable => item == .baseItem and item.baseItem.isPlaceableOn(self),
-			.never => false,
+		return switch (item) {
+			.baseItem => |baseItem| {
+				if (baseItem.block()) |blockType| {
+					if (blockType == self.typ) return true;
+					return rule == .placeable and Block.fromInt(blockType).isPlaceableOn(self);
+				} else return false;
+			},
+
+			.proceduralItem => |proceduralItem| rule == .toolEffective and proceduralItem.isEffectiveOn(self),
+
+			else => false,
 		};
 	}
 };

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -68,7 +68,7 @@ pub const Ore = struct {
 	seed: u64,
 };
 
-const SelectionRule = enum { always, toolEffective, never };
+const SelectionRule = enum { always, toolEffective, placeable, never };
 
 var _transparent: [maxBlockCount]bool = undefined;
 var _collide: [maxBlockCount]bool = undefined;
@@ -530,14 +530,10 @@ pub const Block = packed struct(u32) { // MARK: Block
 	pub fn isSelectableByItem(self: Block, item: Item) bool {
 		if (item == .baseItem and item.baseItem.block() == self.typ) return true;
 
-		if (self.hasTag(.fluid)) {
-			const fluidPlaceable = item == .baseItem and item.baseItem.hasTag(.fluidPlaceable);
-			return fluidPlaceable;
-		}
-
 		return switch (self.selectionRule()) {
 			.always => true,
 			.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(self),
+			.placeable => item == .baseItem and item.baseItem.isPlaceableOn(self),
 			.never => false,
 		};
 	}

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -87,7 +87,6 @@ var _viewThrough: [maxBlockCount]bool = undefined;
 var _alwaysViewThrough: [maxBlockCount]bool = undefined;
 var _hasBackFace: [maxBlockCount]bool = undefined;
 var _tags: [maxBlockCount][]Tag = undefined;
-var _placementTags: [maxBlockCount][]Tag = undefined;
 var _light: [maxBlockCount]u32 = undefined;
 /// How much light this block absorbs if it is transparent
 var _absorption: [maxBlockCount]u32 = undefined;
@@ -137,7 +136,6 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 		}
 	}
 
-	_placementTags[size] = Tag.loadTagsFromZon(main.stackAllocator, zon.getChild("placementTags"));
 	_light[size] = zon.get(u32, "emittedLight", 0);
 	_absorption[size] = zon.get(u32, "absorbedLight", 0xffffff);
 	_degradable[size] = zon.get(bool, "degradable", false);
@@ -451,21 +449,6 @@ pub const Block = packed struct(u32) { // MARK: Block
 		return std.mem.containsAtLeastScalar(Tag, self.tags(), 1, tag);
 	}
 
-	pub inline fn placementTags(self: Block) []const Tag {
-		return _placementTags[self.typ];
-	}
-
-	pub inline fn hasPlacementTag(self: Block, tag: Tag) bool {
-		return std.mem.containsAtLeastScalar(Tag, self.placementTags(), 1, tag);
-	}
-
-	pub inline fn isPlaceableOn(self: Block, block: Block) bool {
-		for (block.tags()) |tag| {
-			if (self.hasPlacementTag(tag)) return true;
-		}
-		return false;
-	}
-
 	pub inline fn light(self: Block) u32 {
 		return _light[self.typ];
 	}
@@ -542,6 +525,13 @@ pub const Block = packed struct(u32) { // MARK: Block
 
 	pub fn canBeChangedInto(self: Block, newBlock: Block, item: main.items.ItemStack, shouldDropSourceBlockOnSuccess: *bool) main.rotation.RotationMode.CanBeChangedInto {
 		return newBlock.mode().canBeChangedInto(self, newBlock, item, shouldDropSourceBlockOnSuccess);
+	}
+
+	pub inline fn isPlaceableOn(self: Block, block: Block) bool {
+		for (block.tags()) |tag| {
+			if (self.hasTag(tag)) return true;
+		}
+		return false;
 	}
 
 	pub fn isSelectableByItem(self: Block, item: Item) bool {

--- a/src/items.zig
+++ b/src/items.zig
@@ -254,7 +254,7 @@ pub const BaseItemIndex = enum(u16) { // MARK: BaseItemIndex
 	pub fn hasPlacementTag(self: BaseItemIndex, tag: Tag) bool {
 		return itemList[@intFromEnum(self)].hasPlacementTag(tag);
 	}
-	pub fn isPlaceableOn(self: BaseItemIndex, targetedBlock: main.blocks.Block) bool {
+	pub fn isPlaceableOn(self: BaseItemIndex, targetedBlock: Block) bool {
 		return itemList[@intFromEnum(self)].isPlaceableOn(targetedBlock);
 	}
 	pub fn hashCode(self: BaseItemIndex) u32 {
@@ -372,7 +372,7 @@ pub const BaseItem = struct { // MARK: BaseItem
 		return false;
 	}
 
-	pub fn isPlaceableOn(self: *const BaseItem, block: main.blocks.Block) bool {
+	pub fn isPlaceableOn(self: *const BaseItem, block: Block) bool {
 		for (block.tags()) |tag| {
 			if (self.hasPlacementTag(tag)) return true;
 		}

--- a/src/items.zig
+++ b/src/items.zig
@@ -251,6 +251,12 @@ pub const BaseItemIndex = enum(u16) { // MARK: BaseItemIndex
 	pub fn hasTag(self: BaseItemIndex, tag: Tag) bool {
 		return itemList[@intFromEnum(self)].hasTag(tag);
 	}
+	pub fn hasPlacementTag(self: BaseItemIndex, tag: Tag) bool {
+		return itemList[@intFromEnum(self)].hasPlacementTag(tag);
+	}
+	pub fn isPlaceableOn(self: BaseItemIndex, targetedBlock: main.blocks.Block) bool {
+		return itemList[@intFromEnum(self)].isPlaceableOn(targetedBlock);
+	}
 	pub fn hashCode(self: BaseItemIndex) u32 {
 		return itemList[@intFromEnum(self)].hashCode();
 	}
@@ -268,6 +274,7 @@ pub const BaseItem = struct { // MARK: BaseItem
 	id: []const u8,
 	name: []const u8,
 	tags: []const Tag,
+	placementTags: []const Tag,
 	tooltip: []const u8,
 
 	stackSize: u16,
@@ -287,6 +294,7 @@ pub const BaseItem = struct { // MARK: BaseItem
 		}
 		self.name = allocator.dupe(u8, zon.get([]const u8, "name", id));
 		self.tags = Tag.loadTagsFromZon(allocator, zon.getChild("tags"));
+		self.placementTags = Tag.loadTagsFromZon(allocator, zon.getChild("placementTags"));
 		self.stackSize = zon.get(u16, "stackSize", 120);
 		const material = zon.getChild("material");
 		if (material == .object) {
@@ -353,6 +361,20 @@ pub const BaseItem = struct { // MARK: BaseItem
 	pub fn hasTag(self: *const BaseItem, tag: Tag) bool {
 		for (self.tags) |other| {
 			if (other == tag) return true;
+		}
+		return false;
+	}
+
+	pub fn hasPlacementTag(self: *const BaseItem, tag: Tag) bool {
+		for (self.placementTags) |other| {
+			if (other == tag) return true;
+		}
+		return false;
+	}
+
+	pub fn isPlaceableOn(self: *const BaseItem, block: main.blocks.Block) bool {
+		for (block.tags()) |tag| {
+			if (self.hasPlacementTag(tag)) return true;
 		}
 		return false;
 	}

--- a/src/items.zig
+++ b/src/items.zig
@@ -251,12 +251,6 @@ pub const BaseItemIndex = enum(u16) { // MARK: BaseItemIndex
 	pub fn hasTag(self: BaseItemIndex, tag: Tag) bool {
 		return itemList[@intFromEnum(self)].hasTag(tag);
 	}
-	pub fn hasPlacementTag(self: BaseItemIndex, tag: Tag) bool {
-		return itemList[@intFromEnum(self)].hasPlacementTag(tag);
-	}
-	pub fn isPlaceableOn(self: BaseItemIndex, targetedBlock: Block) bool {
-		return itemList[@intFromEnum(self)].isPlaceableOn(targetedBlock);
-	}
 	pub fn hashCode(self: BaseItemIndex) u32 {
 		return itemList[@intFromEnum(self)].hashCode();
 	}
@@ -274,7 +268,6 @@ pub const BaseItem = struct { // MARK: BaseItem
 	id: []const u8,
 	name: []const u8,
 	tags: []const Tag,
-	placementTags: []const Tag,
 	tooltip: []const u8,
 
 	stackSize: u16,
@@ -294,7 +287,6 @@ pub const BaseItem = struct { // MARK: BaseItem
 		}
 		self.name = allocator.dupe(u8, zon.get([]const u8, "name", id));
 		self.tags = Tag.loadTagsFromZon(allocator, zon.getChild("tags"));
-		self.placementTags = Tag.loadTagsFromZon(allocator, zon.getChild("placementTags"));
 		self.stackSize = zon.get(u16, "stackSize", 120);
 		const material = zon.getChild("material");
 		if (material == .object) {
@@ -361,20 +353,6 @@ pub const BaseItem = struct { // MARK: BaseItem
 	pub fn hasTag(self: *const BaseItem, tag: Tag) bool {
 		for (self.tags) |other| {
 			if (other == tag) return true;
-		}
-		return false;
-	}
-
-	pub fn hasPlacementTag(self: *const BaseItem, tag: Tag) bool {
-		for (self.placementTags) |other| {
-			if (other == tag) return true;
-		}
-		return false;
-	}
-
-	pub fn isPlaceableOn(self: *const BaseItem, block: Block) bool {
-		for (block.tags()) |tag| {
-			if (self.hasPlacementTag(tag)) return true;
 		}
 		return false;
 	}

--- a/src/tag.zig
+++ b/src/tag.zig
@@ -9,9 +9,8 @@ pub const Tag = enum(u32) {
 	air = 0,
 	fluid = 1,
 	sbbChild = 2,
-	fluidPlaceable = 3,
-	chiselable = 4,
-	playerModel = 5,
+	chiselable = 3,
+	playerModel = 4,
 	_,
 
 	pub fn initTags() void {


### PR DESCRIPTION
To remove the `.fluid` case in item selection, preparation for #627

Adds the block field `.placementTags` and the block selectionRule `.placeable`

It's a simple version for now (selection happens if a placementTag overlaps with a block tag), but it can be changed in the future to some kind of condition checking. Like replacing it with `.placementConstraints` (like tagOverlap, onTop, onBottom), which can work similarly to `.selectionRule`. To get closer to fixing #2491 

I'll also make it possible separately to define multiple selectionRules per block in #2987, to make both the selectionRules `.toolEffective` and `.placeable` possible on the same block, in preparation for adding buckets