### PR TITLE
Make it possible to define multiple selectionRules for a block

### DIFF
--- a/assets/cubyz/blocks/air.zig.zon
+++ b/assets/cubyz/blocks/air.zig.zon
@@ -11,6 +11,6 @@
 	.collide = false,
 
 	.drops = .{},
-	.selectionRules = .{.never},
+	.selectionCapabilities = .{.never},
 	.model = .none,
 }

--- a/assets/cubyz/blocks/air.zig.zon
+++ b/assets/cubyz/blocks/air.zig.zon
@@ -11,6 +11,6 @@
 	.collide = false,
 
 	.drops = .{},
-	.selectionRule = .never,
+	.selectionRules = .{.never},
 	.model = .none,
 }

--- a/assets/cubyz/blocks/air.zig.zon
+++ b/assets/cubyz/blocks/air.zig.zon
@@ -11,6 +11,6 @@
 	.collide = false,
 
 	.drops = .{},
-	.selectionCapabilities = .{.never},
+	.selectionCapabilities = .{},
 	.model = .none,
 }

--- a/assets/cubyz/blocks/bluebells.zig.zon
+++ b/assets/cubyz/blocks/bluebells.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/bolete.zig.zon
+++ b/assets/cubyz/blocks/bolete.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.viewThrough = true,
 	.degradable = true,

--- a/assets/cubyz/blocks/cactus_flower.zig.zon
+++ b/assets/cubyz/blocks/cactus_flower.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.collide = false,

--- a/assets/cubyz/blocks/castilleja.zig.zon
+++ b/assets/cubyz/blocks/castilleja.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/cold_grass_vegetation.zig.zon
+++ b/assets/cubyz/blocks/cold_grass_vegetation.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/daffodil.zig.zon
+++ b/assets/cubyz/blocks/daffodil.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/daisies.zig.zon
+++ b/assets/cubyz/blocks/daisies.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.collide = false,

--- a/assets/cubyz/blocks/dandelions.zig.zon
+++ b/assets/cubyz/blocks/dandelions.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.collide = false,

--- a/assets/cubyz/blocks/dead_leaf_pile.zig.zon
+++ b/assets/cubyz/blocks/dead_leaf_pile.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.collide = false,

--- a/assets/cubyz/blocks/dry_grass_vegetation.zig.zon
+++ b/assets/cubyz/blocks/dry_grass_vegetation.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/duckweed.zig.zon
+++ b/assets/cubyz/blocks/duckweed.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.collide = false,

--- a/assets/cubyz/blocks/fern.zig.zon
+++ b/assets/cubyz/blocks/fern.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/fog/_defaults.zig.zon
+++ b/assets/cubyz/blocks/fog/_defaults.zig.zon
@@ -2,7 +2,7 @@
 	.tags = .{.air},
 	.blockHealth = 2,
 	.drops = .{},
-	.selectionRule = .never,
+	.selectionRules = .{.never},
 	.degradable = true,
 	.transparent = true,
 	.hasBackFace = true,

--- a/assets/cubyz/blocks/fog/_defaults.zig.zon
+++ b/assets/cubyz/blocks/fog/_defaults.zig.zon
@@ -2,7 +2,7 @@
 	.tags = .{.air},
 	.blockHealth = 2,
 	.drops = .{},
-	.selectionRules = .{.never},
+	.selectionCapabilities = .{.never},
 	.degradable = true,
 	.transparent = true,
 	.hasBackFace = true,

--- a/assets/cubyz/blocks/fog/_defaults.zig.zon
+++ b/assets/cubyz/blocks/fog/_defaults.zig.zon
@@ -2,7 +2,7 @@
 	.tags = .{.air},
 	.blockHealth = 2,
 	.drops = .{},
-	.selectionCapabilities = .{.never},
+	.selectionCapabilities = .{},
 	.degradable = true,
 	.transparent = true,
 	.hasBackFace = true,

--- a/assets/cubyz/blocks/glimmergill.zig.zon
+++ b/assets/cubyz/blocks/glimmergill.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/grass/vegetation/dew.zig.zon
+++ b/assets/cubyz/blocks/grass/vegetation/dew.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/grass/vegetation/sky.zig.zon
+++ b/assets/cubyz/blocks/grass/vegetation/sky.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/grass_vegetation.zig.zon
+++ b/assets/cubyz/blocks/grass_vegetation.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/hibiscus.zig.zon
+++ b/assets/cubyz/blocks/hibiscus.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/ivy.zig.zon
+++ b/assets/cubyz/blocks/ivy.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.collide = false,

--- a/assets/cubyz/blocks/lava.zig.zon
+++ b/assets/cubyz/blocks/lava.zig.zon
@@ -1,7 +1,7 @@
 .{
 	.tags = .{.fluid, .hot},
 	.drops = .{},
-	.selectionRule = .toolEffective,
+	.selectionRules = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.transparent = true,

--- a/assets/cubyz/blocks/lava.zig.zon
+++ b/assets/cubyz/blocks/lava.zig.zon
@@ -1,7 +1,7 @@
 .{
 	.tags = .{.fluid, .hot},
 	.drops = .{},
-	.selectionRules = .{.toolEffective},
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.transparent = true,

--- a/assets/cubyz/blocks/lumiflora.zig.zon
+++ b/assets/cubyz/blocks/lumiflora.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/lush_grass_vegetation.zig.zon
+++ b/assets/cubyz/blocks/lush_grass_vegetation.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/marigold.zig.zon
+++ b/assets/cubyz/blocks/marigold.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/monstera.zig.zon
+++ b/assets/cubyz/blocks/monstera.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.collide = false,

--- a/assets/cubyz/blocks/osier.zig.zon
+++ b/assets/cubyz/blocks/osier.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.collide = false,

--- a/assets/cubyz/blocks/red_leaf_pile.zig.zon
+++ b/assets/cubyz/blocks/red_leaf_pile.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.collide = false,

--- a/assets/cubyz/blocks/toadstool.zig.zon
+++ b/assets/cubyz/blocks/toadstool.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/trumpet_lily.zig.zon
+++ b/assets/cubyz/blocks/trumpet_lily.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/tussock.zig.zon
+++ b/assets/cubyz/blocks/tussock.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/vetch.zig.zon
+++ b/assets/cubyz/blocks/vetch.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/vine/_defaults.zig.zon
+++ b/assets/cubyz/blocks/vine/_defaults.zig.zon
@@ -5,7 +5,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/water.zig.zon
+++ b/assets/cubyz/blocks/water.zig.zon
@@ -1,7 +1,7 @@
 .{
 	.tags = .{.fluid},
 	.drops = .{},
-	.selectionRules = .{.toolEffective},
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.transparent = true,

--- a/assets/cubyz/blocks/water.zig.zon
+++ b/assets/cubyz/blocks/water.zig.zon
@@ -1,7 +1,7 @@
 .{
 	.tags = .{.fluid},
 	.drops = .{},
-	.selectionRule = .toolEffective,
+	.selectionRules = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.transparent = true,

--- a/assets/cubyz/blocks/yellow_leaf_pile.zig.zon
+++ b/assets/cubyz/blocks/yellow_leaf_pile.zig.zon
@@ -4,7 +4,7 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
-	.selectionRule = .toolEffective,
+	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
 	.collide = false,

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -76,18 +76,9 @@ const SelectionCapability = enum {
 	pub fn loadSelectionCapabilitiesFromZon(_allocator: main.heap.NeverFailingAllocator, zon: main.ZonElement) []SelectionCapability {
 		var capabilities = main.List(SelectionCapability).initCapacity(_allocator, zon.toSlice().len);
 		for (zon.toSlice()) |capabilityZon| {
-			switch (capabilityZon) {
-				.string, .stringOwned => |string| {
-					if (std.meta.stringToEnum(SelectionCapability, string)) |capability| {
-						capabilities.appendAssumeCapacity(capability);
-					} else {
-						std.log.err("SelectionCapability '{s}' is invalid. Ignoring", .{string});
-					}
-				},
-				else => {
-					std.log.err("SelectionCapability element is not a string (type: {s}). Ignoring", .{@tagName(capabilityZon)});
-				},
-			}
+			if (capabilityZon.as(?SelectionCapability, null)) |capability| {
+				capabilities.appendAssumeCapacity(capability);
+			} else std.log.err("SelectionCapability is invalid. Ignoring", .{});
 		}
 		return capabilities.toOwnedSlice();
 	}

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -68,10 +68,8 @@ pub const Ore = struct {
 	seed: u64,
 };
 
-const SelectionCapability = enum {
-	always,
+const SelectionCapability = enum(u8) {
 	toolEffective,
-	never,
 
 	pub fn loadSelectionCapabilitiesFromZon(_allocator: main.heap.NeverFailingAllocator, zon: main.ZonElement) []SelectionCapability {
 		var capabilities = main.List(SelectionCapability).initCapacity(_allocator, zon.toSlice().len);
@@ -85,9 +83,7 @@ const SelectionCapability = enum {
 
 	pub fn allowsItemSelection(self: SelectionCapability, item: Item, block: Block) bool {
 		return switch (self) {
-			.always => true,
 			.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(block),
-			.never => false,
 		};
 	}
 };
@@ -166,9 +162,6 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 	if (zon.getChildOrNull("selectionCapabilities")) |capabilitiesZon| {
 		const capabilities = SelectionCapability.loadSelectionCapabilitiesFromZon(main.stackAllocator, capabilitiesZon);
 		defer main.stackAllocator.free(capabilities);
-		if (capabilities.len == 0) {
-			std.log.err("Field '.selectionCapabilities' is an empty array. This block can never be selected. Did you mean '.selectionCapabilities = .{{.never}}' instead?", .{});
-		}
 		selectionCapabilities = main.worldArena.allocator.dupe(SelectionCapability, capabilities) catch unreachable;
 	}
 	_selectionCapabilities[size] = selectionCapabilities;

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -68,7 +68,7 @@ pub const Ore = struct {
 	seed: u64,
 };
 
-pub const SelectionCapability = enum {
+const SelectionCapability = enum {
 	always,
 	toolEffective,
 	never,

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -69,17 +69,36 @@ pub const Ore = struct {
 };
 
 pub const SelectionCapability = enum {
-    always,
-    toolEffective,
-    never,
+	always,
+	toolEffective,
+	never,
 
-    pub fn allowsItemSelection(self: SelectionCapability, item: Item, block: Block) bool {
-        return switch (self) {
-            .always => true,
-            .toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(block),
-            .never => false,
-        };
-    }
+	pub fn loadSelectionCapabilitiesFromZon(_allocator: main.heap.NeverFailingAllocator, zon: main.ZonElement) []SelectionCapability {
+		var capabilities = main.List(SelectionCapability).initCapacity(_allocator, zon.toSlice().len);
+		for (zon.toSlice()) |capabilityZon| {
+			switch (capabilityZon) {
+				.string, .stringOwned => |string| {
+					if (std.meta.stringToEnum(SelectionCapability, string)) |capability| {
+						capabilities.appendAssumeCapacity(capability);
+					} else {
+						std.log.err("SelectionCapability '{s}' is invalid. Ignoring", .{string});
+					}
+				},
+				else => {
+					std.log.err("SelectionCapability element is not a string (type: {s}). Ignoring", .{@tagName(capabilityZon)});
+				},
+			}
+		}
+		return capabilities.toOwnedSlice();
+	}
+
+	pub fn allowsItemSelection(self: SelectionCapability, item: Item, block: Block) bool {
+		return switch (self) {
+			.always => true,
+			.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(block),
+			.never => false,
+		};
+	}
 };
 
 var _transparent: [maxBlockCount]bool = undefined;
@@ -152,11 +171,14 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 	_absorption[size] = zon.get(u32, "absorbedLight", 0xffffff);
 	_degradable[size] = zon.get(bool, "degradable", false);
 
-	const selectionCapabilities = zon.get(?[]SelectionCapability, "selectionCapabilities", null);
-	if (selectionCapabilities) |capabilities| {
+	var selectionCapabilities: ?[]SelectionCapability = null;
+	if (zon.getChildOrNull("selectionCapabilities")) |capabilitiesZon| {
+		const capabilities = SelectionCapability.loadSelectionCapabilitiesFromZon(main.stackAllocator, capabilitiesZon);
+		defer main.stackAllocator.free(capabilities);
 		if (capabilities.len == 0) {
 			std.log.err("Field '.selectionCapabilities' is an empty array. This block can never be selected. Did you mean '.selectionCapabilities = .{{.never}}' instead?", .{});
 		}
+		selectionCapabilities = main.worldArena.allocator.dupe(SelectionCapability, capabilities) catch unreachable;
 	}
 	_selectionCapabilities[size] = selectionCapabilities;
 

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -74,7 +74,7 @@ const SelectionCapabilities = struct {
 	const Capability = enum(u8) {
 		toolEffective,
 
-		pub fn allowsItemSelection(self: Capability, item: Item, block: Block) bool {
+		pub fn allowsSelectionByItem(self: Capability, block: Block, item: Item) bool {
 			return switch (self) {
 				.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(block),
 			};
@@ -108,7 +108,7 @@ const SelectionCapabilities = struct {
 
 		const capabilities = self.capabilities orelse return true;
 		for (capabilities) |capability| {
-			if (capability.allowsItemSelection(item, block)) return true;
+			if (capability.allowsSelectionByItem(block, item)) return true;
 		}
 		return false;
 	}

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -68,12 +68,12 @@ pub const Ore = struct {
 	seed: u64,
 };
 
-pub const SelectionRule = enum {
+pub const SelectionCapability = enum {
     always,
     toolEffective,
     never,
 
-    pub fn allowsItemSelection(self: SelectionRule, item: Item, block: Block) bool {
+    pub fn allowsItemSelection(self: SelectionCapability, item: Item, block: Block) bool {
         return switch (self) {
             .always => true,
             .toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(block),
@@ -91,7 +91,7 @@ var _blockResistance: [maxBlockCount]f32 = undefined;
 
 /// Whether you can replace it with another block, mainly used for fluids/gases
 var _replaceable: [maxBlockCount]bool = undefined;
-var _selectionRules: [maxBlockCount]?[]SelectionRule = undefined;
+var _selectionCapabilities: [maxBlockCount]?[]SelectionCapability = undefined;
 var _blockDrops: [maxBlockCount][]const BlockDrop = undefined;
 /// Meaning undegradable parts of trees or other structures can grow through this block.
 var _degradable: [maxBlockCount]bool = undefined;
@@ -152,13 +152,13 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 	_absorption[size] = zon.get(u32, "absorbedLight", 0xffffff);
 	_degradable[size] = zon.get(bool, "degradable", false);
 
-	const selectionRules = zon.get(?[]SelectionRule, "selectionRules", null);
-	if (selectionRules) |rules| {
-		if (rules.len == 0) {
-			std.log.err("Field '.selectionRules' is an empty array. This block can never be selected. Did you mean '.selectionRules = .{{.never}}' instead?", .{});
+	const selectionCapabilities = zon.get(?[]SelectionCapability, "selectionCapabilities", null);
+	if (selectionCapabilities) |capabilities| {
+		if (capabilities.len == 0) {
+			std.log.err("Field '.selectionCapabilities' is an empty array. This block can never be selected. Did you mean '.selectionCapabilities = .{{.never}}' instead?", .{});
 		}
 	}
-	_selectionRules[size] = selectionRules;
+	_selectionCapabilities[size] = selectionCapabilities;
 
 	_replaceable[size] = zon.get(bool, "replaceable", false);
 	_transparent[size] = zon.get(bool, "transparent", false);
@@ -434,8 +434,8 @@ pub const Block = packed struct(u32) { // MARK: Block
 		return _replaceable[self.typ];
 	}
 
-	pub inline fn selectionRules(self: Block) ?[]SelectionRule {
-		return _selectionRules[self.typ];
+	pub inline fn selectionCapabilities(self: Block) ?[]SelectionCapability {
+		return _selectionCapabilities[self.typ];
 	}
 
 	pub inline fn blockDrops(self: Block) []const BlockDrop {
@@ -559,9 +559,9 @@ pub const Block = packed struct(u32) { // MARK: Block
 			return fluidPlaceable;
 		}
 
-		const rules = self.selectionRules() orelse return true;
-		for (rules) |rule| {
-			if (rule.allowsItemSelection(item, self)) return true;
+		const capabilities = self.selectionCapabilities() orelse return true;
+		for (capabilities) |capability| {
+			if (capability.allowsItemSelection(item, self)) return true;
 		}
 		return false;
 	}

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -97,7 +97,7 @@ var _blockResistance: [maxBlockCount]f32 = undefined;
 
 /// Whether you can replace it with another block, mainly used for fluids/gases
 var _replaceable: [maxBlockCount]bool = undefined;
-var _selectionCapabilities: [maxBlockCount]?[]SelectionCapability = undefined;
+var _selectionCapabilities: [maxBlockCount]?[]const SelectionCapability = undefined;
 var _blockDrops: [maxBlockCount][]const BlockDrop = undefined;
 /// Meaning undegradable parts of trees or other structures can grow through this block.
 var _degradable: [maxBlockCount]bool = undefined;
@@ -438,7 +438,7 @@ pub const Block = packed struct(u32) { // MARK: Block
 		return _replaceable[self.typ];
 	}
 
-	pub inline fn selectionCapabilities(self: Block) ?[]SelectionCapability {
+	pub inline fn selectionCapabilities(self: Block) ?[]const SelectionCapability {
 		return _selectionCapabilities[self.typ];
 	}
 

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -69,14 +69,24 @@ pub const Ore = struct {
 };
 
 const SelectionCapabilities = struct {
-	capabilities: ?[]const SelectionCapability,
+	capabilities: ?[]const Capability,
+
+	const Capability = enum(u8) {
+		toolEffective,
+
+		pub fn allowsItemSelection(self: Capability, item: Item, block: Block) bool {
+			return switch (self) {
+				.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(block),
+			};
+		}
+	};
 
 	pub const alwaysSelectable: SelectionCapabilities = .{.capabilities = null};
 
 	pub fn loadFromZon(arena: main.heap.NeverFailingAllocator, zon: main.ZonElement) SelectionCapabilities {
-		var list = main.ListUnmanaged(SelectionCapability).initCapacity(arena, zon.toSlice().len);
+		var list = main.ListUnmanaged(Capability).initCapacity(arena, zon.toSlice().len);
 		for (zon.toSlice()) |capabilityZon| {
-			if (capabilityZon.as(?SelectionCapability, null)) |capability| {
+			if (capabilityZon.as(?Capability, null)) |capability| {
 				list.appendAssumeCapacity(capability);
 			} else std.log.err("SelectionCapability is invalid. Ignoring", .{});
 		}
@@ -101,16 +111,6 @@ const SelectionCapabilities = struct {
 			if (capability.allowsItemSelection(item, block)) return true;
 		}
 		return false;
-	}
-};
-
-const SelectionCapability = enum(u8) {
-	toolEffective,
-
-	pub fn allowsItemSelection(self: SelectionCapability, item: Item, block: Block) bool {
-		return switch (self) {
-			.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(block),
-		};
 	}
 };
 

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -160,9 +160,7 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 
 	var selectionCapabilities: ?[]SelectionCapability = null;
 	if (zon.getChildOrNull("selectionCapabilities")) |capabilitiesZon| {
-		const capabilities = SelectionCapability.loadSelectionCapabilitiesFromZon(main.stackAllocator, capabilitiesZon);
-		defer main.stackAllocator.free(capabilities);
-		selectionCapabilities = main.worldArena.allocator.dupe(SelectionCapability, capabilities) catch unreachable;
+		selectionCapabilities = SelectionCapability.loadSelectionCapabilitiesFromZon(main.worldArena, capabilitiesZon);
 	}
 	_selectionCapabilities[size] = selectionCapabilities;
 

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -71,14 +71,14 @@ pub const Ore = struct {
 const SelectionCapability = enum(u8) {
 	toolEffective,
 
-	pub fn loadSelectionCapabilitiesFromZon(_allocator: main.heap.NeverFailingAllocator, zon: main.ZonElement) []SelectionCapability {
-		var capabilities = main.List(SelectionCapability).initCapacity(_allocator, zon.toSlice().len);
+	pub fn loadSelectionCapabilitiesFromZon(arena: main.heap.NeverFailingAllocator, zon: main.ZonElement) []SelectionCapability {
+		var capabilities = main.ListUnmanaged(SelectionCapability).initCapacity(arena, zon.toSlice().len);
 		for (zon.toSlice()) |capabilityZon| {
 			if (capabilityZon.as(?SelectionCapability, null)) |capability| {
 				capabilities.appendAssumeCapacity(capability);
 			} else std.log.err("SelectionCapability is invalid. Ignoring", .{});
 		}
-		return capabilities.toOwnedSlice();
+		return capabilities.items;
 	}
 
 	pub fn allowsItemSelection(self: SelectionCapability, item: Item, block: Block) bool {

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -71,7 +71,7 @@ pub const Ore = struct {
 const SelectionCapabilities = struct {
 	capabilities: ?[]const SelectionCapability,
 
-	pub const alwaysSelectable = SelectionCapabilities{.capabilities = null};
+	pub const alwaysSelectable: SelectionCapabilities = .{.capabilities = null};
 
 	pub fn loadFromZon(arena: main.heap.NeverFailingAllocator, zon: main.ZonElement) SelectionCapabilities {
 		var list = main.ListUnmanaged(SelectionCapability).initCapacity(arena, zon.toSlice().len);

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -68,7 +68,19 @@ pub const Ore = struct {
 	seed: u64,
 };
 
-const SelectionRule = enum { always, toolEffective, never };
+pub const SelectionRule = enum {
+    always,
+    toolEffective,
+    never,
+
+    pub fn allowsItemSelection(self: SelectionRule, item: Item, block: Block) bool {
+        return switch (self) {
+            .always => true,
+            .toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(block),
+            .never => false,
+        };
+    }
+};
 
 var _transparent: [maxBlockCount]bool = undefined;
 var _collide: [maxBlockCount]bool = undefined;
@@ -79,7 +91,7 @@ var _blockResistance: [maxBlockCount]f32 = undefined;
 
 /// Whether you can replace it with another block, mainly used for fluids/gases
 var _replaceable: [maxBlockCount]bool = undefined;
-var _selectionRule: [maxBlockCount]SelectionRule = undefined;
+var _selectionRules: [maxBlockCount]?[]SelectionRule = undefined;
 var _blockDrops: [maxBlockCount][]const BlockDrop = undefined;
 /// Meaning undegradable parts of trees or other structures can grow through this block.
 var _degradable: [maxBlockCount]bool = undefined;
@@ -139,7 +151,15 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 	_light[size] = zon.get(u32, "emittedLight", 0);
 	_absorption[size] = zon.get(u32, "absorbedLight", 0xffffff);
 	_degradable[size] = zon.get(bool, "degradable", false);
-	_selectionRule[size] = zon.get(SelectionRule, "selectionRule", .always);
+
+	const selectionRules = zon.get(?[]SelectionRule, "selectionRules", null);
+	if (selectionRules) |rules| {
+		if (rules.len == 0) {
+			std.log.err("Field '.selectionRules' is an empty array. This block can never be selected. Did you mean '.selectionRules = .{{.never}}' instead?", .{});
+		}
+	}
+	_selectionRules[size] = selectionRules;
+
 	_replaceable[size] = zon.get(bool, "replaceable", false);
 	_transparent[size] = zon.get(bool, "transparent", false);
 	_collide[size] = zon.get(bool, "collide", true);
@@ -414,8 +434,8 @@ pub const Block = packed struct(u32) { // MARK: Block
 		return _replaceable[self.typ];
 	}
 
-	pub inline fn selectionRule(self: Block) SelectionRule {
-		return _selectionRule[self.typ];
+	pub inline fn selectionRules(self: Block) ?[]SelectionRule {
+		return _selectionRules[self.typ];
 	}
 
 	pub inline fn blockDrops(self: Block) []const BlockDrop {
@@ -539,11 +559,11 @@ pub const Block = packed struct(u32) { // MARK: Block
 			return fluidPlaceable;
 		}
 
-		return switch (self.selectionRule()) {
-			.always => true,
-			.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(self),
-			.never => false,
-		};
+		const rules = self.selectionRules() orelse return true;
+		for (rules) |rule| {
+			if (rule.allowsItemSelection(item, self)) return true;
+		}
+		return false;
 	}
 };
 

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -185,9 +185,9 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 	_degradable[size] = zon.get(bool, "degradable", false);
 
 	if (zon.getChildOrNull("selectionCapabilities")) |capabilitiesZon| {
-		_selectionCapabilities[size] = SelectionCapabilities.loadFromZon(main.worldArena, capabilitiesZon);
+		_selectionCapabilities[size] = .loadFromZon(main.worldArena, capabilitiesZon);
 	} else {
-		_selectionCapabilities[size] = SelectionCapabilities.alwaysSelectable;
+		_selectionCapabilities[size] = .alwaysSelectable;
 	}
 
 	_replaceable[size] = zon.get(bool, "replaceable", false);

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -68,18 +68,44 @@ pub const Ore = struct {
 	seed: u64,
 };
 
-const SelectionCapability = enum(u8) {
-	toolEffective,
+const SelectionCapabilities = struct {
+	capabilities: ?[]const SelectionCapability,
 
-	pub fn loadSelectionCapabilitiesFromZon(arena: main.heap.NeverFailingAllocator, zon: main.ZonElement) []SelectionCapability {
-		var capabilities = main.ListUnmanaged(SelectionCapability).initCapacity(arena, zon.toSlice().len);
+	pub const alwaysSelectable = SelectionCapabilities{.capabilities = null};
+
+	pub fn loadFromZon(arena: main.heap.NeverFailingAllocator, zon: main.ZonElement) SelectionCapabilities {
+		var list = main.ListUnmanaged(SelectionCapability).initCapacity(arena, zon.toSlice().len);
 		for (zon.toSlice()) |capabilityZon| {
 			if (capabilityZon.as(?SelectionCapability, null)) |capability| {
-				capabilities.appendAssumeCapacity(capability);
+				list.appendAssumeCapacity(capability);
 			} else std.log.err("SelectionCapability is invalid. Ignoring", .{});
 		}
-		return capabilities.items;
+		return .{.capabilities = list.items};
 	}
+
+	pub fn allowsSelectionByItem(self: SelectionCapabilities, block: Block, item: Item) bool {
+		if (item == .baseItem) {
+			const base = item.baseItem;
+			if (base.block() == block.typ or std.mem.eql(u8, base.id(), "cubyz:selection_wand")) {
+				return true;
+			}
+		}
+
+		if (block.hasTag(.fluid)) {
+			const fluidPlaceable = item == .baseItem and item.baseItem.hasTag(.fluidPlaceable);
+			return fluidPlaceable;
+		}
+
+		const capabilities = self.capabilities orelse return true;
+		for (capabilities) |capability| {
+			if (capability.allowsItemSelection(item, block)) return true;
+		}
+		return false;
+	}
+};
+
+const SelectionCapability = enum(u8) {
+	toolEffective,
 
 	pub fn allowsItemSelection(self: SelectionCapability, item: Item, block: Block) bool {
 		return switch (self) {
@@ -97,7 +123,7 @@ var _blockResistance: [maxBlockCount]f32 = undefined;
 
 /// Whether you can replace it with another block, mainly used for fluids/gases
 var _replaceable: [maxBlockCount]bool = undefined;
-var _selectionCapabilities: [maxBlockCount]?[]const SelectionCapability = undefined;
+var _selectionCapabilities: [maxBlockCount]SelectionCapabilities = undefined;
 var _blockDrops: [maxBlockCount][]const BlockDrop = undefined;
 /// Meaning undegradable parts of trees or other structures can grow through this block.
 var _degradable: [maxBlockCount]bool = undefined;
@@ -158,11 +184,11 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 	_absorption[size] = zon.get(u32, "absorbedLight", 0xffffff);
 	_degradable[size] = zon.get(bool, "degradable", false);
 
-	var selectionCapabilities: ?[]SelectionCapability = null;
 	if (zon.getChildOrNull("selectionCapabilities")) |capabilitiesZon| {
-		selectionCapabilities = SelectionCapability.loadSelectionCapabilitiesFromZon(main.worldArena, capabilitiesZon);
+		_selectionCapabilities[size] = SelectionCapabilities.loadFromZon(main.worldArena, capabilitiesZon);
+	} else {
+		_selectionCapabilities[size] = SelectionCapabilities.alwaysSelectable;
 	}
-	_selectionCapabilities[size] = selectionCapabilities;
 
 	_replaceable[size] = zon.get(bool, "replaceable", false);
 	_transparent[size] = zon.get(bool, "transparent", false);
@@ -438,7 +464,7 @@ pub const Block = packed struct(u32) { // MARK: Block
 		return _replaceable[self.typ];
 	}
 
-	pub inline fn selectionCapabilities(self: Block) ?[]const SelectionCapability {
+	pub inline fn selectionCapabilities(self: Block) SelectionCapabilities {
 		return _selectionCapabilities[self.typ];
 	}
 
@@ -550,24 +576,8 @@ pub const Block = packed struct(u32) { // MARK: Block
 		return newBlock.mode().canBeChangedInto(self, newBlock, item, shouldDropSourceBlockOnSuccess);
 	}
 
-	pub fn isSelectableByItem(self: Block, item: Item) bool {
-		if (item == .baseItem) {
-			const base = item.baseItem;
-			if (base.block() == self.typ or std.mem.eql(u8, base.id(), "cubyz:selection_wand")) {
-				return true;
-			}
-		}
-
-		if (self.hasTag(.fluid)) {
-			const fluidPlaceable = item == .baseItem and item.baseItem.hasTag(.fluidPlaceable);
-			return fluidPlaceable;
-		}
-
-		const capabilities = self.selectionCapabilities() orelse return true;
-		for (capabilities) |capability| {
-			if (capability.allowsItemSelection(item, self)) return true;
-		}
-		return false;
+	pub inline fn isSelectableByItem(self: Block, item: Item) bool {
+		return self.selectionCapabilities().allowsSelectionByItem(self, item);
 	}
 };
 


### PR DESCRIPTION
Related: #2983

To make both the selectionRules `.toolEffective` and `.placeable` possible on the same block, in preparation for adding buckets (#627)

Also rename it to selectionCapabilities, because it's clearer that any being true will lead to the block being selected
