### PR TITLE
Headless server: bootstrap world if missing and handle SIGTERM/SIGINT

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -157,6 +157,9 @@ fn createLaunchConfig(b: *std.Build) !void {
 			\\    .autoEnterWorld = "",
 			\\    .headlessServer = false,
 			\\    // .preferredAuthenticationAlgorithm = .ed25519, // Uncomment and change this if you own a server in an outdated game version where the default algorithm got compromised.
+			\\    // .createIfMissing = false, // When true (and headlessServer is true), the world named in autoEnterWorld is created if it doesn't exist yet.
+			\\    // .worldSeed = 0, // Seed used when auto-creating a world. If unset, a random seed is generated.
+			\\    // .worldPreset = "cubyz:default", // World preset used when auto-creating a world.
 			\\}
 		;
 		try std.Io.Dir.cwd().writeFile(io.io(), .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -404,6 +404,22 @@ pub fn exitToMenu() void {
 	shouldExitToMenu.store(true, .monotonic);
 }
 
+fn shutdownSignalHandler(_: std.posix.SIG) callconv(.c) void {
+	server.stop();
+}
+
+fn installSignalHandlers() void {
+	if (builtin.os.tag == .windows) return;
+	if (!@hasDecl(std.posix, "Sigaction")) return;
+	var act: std.posix.Sigaction = .{
+		.handler = .{.handler = shutdownSignalHandler},
+		.mask = std.posix.sigemptyset(),
+		.flags = 0,
+	};
+	std.posix.sigaction(.TERM, &act, null);
+	std.posix.sigaction(.INT, &act, null);
+}
+
 fn isHiddenOrParentHiddenPosix(path: []const u8) bool {
 	var iter = std.fs.path.componentIterator(path) catch |err| {
 		std.log.err("Cannot iterate on path {s}: {s}!", .{path, @errorName(err)});
@@ -441,6 +457,7 @@ pub fn main(args: std.process.Init.Minimal) void { // MARK: main()
 	settings.launchConfig.init();
 
 	const headless = settings.launchConfig.headlessServer;
+	if (headless) installSignalHandlers();
 
 	if (!headless) gui.initWindowList();
 	defer if (!headless) gui.deinitWindowList();
@@ -522,11 +539,40 @@ pub fn main(args: std.process.Init.Minimal) void { // MARK: main()
 	server.terrain.globalInit();
 	defer server.terrain.globalDeinit();
 
+	if (headless and settings.launchConfig.createIfMissing) {
+		bootstrapWorldIfMissing() catch |err| {
+			std.log.err("Failed to bootstrap world {s}: {s}", .{settings.launchConfig.autoEnterWorld, @errorName(err)});
+			@panic("World bootstrap failed");
+		};
+	}
+
 	if (headless) {
 		server.startFromExistingThread(settings.launchConfig.autoEnterWorld, null);
 	} else {
 		clientMain();
 	}
+}
+
+fn bootstrapWorldIfMissing() !void {
+	const worldName = settings.launchConfig.autoEnterWorld;
+	if (worldName.len == 0) {
+		std.log.err("createIfMissing is true but autoEnterWorld is empty.", .{});
+		return error.NoWorldName;
+	}
+	const savePath = std.fmt.allocPrint(stackAllocator.allocator, "saves/{s}", .{worldName}) catch unreachable;
+	defer stackAllocator.free(savePath);
+	if (files.cubyzDir().hasDir(savePath)) return;
+
+	const presetName = settings.launchConfig.worldPreset;
+	const preset = assets.worldPresets().get(presetName) orelse {
+		std.log.err("Unknown world preset: {s}", .{presetName});
+		return error.UnknownWorldPreset;
+	};
+
+	var worldSettings: server.world_zig.Settings = .defaults;
+	worldSettings.seed = settings.launchConfig.worldSeed orelse random.nextInt(u64, &seed);
+	try server.world_zig.tryCreateWorld(worldName, worldSettings, preset);
+	std.log.info("Created world {s} (preset {s}, seed {d}).", .{worldName, presetName, worldSettings.seed});
 }
 
 pub fn clientMain() void { // MARK: clientMain()

--- a/src/settings.zig
+++ b/src/settings.zig
@@ -214,6 +214,10 @@ pub const launchConfig = struct {
 
 	pub var vulkanTestingMode: bool = false;
 
+	pub var createIfMissing: bool = false;
+	pub var worldSeed: ?u64 = null;
+	pub var worldPreset: []const u8 = "cubyz:default";
+
 	pub fn init() void {
 		const zon: ZonElement = main.files.cwd().readToZon(main.stackAllocator, "launchConfig.zon") catch |err| blk: {
 			std.log.err("Could not read launchConfig.zon: {s}", .{@errorName(err)});
@@ -226,6 +230,9 @@ pub const launchConfig = struct {
 		autoEnterWorld = main.globalArena.dupe(u8, zon.get([]const u8, "autoEnterWorld", autoEnterWorld));
 		preferredAuthenticationAlgorithm = zon.get(main.network.authentication.KeyTypeEnum, "preferredAuthenticationAlgorithm", preferredAuthenticationAlgorithm);
 		vulkanTestingMode = zon.get(bool, "vulkanTestingMode", false);
+		createIfMissing = zon.get(bool, "createIfMissing", createIfMissing);
+		worldSeed = zon.get(?u64, "worldSeed", null);
+		worldPreset = main.globalArena.dupe(u8, zon.get([]const u8, "worldPreset", worldPreset));
 	}
 };
 


### PR DESCRIPTION
Make `headlessServer=true` actually self-sufficient: today the binary panics if the world named in `autoEnterWorld` doesn't exist on disk, because world creation only happens through the GUI's `tryCreateWorld()`. That makes it impossible to ship the server in an immutable container without manually pre-seeding `saves/<name>/`.

This adds three optional `launchConfig` fields and a small bootstrap branch in `main()`:

- `createIfMissing` (default `false`) — when `true` *and* `headlessServer` is set, the world named in `autoEnterWorld` is created via `tryCreateWorld()` if it doesn't already exist.
- `worldSeed: ?u64` — optional seed for the auto-created world; random if unset.
- `worldPreset: []const u8` — preset name, defaults to `cubyz:default`.

Existing saves are never touched (the new code path is gated on `files.cubyzDir().hasDir("saves/<name>")` returning `false`). The `launchConfig.zon` template generated by `build.zig` documents the new keys.

The same change also installs POSIX `SIGTERM`/`SIGINT` handlers (only when running headless, only on POSIX) that call `server.stop()`, so orchestrators (systemd, Kubernetes, ...) can roll the process cleanly and let chunks flush during the configured grace period. Desktop client behaviour is unchanged.

Motivated by packaging Cubyz as a containerised dedicated server; happy to drop or rework parts of the API if you'd prefer a different shape.