### PR TITLE
Add `ListUnmanaged.print`

### DIFF
--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -435,7 +435,8 @@ test "ListUnmanaged.print single call" {
 
 	list.print(main.stackAllocator, "foo {}", .{34});
 
-	try std.testing.expectEqualStrings(list.items, "foo 34");
+	try std.testing.expectEqualStrings("foo 34", list.items);
+	try std.testing.expect(list.items.len <= list.capacity);
 }
 
 test "ListUnmanaged.print with a string" {
@@ -444,7 +445,8 @@ test "ListUnmanaged.print with a string" {
 
 	list.print(main.stackAllocator, "foo {s}", .{"bar spam BUZZ"});
 
-	try std.testing.expectEqualStrings(list.items, "foo bar spam BUZZ");
+	try std.testing.expectEqualStrings("foo bar spam BUZZ", list.items);
+	try std.testing.expect(list.items.len <= list.capacity);
 }
 
 test "ListUnmanaged.print multiple writes" {
@@ -467,7 +469,8 @@ test "ListUnmanaged.print multiple writes" {
 		\\
 	;
 
-	try std.testing.expectEqualStrings(list.items, expected);
+	try std.testing.expectEqualStrings(expected, list.items);
+	try std.testing.expect(list.items.len <= list.capacity);
 }
 
 /// Holds multiple arrays sequentially in memory.

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -421,12 +421,28 @@ pub fn ListUnmanaged(comptime T: type) type {
 	};
 }
 
-test "ListUnmanaged.print single call" {
+test "ListUnmanaged.print single call, buffer not preserved" {
 	var list: ListUnmanaged(u8) = .{};
+	const oldAddress = list.items.ptr;
+	defer list.deinit(main.stackAllocator);
+
+	list.print(main.stackAllocator, "foo {d:.1}", .{34});
+	const newAddress = list.items.ptr;
+
+	try std.testing.expect(oldAddress != newAddress);
+	try std.testing.expectEqualStrings("foo 34", list.items);
+	try std.testing.expect(list.items.len <= list.capacity);
+}
+
+test "ListUnmanaged.print initCapacity, buffer preserved" {
+	var list: ListUnmanaged(u8) = .initCapacity(main.stackAllocator, 6);
+	const oldAddress = list.items.ptr;
 	defer list.deinit(main.stackAllocator);
 
 	list.print(main.stackAllocator, "foo {}", .{34});
+	const newAddress = list.items.ptr;
 
+	try std.testing.expect(oldAddress == newAddress);
 	try std.testing.expectEqualStrings("foo 34", list.items);
 	try std.testing.expect(list.items.len <= list.capacity);
 }
@@ -441,26 +457,30 @@ test "ListUnmanaged.print with a string" {
 	try std.testing.expect(list.items.len <= list.capacity);
 }
 
-test "ListUnmanaged.print multiple writes" {
+test "ListUnmanaged.print multiple prints" {
 	var list: ListUnmanaged(u8) = .{};
+	const oldAddress = list.items.ptr;
 	defer list.deinit(main.stackAllocator);
 
 	// The tricky part of the implementation is to correctly reassign buffer bounds, so every time
 	// we use the list as print destination, we want to make sure it retains normal list behavior
 	// by inserting a single element.
 	list.append(main.stackAllocator, '\n');
-	list.print(main.stackAllocator, "BarFooSpam {any}", .{[2]f32{0.3, 0.4}});
+	list.print(main.stackAllocator, "BarFooSpam {}", .{0.3});
 	list.append(main.stackAllocator, '\n');
 	list.print(main.stackAllocator, "fooBarSpam {}", .{34});
 	list.append(main.stackAllocator, '\n');
 
+	const newAddress = list.items.ptr;
+
 	const expected =
 		\\
-		\\BarFooSpam { 0.3, 0.4 }
+		\\BarFooSpam 0.3
 		\\fooBarSpam 34
 		\\
 	;
 
+	try std.testing.expect(oldAddress != newAddress);
 	try std.testing.expectEqualStrings(expected, list.items);
 	try std.testing.expect(list.items.len <= list.capacity);
 }

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -406,7 +406,24 @@ pub fn ListUnmanaged(comptime T: type) type {
 				self.items.len -= len - new_items.len;
 			}
 		}
+
+		pub fn print(self: *@This(), allocator: NeverFailingAllocator, comptime fmt: []const u8, args: anytype) void {
+			var writer = std.Io.Writer.Allocating.init(main.stackAllocator.allocator);
+			defer writer.deinit();
+			writer.writer.print(fmt, args) catch unreachable;
+			self.appendSlice(allocator, writer.written());
+		}
 	};
+}
+
+test "ListUnmanaged.print" {
+	const list: ListUnmanaged(u8) = .{};
+	defer list.deinit(main.stackAllocator);
+
+	list.print(main.stackAllocator, "foo {} ", .{33});
+	list.print(main.stackAllocator, "bar {}", .{34});
+
+	std.testing.expectEqualStrings(list.items, "foo 33 bar 34");
 }
 
 /// Holds multiple arrays sequentially in memory.

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -461,11 +461,11 @@ test "ListUnmanaged.print multiple writes" {
 	list.append(main.stackAllocator, '\n');
 
 	const expected =
-	\\
-	\\BarFooSpam { 0.3, 0.4 }
-	\\fooBarSpam 34
-	\\
-;
+		\\
+		\\BarFooSpam { 0.3, 0.4 }
+		\\fooBarSpam 34
+		\\
+	;
 
 	try std.testing.expectEqualStrings(list.items, expected);
 }

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -408,22 +408,66 @@ pub fn ListUnmanaged(comptime T: type) type {
 		}
 
 		pub fn print(self: *@This(), allocator: NeverFailingAllocator, comptime fmt: []const u8, args: anytype) void {
-			var writer = std.Io.Writer.Allocating.init(main.stackAllocator.allocator);
-			defer writer.deinit();
+			// It seems that concepts of capacity and current size are managed in a reversed mannor in Writer.
+			// The `writer.buffer` (a slice) contains what we call capacity as its `len`, while the current
+			// use of the buffer is stored by `writer.end` attribute.
+			var buffer = self.items;
+			buffer.len = self.capacity;
+
+			// Unfortinately there is no constructor that would allow us to use partially filled buffer.
+			// We have to just create a buffer from slice and move the end pointer afterwards.
+			var writer = std.Io.Writer.Allocating.initOwnedSlice(allocator.allocator, buffer);
+			writer.writer.end = self.items.len;
+
 			writer.writer.print(fmt, args) catch unreachable;
-			self.appendSlice(allocator, writer.written());
+
+			// We need to reassign the length and capacity, in case buffer was reallocated during printing.
+			// Mind that they have to be swapped again.
+			self.items = writer.written();
+			self.capacity = writer.writer.buffer.len;
 		}
 	};
 }
 
-test "ListUnmanaged.print" {
-	const list: ListUnmanaged(u8) = .{};
+test "ListUnmanaged.print single call" {
+	var list: ListUnmanaged(u8) = .{};
 	defer list.deinit(main.stackAllocator);
 
-	list.print(main.stackAllocator, "foo {} ", .{33});
-	list.print(main.stackAllocator, "bar {}", .{34});
+	list.print(main.stackAllocator, "foo {}", .{34});
 
-	std.testing.expectEqualStrings(list.items, "foo 33 bar 34");
+	try std.testing.expectEqualStrings(list.items, "foo 34");
+}
+
+test "ListUnmanaged.print with a string" {
+	var list: ListUnmanaged(u8) = .{};
+	defer list.deinit(main.stackAllocator);
+
+	list.print(main.stackAllocator, "foo {s}", .{"bar spam BUZZ"});
+
+	try std.testing.expectEqualStrings(list.items, "foo bar spam BUZZ");
+}
+
+test "ListUnmanaged.print multiple writes" {
+	var list: ListUnmanaged(u8) = .{};
+	defer list.deinit(main.stackAllocator);
+
+	// The tricky part of the implementation is to correctly reassign buffer bounds, so every time
+	// we use the list as print destination, we want to make sure it retains normal list behavior
+	// by inserting a single element.
+	list.append(main.stackAllocator, '\n');
+	list.print(main.stackAllocator, "BarFooSpam {}", .{main.vec.Vec2d{0.3, 0.4}});
+	list.append(main.stackAllocator, '\n');
+	list.print(main.stackAllocator, "fooBarSpam {}", .{34});
+	list.append(main.stackAllocator, '\n');
+
+	const expected =
+	\\
+	\\BarFooSpam { 0.3, 0.4 }
+	\\fooBarSpam 34
+	\\
+;
+
+	try std.testing.expectEqualStrings(list.items, expected);
 }
 
 /// Holds multiple arrays sequentially in memory.

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -408,7 +408,7 @@ pub fn ListUnmanaged(comptime T: type) type {
 		}
 
 		pub fn print(self: *@This(), allocator: NeverFailingAllocator, comptime fmt: []const u8, args: anytype) void {
-			// It seems that concepts of capacity and current size are managed in a reversed mannor in Writer.
+			// It seems that concepts of capacity and current size are swapped in Writer compared to our list.
 			// The `writer.buffer` (a slice) contains what we call capacity as its `len`, while the current
 			// use of the buffer is stored by `writer.end` attribute.
 			var buffer = self.items;

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -449,7 +449,7 @@ test "ListUnmanaged.print multiple writes" {
 	// we use the list as print destination, we want to make sure it retains normal list behavior
 	// by inserting a single element.
 	list.append(main.stackAllocator, '\n');
-	list.print(main.stackAllocator, "BarFooSpam {}", .{main.vec.Vec2d{0.3, 0.4}});
+	list.print(main.stackAllocator, "BarFooSpam {any}", .{[2]f32{0.3, 0.4}});
 	list.append(main.stackAllocator, '\n');
 	list.print(main.stackAllocator, "fooBarSpam {}", .{34});
 	list.append(main.stackAllocator, '\n');

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -408,23 +408,15 @@ pub fn ListUnmanaged(comptime T: type) type {
 		}
 
 		pub fn print(self: *@This(), allocator: NeverFailingAllocator, comptime fmt: []const u8, args: anytype) void {
-			// It seems that concepts of capacity and current size are swapped in Writer compared to our list.
-			// The `writer.buffer` (a slice) contains what we call capacity as its `len`, while the current
-			// use of the buffer is stored by `writer.end` attribute.
-			var buffer = self.items;
-			buffer.len = self.capacity;
-
-			// Unfortinately there is no constructor that would allow us to use partially filled buffer.
-			// We have to just create a buffer from slice and move the end pointer afterwards.
-			var writer = std.Io.Writer.Allocating.initOwnedSlice(allocator.allocator, buffer);
-			writer.writer.end = self.items.len;
+			var buffer: std.ArrayList(u8) = .{.items = self.items, .capacity = self.capacity};
+			var writer = std.Io.Writer.Allocating.fromArrayList(allocator.allocator, &buffer);
+			// We don't deinit, we will keep the ownership of the array later on!
 
 			writer.writer.print(fmt, args) catch unreachable;
+			buffer = writer.toArrayList();
 
-			// We need to reassign the length and capacity, in case buffer was reallocated during printing.
-			// Mind that they have to be swapped again.
-			self.items = writer.written();
-			self.capacity = writer.writer.buffer.len;
+			self.items = buffer.items;
+			self.capacity = buffer.capacity;
 		}
 	};
 }


### PR DESCRIPTION
This pull request adds `print` method to `ListUnmanaged` struct.
To avoid copying a leftover TODO from `print` function in `List`, it also makes an attempt on addressing it:

https://github.com/Argmaster/Cubyz/blob/ListUnmanaged.print/src/utils/list.zig#L213

> // TODO: Is there no easier way to make this without an extra copy?

We might as well just leave it for different time tho

Resolves: https://github.com/PixelGuys/Cubyz/pull/1425#discussion_r3132400987