### PR TITLE
Restructure the SDF system, splitting it into two phases

### DIFF
--- a/src/server/terrain/sdf.zig
+++ b/src/server/terrain/sdf.zig
@@ -11,7 +11,7 @@ const ZonElement = main.ZonElement;
 
 pub const SdfModel = struct { // MARK: SdfModel
 	data: *anyopaque,
-	generateFn: *const fn (self: *anyopaque, sdf: main.utils.Array3D(f32), interpolationSmoothness: main.utils.Array3D(f32), relPos: Vec3i, seed: u64, perimeter: f32, voxelSize: u31, voxelSizeShift: u5) void,
+	instantiateFn: *const fn (self: *anyopaque, arena: NeverFailingAllocator, seed: *u64) SdfInstance,
 	maxBiomeCenterDistance: f32,
 	minAmount: f32,
 	maxAmount: f32,
@@ -19,7 +19,7 @@ pub const SdfModel = struct { // MARK: SdfModel
 
 	const VTable = struct {
 		init: *const fn (parameters: ZonElement) ?*anyopaque,
-		generate: *const fn (self: *anyopaque, sdf: main.utils.Array3D(f32), interpolationSmoothness: main.utils.Array3D(f32), relPos: Vec3i, seed: u64, perimeter: f32, voxelSize: u31, voxelSizeShift: u5) void,
+		instantiate: *const fn (self: *anyopaque, arena: NeverFailingAllocator, seed: *u64) SdfInstance,
 	};
 
 	pub fn initModel(parameters: ZonElement) ?SdfModel {
@@ -34,7 +34,7 @@ pub const SdfModel = struct { // MARK: SdfModel
 		};
 		return .{
 			.data = vtableModel,
-			.generateFn = vtable.generate,
+			.instantiateFn = vtable.instantiate,
 			.maxBiomeCenterDistance = std.math.clamp(parameters.get(f32, "maxBiomeCenterDistance", terrain.CaveBiomeMap.CaveBiomeMapFragment.caveBiomeSize/2), 0, terrain.CaveBiomeMap.CaveBiomeMapFragment.caveBiomeSize/2),
 			.minAmount = parameters.get(f32, "minAmount", 1),
 			.maxAmount = parameters.get(f32, "maxAmount", parameters.get(f32, "minAmount", 1)),
@@ -42,17 +42,26 @@ pub const SdfModel = struct { // MARK: SdfModel
 		};
 	}
 
-	pub fn generate(self: SdfModel, sdf: main.utils.Array3D(f32), biomeMap: *const CaveBiomeMapView, interpolationSmoothness: main.utils.Array3D(f32), sdfPos: Vec3i, biomePos: Vec3i, seed: *u64, perimeter: f32, voxelSize: u31, voxelSizeShift: u5) void {
+	pub fn generate(self: SdfModel, sdf: main.utils.Array3D(f32), biomeMap: *const CaveBiomeMapView, interpolationSmoothness: main.utils.Array3D(f32), sdfPos: Vec3i, biomePos: Vec3i, seed: *u64, perimeter: comptime_int, voxelSize: u31, voxelSizeShift: u5) void {
 		const amount: usize = @floor(self.minAmount + main.random.nextFloat(seed)*(self.maxAmount - self.minAmount) + main.random.nextFloat(seed));
 		for (0..amount) |_| {
+			const arena = main.stackAllocator.createArena();
+			defer main.stackAllocator.destroyArena(arena);
 			const offsetDir = blk: while (true) {
 				const offset = main.random.nextFloatVectorSigned(3, seed);
 				if (vec.lengthSquare(offset) < 1) break :blk offset;
 			};
 			var pos = biomePos +% @as(Vec3i, @trunc(offsetDir*@as(Vec3f, @splat(self.maxBiomeCenterDistance))));
 			pos[2] +%= biomeMap.getCaveBiomeOffset(pos[0], pos[1]);
-			self.generateFn(self.data, sdf, interpolationSmoothness, pos -% sdfPos, seed.*, perimeter, voxelSize, voxelSizeShift);
+			var instance = self.instantiateFn(self.data, arena, seed);
+			instance.minBounds += pos;
+			instance.maxBounds += pos;
+			instance.generate(sdf, interpolationSmoothness, sdfPos, perimeter, voxelSize, voxelSizeShift);
 		}
+	}
+
+	pub fn instantiate(self: SdfModel, arena: NeverFailingAllocator, seed: *u64) SdfInstance {
+		return self.instantiateFn(self.data, arena, seed);
 	}
 
 	var modelRegistry: std.StringHashMapUnmanaged(VTable) = .{};
@@ -60,8 +69,40 @@ pub const SdfModel = struct { // MARK: SdfModel
 	pub fn registerGenerator(comptime Generator: type) void {
 		var self: VTable = undefined;
 		self.init = main.meta.castFunctionReturnToOptionalAnyopaque(Generator.init);
-		self.generate = main.meta.castFunctionSelfToAnyopaque(Generator.generate);
+		self.instantiate = main.meta.castFunctionSelfToAnyopaque(Generator.instantiate);
 		modelRegistry.put(main.globalArena.allocator, Generator.id, self) catch unreachable;
+	}
+};
+
+pub const SdfInstance = struct { // MARK: SdfInstance
+	data: *anyopaque,
+	generateFn: *const fn (self: *anyopaque, samplePos: Vec3f) f32,
+	minBounds: Vec3i,
+	maxBounds: Vec3i,
+	centerPosOffset: Vec3f,
+
+	pub fn generate(self: SdfInstance, sdf: main.utils.Array3D(f32), interpolationSmoothness: main.utils.Array3D(f32), sdfPos: Vec3i, perimeter: comptime_int, voxelSize: u31, voxelSizeShift: u5) void {
+		const dimVector: Vec3i = @intCast(@Vector(3, u32){sdf.width*voxelSize, sdf.depth*voxelSize, sdf.height*voxelSize});
+		const mask: @Vector(3, u31) = @splat(voxelSize - 1);
+		const min = @max(Vec3i{0, 0, 0}, self.minBounds -% @as(Vec3i, @splat(perimeter)) -% sdfPos) & ~mask;
+		const max = @min(dimVector, self.maxBounds +% @as(Vec3i, @splat(perimeter)) -% sdfPos) + mask & ~@as(Vec3i, mask);
+		if (@reduce(.Or, max <= min)) return;
+
+		var x = min[0] & ~(voxelSize - 1);
+		while (x != max[0]) : (x += voxelSize) {
+			var y = min[1] & ~(voxelSize - 1);
+			while (y != max[1]) : (y += voxelSize) {
+				var z = min[2] & ~(voxelSize - 1);
+				while (z < max[2]) : (z += voxelSize) {
+					const pos = @as(Vec3f, @floatFromInt(Vec3i{x, y, z} +% sdfPos -% self.minBounds)) - self.centerPosOffset;
+					const sdfSample = self.generateFn(self.data, pos);
+					if (sdfSample > perimeter) continue;
+
+					const out = sdf.ptr(x >> voxelSizeShift, y >> voxelSizeShift, z >> voxelSizeShift);
+					out.* = smoothUnion(sdfSample, out.*, interpolationSmoothness.get(x >> voxelSizeShift, y >> voxelSizeShift, z >> voxelSizeShift));
+				}
+			}
+		}
 	}
 };
 

--- a/src/server/terrain/sdf_models/cylinder.zig
+++ b/src/server/terrain/sdf_models/cylinder.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 
 const main = @import("main");
 const Array3D = main.utils.Array3D;
+const NeverFailingAllocator = main.heap.NeverFailingAllocator;
 const sdf = main.server.terrain.sdf;
+const SdfInstance = sdf.SdfInstance;
 const vec = main.vec;
 const Vec2f = vec.Vec2f;
 const Vec2i = vec.Vec2i;
@@ -17,6 +19,11 @@ maxRadius: f32,
 minHalfHeight: f32,
 maxHalfHeight: f32,
 
+const Instance = struct {
+	radius: f32,
+	halfHeight: f32,
+};
+
 pub fn init(zon: ZonElement) ?*@This() {
 	const result = main.worldArena.create(@This());
 	result.minRadius = zon.get(f32, "minRadius", 16);
@@ -26,33 +33,24 @@ pub fn init(zon: ZonElement) ?*@This() {
 	return result;
 }
 
-pub fn generate(self: *@This(), output: main.utils.Array3D(f32), interpolationSmoothness: main.utils.Array3D(f32), relPos: Vec3i, _seed: u64, perimeter: f32, voxelSize: u31, voxelSizeShift: u5) void {
-	var seed = _seed;
-	const radius = self.minRadius + (self.maxRadius - self.minRadius)*main.random.nextFloat(&seed);
-	const halfHeight = self.minHalfHeight + (self.maxHalfHeight - self.minHalfHeight)*main.random.nextFloat(&seed);
+pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {
+	const instance = arena.create(Instance);
+	instance.* = .{
+		.radius = self.minRadius + (self.maxRadius - self.minRadius)*main.random.nextFloat(seed),
+		.halfHeight = self.minHalfHeight + (self.maxHalfHeight - self.minHalfHeight)*main.random.nextFloat(seed),
+	};
+	const bounds: Vec3f = .{instance.radius, instance.radius, instance.halfHeight};
+	return .{
+		.data = instance,
+		.generateFn = main.meta.castFunctionSelfToAnyopaque(generate),
+		.minBounds = @floor(-bounds),
+		.maxBounds = @ceil(bounds),
+		.centerPosOffset = @ceil(bounds),
+	};
+}
 
-	const relPosF32: Vec3f = @floatFromInt(relPos);
-	const dimVector: Vec3f = @floatFromInt(@Vector(3, u32){output.width*voxelSize, output.depth*voxelSize, output.height*voxelSize});
-	const min = @max(@as(Vec3f, @splat(0)), relPosF32 - Vec3f{radius, radius, halfHeight} - @as(Vec3f, @splat(perimeter)));
-	const max = @min(dimVector, relPosF32 + Vec3f{radius, radius, halfHeight} + @as(Vec3f, @splat(perimeter)));
-
-	const minInt: @Vector(3, u31) = @floor(min);
-	const maxInt: Vec3i = @ceil(max);
-
-	var x = minInt[0] & ~(voxelSize - 1);
-	while (x < maxInt[0]) : (x += voxelSize) {
-		var y = minInt[1] & ~(voxelSize - 1);
-		while (y < maxInt[1]) : (y += voxelSize) {
-			var z = minInt[2] & ~(voxelSize - 1);
-			while (z < maxInt[2]) : (z += voxelSize) {
-				const circleSdf: f32 = vec.length(@as(Vec2f, @floatFromInt(Vec2i{x, y} - vec.xy(relPos)))) - radius;
-				const heightSdf: f32 = @as(f32, @floatFromInt(@abs(z - relPos[2]))) - halfHeight;
-				const fullSdf = vec.length(@max(Vec2f{heightSdf, circleSdf}, Vec2f{0, 0})) + @min(0, @max(circleSdf, heightSdf));
-				if (fullSdf > perimeter) continue;
-
-				const out = output.ptr(x >> voxelSizeShift, y >> voxelSizeShift, z >> voxelSizeShift);
-				out.* = sdf.smoothUnion(fullSdf, out.*, interpolationSmoothness.get(x >> voxelSizeShift, y >> voxelSizeShift, z >> voxelSizeShift));
-			}
-		}
-	}
+pub fn generate(self: *Instance, samplePos: Vec3f) f32 {
+	const circleSdf: f32 = vec.length(vec.xy(samplePos)) - self.radius;
+	const heightSdf: f32 = @abs(samplePos[2]) - self.halfHeight;
+	return vec.length(@max(Vec2f{heightSdf, circleSdf}, Vec2f{0, 0})) + @min(0, @max(circleSdf, heightSdf));
 }

--- a/src/server/terrain/sdf_models/partial_sphere.zig
+++ b/src/server/terrain/sdf_models/partial_sphere.zig
@@ -36,15 +36,19 @@ pub fn init(zon: ZonElement) ?*@This() {
 
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {
 	const instance = arena.create(Instance);
-	instance.* = .{.radius = self.minRadius + (self.maxRadius - self.minRadius)*main.random.nextFloat(seed), .cutDirection = vec.normalize(self.cutDirection + main.random.nextFloatVectorSigned(3, seed)*@as(Vec3f, @splat(self.cutDirectionRandomness))), .cutPercentage = self.cutPercentage};
-	const bounds: Vec3f = @splat(instance.radius); // TODO: Could be tighter
-	const offset: Vec3f = @splat(0); // TODO: Offset it to do the thing
+	instance.* = .{
+		.radius = self.minRadius + (self.maxRadius - self.minRadius)*main.random.nextFloat(seed),
+		.cutDirection = vec.normalize(self.cutDirection + main.random.nextFloatVectorSigned(3, seed)*@as(Vec3f, @splat(self.cutDirectionRandomness))),
+		.cutPercentage = self.cutPercentage,
+	};
+	const bounds: Vec3f = @splat(instance.radius);
+	const offset: Vec3f = instance.cutDirection*@as(Vec3f, @splat(self.cutPercentage/2*instance.radius));
 	return .{
 		.data = instance,
 		.generateFn = main.meta.castFunctionSelfToAnyopaque(generate),
 		.minBounds = @floor(-bounds + offset),
 		.maxBounds = @ceil(bounds + offset),
-		.centerPosOffset = @ceil(bounds + offset),
+		.centerPosOffset = @ceil(bounds),
 	};
 }
 

--- a/src/server/terrain/sdf_models/partial_sphere.zig
+++ b/src/server/terrain/sdf_models/partial_sphere.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 
 const main = @import("main");
 const Array3D = main.utils.Array3D;
+const NeverFailingAllocator = main.heap.NeverFailingAllocator;
 const sdf = main.server.terrain.sdf;
+const SdfInstance = sdf.SdfInstance;
 const vec = main.vec;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
@@ -16,6 +18,12 @@ cutPercentage: f32,
 cutDirection: Vec3f,
 cutDirectionRandomness: f32,
 
+const Instance = struct {
+	radius: f32,
+	cutPercentage: f32,
+	cutDirection: Vec3f,
+};
+
 pub fn init(zon: ZonElement) ?*@This() {
 	const result = main.worldArena.create(@This());
 	result.minRadius = zon.get(f32, "minRadius", 16);
@@ -26,40 +34,22 @@ pub fn init(zon: ZonElement) ?*@This() {
 	return result;
 }
 
-pub fn generate(self: *@This(), output: main.utils.Array3D(f32), interpolationSmoothness: main.utils.Array3D(f32), relPos: Vec3i, _seed: u64, _perimeter: f32, voxelSize: u31, voxelSizeShift: u5) void {
-	const perimeter = _perimeter + @as(f32, @floatFromInt(voxelSize));
-	var seed = _seed;
-	const radius = self.minRadius + (self.maxRadius - self.minRadius)*main.random.nextFloat(&seed);
+pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {
+	const instance = arena.create(Instance);
+	instance.* = .{.radius = self.minRadius + (self.maxRadius - self.minRadius)*main.random.nextFloat(seed), .cutDirection = vec.normalize(self.cutDirection + main.random.nextFloatVectorSigned(3, seed)*@as(Vec3f, @splat(self.cutDirectionRandomness))), .cutPercentage = self.cutPercentage};
+	const bounds: Vec3f = @splat(instance.radius); // TODO: Could be tighter
+	const offset: Vec3f = @splat(0); // TODO: Offset it to do the thing
+	return .{
+		.data = instance,
+		.generateFn = main.meta.castFunctionSelfToAnyopaque(generate),
+		.minBounds = @floor(-bounds + offset),
+		.maxBounds = @ceil(bounds + offset),
+		.centerPosOffset = @ceil(bounds + offset),
+	};
+}
 
-	var relPosF32: Vec3f = @floatFromInt(relPos);
-	const cutDirection = vec.normalize(self.cutDirection + main.random.nextFloatVectorSigned(3, &seed)*@as(Vec3f, @splat(self.cutDirectionRandomness)));
-	relPosF32 += cutDirection*@as(Vec3f, @splat(self.cutPercentage/2*radius));
-	const dimVector: Vec3f = @floatFromInt(@Vector(3, u32){output.width*voxelSize, output.depth*voxelSize, output.height*voxelSize});
-	const min = @max(@as(Vec3f, @splat(0)), relPosF32 - @as(Vec3f, @splat(radius + perimeter)));
-	const max = @min(dimVector, relPosF32 + @as(Vec3f, @splat(radius + perimeter)));
-
-	const minInt: @Vector(3, u31) = @floor(min);
-	const maxInt: Vec3i = @ceil(max);
-
-	var x = minInt[0] & ~(voxelSize - 1);
-	while (x < maxInt[0]) : (x += voxelSize) {
-		var y = minInt[1] & ~(voxelSize - 1);
-		while (y < maxInt[1]) : (y += voxelSize) {
-			var z = minInt[2] & ~(voxelSize - 1);
-			while (z < maxInt[2]) : (z += voxelSize) {
-				const centerDistance = @as(Vec3f, @floatFromInt(Vec3i{x, y, z})) - relPosF32;
-				const distanceSquare: f32 = vec.lengthSquare(centerDistance);
-				if (distanceSquare > (radius + perimeter)*(radius + perimeter)) continue;
-
-				const directionDistance = vec.dot(cutDirection, centerDistance) - radius + self.cutPercentage*radius*2;
-				if (directionDistance > perimeter) continue;
-
-				const sphereSdf = @sqrt(distanceSquare) - radius;
-				const fullSdf: f32 = sdf.intersection(sphereSdf, directionDistance);
-
-				const out = output.ptr(x >> voxelSizeShift, y >> voxelSizeShift, z >> voxelSizeShift);
-				out.* = sdf.smoothUnion(fullSdf, out.*, interpolationSmoothness.get(x >> voxelSizeShift, y >> voxelSizeShift, z >> voxelSizeShift));
-			}
-		}
-	}
+pub fn generate(self: *Instance, samplePos: Vec3f) f32 {
+	const sphereSdf = vec.length(samplePos) - self.radius;
+	const planeSdf = vec.dot(self.cutDirection, samplePos) - self.radius + self.cutPercentage*self.radius*2;
+	return sdf.intersection(sphereSdf, planeSdf);
 }

--- a/src/server/terrain/sdf_models/rectangular_cuboid.zig
+++ b/src/server/terrain/sdf_models/rectangular_cuboid.zig
@@ -41,6 +41,6 @@ pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) Sdf
 }
 
 pub fn generate(self: *Instance, samplePos: Vec3f) f32 {
-	const dimensionalSdf: Vec3f = samplePos - self.radii;
+	const dimensionalSdf: Vec3f = @abs(samplePos) - self.radii;
 	return vec.length(@max(dimensionalSdf, @as(Vec3f, @splat(0)))) + @min(0, @max(dimensionalSdf[0], dimensionalSdf[1], dimensionalSdf[2]));
 }

--- a/src/server/terrain/sdf_models/rectangular_cuboid.zig
+++ b/src/server/terrain/sdf_models/rectangular_cuboid.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 
 const main = @import("main");
 const Array3D = main.utils.Array3D;
+const NeverFailingAllocator = main.heap.NeverFailingAllocator;
 const sdf = main.server.terrain.sdf;
+const SdfInstance = sdf.SdfInstance;
 const vec = main.vec;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
@@ -13,6 +15,10 @@ pub const id = "cubyz:rectangular_cuboid";
 minRadii: Vec3f,
 maxRadii: Vec3f,
 
+const Instance = struct {
+	radii: Vec3f,
+};
+
 pub fn init(zon: ZonElement) ?*@This() {
 	const result = main.worldArena.create(@This());
 	result.minRadii = zon.get(Vec3f, "minSideLengths", @splat(32))/@as(Vec3f, @splat(2));
@@ -20,31 +26,21 @@ pub fn init(zon: ZonElement) ?*@This() {
 	return result;
 }
 
-pub fn generate(self: *@This(), output: main.utils.Array3D(f32), interpolationSmoothness: main.utils.Array3D(f32), relPos: Vec3i, _seed: u64, perimeter: f32, voxelSize: u31, voxelSizeShift: u5) void {
-	var seed = _seed;
-	const radii = self.minRadii + (self.maxRadii - self.minRadii)*main.random.nextFloatVector(3, &seed);
+pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {
+	const instance = arena.create(Instance);
+	instance.* = .{
+		.radii = self.minRadii + (self.maxRadii - self.minRadii)*main.random.nextFloatVector(3, seed),
+	};
+	return .{
+		.data = instance,
+		.generateFn = main.meta.castFunctionSelfToAnyopaque(generate),
+		.minBounds = @floor(-instance.radii),
+		.maxBounds = @ceil(instance.radii),
+		.centerPosOffset = @ceil(instance.radii),
+	};
+}
 
-	const relPosF32: Vec3f = @floatFromInt(relPos);
-	const dimVector: Vec3f = @floatFromInt(@Vector(3, u32){output.width*voxelSize, output.depth*voxelSize, output.height*voxelSize});
-	const min = @max(@as(Vec3f, @splat(0)), relPosF32 - radii - @as(Vec3f, @splat(perimeter)));
-	const max = @min(dimVector, relPosF32 + radii + @as(Vec3f, @splat(perimeter)));
-
-	const minInt: @Vector(3, u31) = @floor(min);
-	const maxInt: Vec3i = @ceil(max);
-
-	var x = minInt[0] & ~(voxelSize - 1);
-	while (x < maxInt[0]) : (x += voxelSize) {
-		var y = minInt[1] & ~(voxelSize - 1);
-		while (y < maxInt[1]) : (y += voxelSize) {
-			var z = minInt[2] & ~(voxelSize - 1);
-			while (z < maxInt[2]) : (z += voxelSize) {
-				const dimensionalSdf: Vec3f = @as(Vec3f, @floatFromInt(@abs(Vec3i{x, y, z} - relPos))) - radii;
-				const fullSdf = vec.length(@max(dimensionalSdf, @as(Vec3f, @splat(0)))) + @min(0, @max(dimensionalSdf[0], dimensionalSdf[1], dimensionalSdf[2]));
-				if (fullSdf > perimeter) continue;
-
-				const out = output.ptr(x >> voxelSizeShift, y >> voxelSizeShift, z >> voxelSizeShift);
-				out.* = sdf.smoothUnion(fullSdf, out.*, interpolationSmoothness.get(x >> voxelSizeShift, y >> voxelSizeShift, z >> voxelSizeShift));
-			}
-		}
-	}
+pub fn generate(self: *Instance, samplePos: Vec3f) f32 {
+	const dimensionalSdf: Vec3f = samplePos - self.radii;
+	return vec.length(@max(dimensionalSdf, @as(Vec3f, @splat(0)))) + @min(0, @max(dimensionalSdf[0], dimensionalSdf[1], dimensionalSdf[2]));
 }

--- a/src/server/terrain/sdf_models/sphere.zig
+++ b/src/server/terrain/sdf_models/sphere.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 
 const main = @import("main");
 const Array3D = main.utils.Array3D;
+const NeverFailingAllocator = main.heap.NeverFailingAllocator;
 const sdf = main.server.terrain.sdf;
+const SdfInstance = sdf.SdfInstance;
 const vec = main.vec;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
@@ -13,6 +15,10 @@ pub const id = "cubyz:sphere";
 minRadius: f32,
 maxRadius: f32,
 
+const Instance = struct {
+	radius: f32,
+};
+
 pub fn init(zon: ZonElement) ?*@This() {
 	const result = main.worldArena.create(@This());
 	result.minRadius = zon.get(f32, "minRadius", 16);
@@ -20,32 +26,20 @@ pub fn init(zon: ZonElement) ?*@This() {
 	return result;
 }
 
-pub fn generate(self: *@This(), output: main.utils.Array3D(f32), interpolationSmoothness: main.utils.Array3D(f32), relPos: Vec3i, _seed: u64, perimeter: f32, voxelSize: u31, voxelSizeShift: u5) void {
-	var seed = _seed;
-	const radius = self.minRadius + (self.maxRadius - self.minRadius)*main.random.nextFloat(&seed);
+pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {
+	const instance = arena.create(Instance);
+	instance.* = .{
+		.radius = self.minRadius + (self.maxRadius - self.minRadius)*main.random.nextFloat(seed),
+	};
+	return .{
+		.data = instance,
+		.generateFn = main.meta.castFunctionSelfToAnyopaque(generate),
+		.minBounds = @splat(@floor(-instance.radius)),
+		.maxBounds = @splat(@ceil(instance.radius)),
+		.centerPosOffset = @splat(@ceil(instance.radius)),
+	};
+}
 
-	const relPosF32: Vec3f = @floatFromInt(relPos);
-	const dimVector: Vec3f = @floatFromInt(@Vector(3, u32){output.width*voxelSize, output.depth*voxelSize, output.height*voxelSize});
-	const min = @max(@as(Vec3f, @splat(0)), relPosF32 - @as(Vec3f, @splat(radius + perimeter)));
-	const max = @min(dimVector, relPosF32 + @as(Vec3f, @splat(radius + perimeter)));
-
-	const minInt: @Vector(3, u31) = @floor(min);
-	const maxInt: Vec3i = @ceil(max);
-
-	var x = minInt[0] & ~(voxelSize - 1);
-	while (x < maxInt[0]) : (x += voxelSize) {
-		var y = minInt[1] & ~(voxelSize - 1);
-		while (y < maxInt[1]) : (y += voxelSize) {
-			var z = minInt[2] & ~(voxelSize - 1);
-			while (z < maxInt[2]) : (z += voxelSize) {
-				const distanceSquare: f32 = @floatFromInt((x - relPos[0])*(x - relPos[0]) + (y - relPos[1])*(y - relPos[1]) + (z - relPos[2])*(z - relPos[2]));
-				if (distanceSquare > (radius + perimeter)*(radius + perimeter)) continue;
-
-				const sphereSdf = @sqrt(distanceSquare) - radius;
-
-				const out = output.ptr(x >> voxelSizeShift, y >> voxelSizeShift, z >> voxelSizeShift);
-				out.* = sdf.smoothUnion(sphereSdf, out.*, interpolationSmoothness.get(x >> voxelSizeShift, y >> voxelSizeShift, z >> voxelSizeShift));
-			}
-		}
-	}
+pub fn generate(self: *Instance, samplePos: Vec3f) f32 {
+	return vec.length(samplePos) - self.radius;
 }

--- a/src/server/terrain/sdf_models/torus.zig
+++ b/src/server/terrain/sdf_models/torus.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 
 const main = @import("main");
 const Array3D = main.utils.Array3D;
+const NeverFailingAllocator = main.heap.NeverFailingAllocator;
 const sdf = main.server.terrain.sdf;
+const SdfInstance = sdf.SdfInstance;
 const vec = main.vec;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
@@ -15,6 +17,11 @@ maxRadius: f32,
 minThickness: f32,
 maxThickness: f32,
 
+const Instance = struct {
+	radius: f32,
+	thickness: f32,
+};
+
 pub fn init(zon: ZonElement) ?*@This() {
 	const result = main.worldArena.create(@This());
 	result.minRadius = zon.get(f32, "minRadius", 16);
@@ -24,36 +31,24 @@ pub fn init(zon: ZonElement) ?*@This() {
 	return result;
 }
 
-pub fn generate(self: *@This(), output: main.utils.Array3D(f32), interpolationSmoothness: main.utils.Array3D(f32), relPos: Vec3i, _seed: u64, perimeter: f32, voxelSize: u31, voxelSizeShift: u5) void {
-	var seed = _seed;
-	const radius = self.minRadius + (self.maxRadius - self.minRadius)*main.random.nextFloat(&seed);
-	const thickness = self.minThickness + (self.maxThickness - self.minThickness)*main.random.nextFloat(&seed);
+pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {
+	const instance = arena.create(Instance);
+	instance.* = .{
+		.radius = self.minRadius + (self.maxRadius - self.minRadius)*main.random.nextFloat(seed),
+		.thickness = self.minThickness + (self.maxThickness - self.minThickness)*main.random.nextFloat(seed),
+	};
+	const bounds: Vec3f = .{instance.radius + instance.thickness, instance.radius + instance.thickness, instance.thickness};
+	return .{
+		.data = instance,
+		.generateFn = main.meta.castFunctionSelfToAnyopaque(generate),
+		.minBounds = @floor(-bounds),
+		.maxBounds = @ceil(bounds),
+		.centerPosOffset = @ceil(bounds),
+	};
+}
 
-	const relPosF32: Vec3f = @floatFromInt(relPos);
-	const dimVector: Vec3f = @floatFromInt(@Vector(3, u32){output.width*voxelSize, output.depth*voxelSize, output.height*voxelSize});
-	const min = @max(@as(Vec3f, @splat(0)), relPosF32 - Vec3f{radius + thickness + perimeter, radius + thickness + perimeter, thickness + perimeter});
-	const max = @min(dimVector, relPosF32 + Vec3f{radius + thickness + perimeter, radius + thickness + perimeter, thickness + perimeter});
-
-	const minInt: @Vector(3, u31) = @floor(min);
-	const maxInt: Vec3i = @ceil(max);
-
-	var x = minInt[0] & ~(voxelSize - 1);
-	while (x < maxInt[0]) : (x += voxelSize) {
-		var y = minInt[1] & ~(voxelSize - 1);
-		while (y < maxInt[1]) : (y += voxelSize) {
-			var z = minInt[2] & ~(voxelSize - 1);
-			while (z < maxInt[2]) : (z += voxelSize) {
-				const xDifference: f32 = @floatFromInt(x - relPos[0]);
-				const yDifference: f32 = @floatFromInt(y - relPos[1]);
-				const zDifference: f32 = @floatFromInt(z - relPos[2]);
-				const radialDistance: f32 = @sqrt(xDifference*xDifference + yDifference*yDifference);
-				const adjustedDistance: f32 = radialDistance - radius;
-				const toroidalDistance: f32 = @sqrt(adjustedDistance*adjustedDistance + zDifference*zDifference) - thickness;
-				if (toroidalDistance - perimeter > 0) continue;
-
-				const out = output.ptr(x >> voxelSizeShift, y >> voxelSizeShift, z >> voxelSizeShift);
-				out.* = sdf.smoothUnion(toroidalDistance, out.*, interpolationSmoothness.get(x >> voxelSizeShift, y >> voxelSizeShift, z >> voxelSizeShift));
-			}
-		}
-	}
+pub fn generate(self: *Instance, samplePos: Vec3f) f32 {
+	const radialDistance: f32 = @sqrt(samplePos[0]*samplePos[0] + samplePos[1]*samplePos[1]);
+	const adjustedDistance: f32 = radialDistance - self.radius;
+	return @sqrt(adjustedDistance*adjustedDistance + samplePos[2]*samplePos[2]) - self.thickness;
 }


### PR DESCRIPTION
This has a notable performance cost, adding the extra virtual function call adds about 30% to the performance cost. But I think it's worth it for the flexibility we get (#2751 #2885)

On the other hand, some of that cost can now be offset by generating the SDF instances in a separately cached data structure together with large structures (similar to how it's done in the small structure map).

Also noteworthy is that the sdf implementations are now a lot simpler, since they don't need to iterate the volume anymore.

fixes #2854