### PR TITLE
Require sickles for selecting and collecting foliage (only config changes)

### DIFF
--- a/assets/cubyz/blocks/bluebells.zig.zon
+++ b/assets/cubyz/blocks/bluebells.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x121012,

--- a/assets/cubyz/blocks/bolete.zig.zon
+++ b/assets/cubyz/blocks/bolete.zig.zon
@@ -2,8 +2,9 @@
 	.tags = .{.cuttable, .mushroom},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
 	.replaceable = true,
 	.viewThrough = true,
 	.degradable = true,

--- a/assets/cubyz/blocks/branch/leafy/baobab.zig.zon
+++ b/assets/cubyz/blocks/branch/leafy/baobab.zig.zon
@@ -6,7 +6,8 @@
 		},
 	},
 	.drops = .{
-		.{.items = .{"cubyz:leaves/baobab", "cubyz:branch/baobab"}},
+		.{.items = .{"cubyz:branch/baobab"}},
+		.{.items = .{"cubyz:leaves/baobab"}, .allowedToolTags = .{.cuttable}},
 	},
 	.texture = "cubyz:leaves/baobab",
 	.texture6 = "cubyz:branch/baobab/dot",

--- a/assets/cubyz/blocks/branch/leafy/birch.zig.zon
+++ b/assets/cubyz/blocks/branch/leafy/birch.zig.zon
@@ -6,7 +6,8 @@
 		},
 	},
 	.drops = .{
-		.{.items = .{"cubyz:leaves/birch", "cubyz:branch/birch"}},
+		.{.items = .{"cubyz:branch/birch"}},
+		.{.items = .{"cubyz:leaves/birch"}, .allowedToolTags = .{.cuttable}},
 	},
 	.texture = "cubyz:leaves/birch",
 	.texture6 = "cubyz:branch/birch/dot",

--- a/assets/cubyz/blocks/branch/leafy/cirrus.zig.zon
+++ b/assets/cubyz/blocks/branch/leafy/cirrus.zig.zon
@@ -6,7 +6,8 @@
 		},
 	},
 	.drops = .{
-		.{.items = .{"cubyz:leaves/cirrus", "cubyz:branch/cirrus"}},
+		.{.items = .{"cubyz:branch/cirrus"}},
+		.{.items = .{"cubyz:leaves/cirrus"}, .allowedToolTags = .{.cuttable}},
 	},
 	.texture = "cubyz:leaves/cirrus",
 	.texture6 = "cubyz:branch/cirrus/dot",

--- a/assets/cubyz/blocks/branch/leafy/mahogany.zig.zon
+++ b/assets/cubyz/blocks/branch/leafy/mahogany.zig.zon
@@ -6,7 +6,8 @@
 		},
 	},
 	.drops = .{
-		.{.items = .{"cubyz:leaves/mahogany", "cubyz:branch/mahogany"}},
+		.{.items = .{"cubyz:branch/mahogany"}},
+		.{.items = .{"cubyz:leaves/mahogany"}, .allowedToolTags = .{.cuttable}},
 	},
 	.texture = "cubyz:leaves/mahogany",
 	.texture6 = "cubyz:branch/mahogany/dot",

--- a/assets/cubyz/blocks/branch/leafy/oak.zig.zon
+++ b/assets/cubyz/blocks/branch/leafy/oak.zig.zon
@@ -6,7 +6,8 @@
 		},
 	},
 	.drops = .{
-		.{.items = .{"cubyz:leaves/oak", "cubyz:branch/oak"}},
+		.{.items = .{"cubyz:branch/oak"}},
+		.{.items = .{"cubyz:leaves/oak"}, .allowedToolTags = .{.cuttable}},
 	},
 	.texture = "cubyz:leaves/oak",
 	.texture6 = "cubyz:branch/oak/dot",

--- a/assets/cubyz/blocks/branch/leafy/palm.zig.zon
+++ b/assets/cubyz/blocks/branch/leafy/palm.zig.zon
@@ -11,7 +11,8 @@
 		},
 	},
 	.drops = .{
-		.{.items = .{"cubyz:leaves/palm", "cubyz:branch/palm"}},
+		.{.items = .{"cubyz:branch/palm"}},
+		.{.items = .{"cubyz:leaves/palm"}, .allowedToolTags = .{.cuttable}},
 	},
 	.texture = "cubyz:leaves/palm",
 	.texture12 = "cubyz:leaves/palm_hanging",

--- a/assets/cubyz/blocks/branch/leafy/pine.zig.zon
+++ b/assets/cubyz/blocks/branch/leafy/pine.zig.zon
@@ -6,7 +6,8 @@
 		},
 	},
 	.drops = .{
-		.{.items = .{"cubyz:leaves/pine", "cubyz:branch/pine"}},
+		.{.items = .{"cubyz:branch/pine"}},
+		.{.items = .{"cubyz:leaves/pine"}, .allowedToolTags = .{.cuttable}},
 	},
 	.texture = "cubyz:leaves/pine",
 	.texture6 = "cubyz:branch/pine/dot",

--- a/assets/cubyz/blocks/branch/leafy/willow.zig.zon
+++ b/assets/cubyz/blocks/branch/leafy/willow.zig.zon
@@ -6,7 +6,8 @@
 		},
 	},
 	.drops = .{
-		.{.items = .{"cubyz:leaves/willow", "cubyz:branch/willow"}},
+		.{.items = .{"cubyz:branch/willow"}},
+		.{.items = .{"cubyz:leaves/willow"}, .allowedToolTags = .{.cuttable}},
 	},
 	.texture = "cubyz:leaves/willow",
 	.texture6 = "cubyz:branch/willow/dot",

--- a/assets/cubyz/blocks/cactus_flower.zig.zon
+++ b/assets/cubyz/blocks/cactus_flower.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.collide = false,
 	.alwaysViewThrough = true,

--- a/assets/cubyz/blocks/castilleja.zig.zon
+++ b/assets/cubyz/blocks/castilleja.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,

--- a/assets/cubyz/blocks/cold_grass_vegetation.zig.zon
+++ b/assets/cubyz/blocks/cold_grass_vegetation.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,
@@ -13,7 +15,6 @@
 	.item = .{
 		.texture = "cold_grass.png",
 	},
-	.replaceable = true,
 	.lodReplacement = "cubyz:air",
 	.onUpdate = .{
 		.type = .checkSupportBlocks,

--- a/assets/cubyz/blocks/daffodil.zig.zon
+++ b/assets/cubyz/blocks/daffodil.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,

--- a/assets/cubyz/blocks/daisies.zig.zon
+++ b/assets/cubyz/blocks/daisies.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.collide = false,
 	.alwaysViewThrough = true,

--- a/assets/cubyz/blocks/dandelions.zig.zon
+++ b/assets/cubyz/blocks/dandelions.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.collide = false,
 	.alwaysViewThrough = true,

--- a/assets/cubyz/blocks/dead_leaf_pile.zig.zon
+++ b/assets/cubyz/blocks/dead_leaf_pile.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable, .leaf},
 	.blockHealth = 0.1,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.collide = false,
 	.alwaysViewThrough = true,

--- a/assets/cubyz/blocks/dry_grass_vegetation.zig.zon
+++ b/assets/cubyz/blocks/dry_grass_vegetation.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,
@@ -13,7 +15,6 @@
 	.item = .{
 		.texture = "dry_grass.png",
 	},
-	.replaceable = true,
 	.lodReplacement = "cubyz:air",
 	.onUpdate = .{
 		.type = .checkSupportBlocks,

--- a/assets/cubyz/blocks/duckweed.zig.zon
+++ b/assets/cubyz/blocks/duckweed.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.1,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.collide = false,
 	.alwaysViewThrough = true,

--- a/assets/cubyz/blocks/fern.zig.zon
+++ b/assets/cubyz/blocks/fern.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,
@@ -13,7 +15,6 @@
 	.item = .{
 		.texture = "fern.png",
 	},
-	.replaceable = true,
 	.lodReplacement = "cubyz:air",
 	.onUpdate = .{
 		.type = .checkSupportBlocks,

--- a/assets/cubyz/blocks/glimmergill.zig.zon
+++ b/assets/cubyz/blocks/glimmergill.zig.zon
@@ -2,8 +2,9 @@
 	.tags = .{.cuttable, .mushroom},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/grass/vegetation/dew.zig.zon
+++ b/assets/cubyz/blocks/grass/vegetation/dew.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,

--- a/assets/cubyz/blocks/grass/vegetation/sky.zig.zon
+++ b/assets/cubyz/blocks/grass/vegetation/sky.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,

--- a/assets/cubyz/blocks/grass_vegetation.zig.zon
+++ b/assets/cubyz/blocks/grass_vegetation.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,
@@ -13,7 +15,6 @@
 	.item = .{
 		.texture = "grass.png",
 	},
-	.replaceable = true,
 	.lodReplacement = "cubyz:air",
 	.onUpdate = .{
 		.type = .checkSupportBlocks,

--- a/assets/cubyz/blocks/hibiscus.zig.zon
+++ b/assets/cubyz/blocks/hibiscus.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,

--- a/assets/cubyz/blocks/ivy.zig.zon
+++ b/assets/cubyz/blocks/ivy.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.collide = false,
 	.alwaysViewThrough = true,

--- a/assets/cubyz/blocks/leaves/_defaults.zig.zon
+++ b/assets/cubyz/blocks/leaves/_defaults.zig.zon
@@ -7,8 +7,8 @@
 		},
 	},
 	.drops = .{
-		.{.items = .{.auto}},
-		.{.chance = 0.01, .items = .{"cubyz:apple"}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
+		.{.chance = 0.01, .items = .{"cubyz:apple"}, .forbiddenToolTags = .{.cuttable}},
 	},
 	.rotation = "cubyz:decayable",
 	.tags = .{.cuttable, .leaf},

--- a/assets/cubyz/blocks/lily_pad.zig.zon
+++ b/assets/cubyz/blocks/lily_pad.zig.zon
@@ -2,7 +2,7 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
 	.degradable = true,
 	.alwaysViewThrough = true,

--- a/assets/cubyz/blocks/lumiflora.zig.zon
+++ b/assets/cubyz/blocks/lumiflora.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,

--- a/assets/cubyz/blocks/lush_grass_vegetation.zig.zon
+++ b/assets/cubyz/blocks/lush_grass_vegetation.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,
@@ -13,7 +15,6 @@
 	.item = .{
 		.texture = "lush_grass.png",
 	},
-	.replaceable = true,
 	.lodReplacement = "cubyz:air",
 	.onUpdate = .{
 		.type = .checkSupportBlocks,

--- a/assets/cubyz/blocks/marigold.zig.zon
+++ b/assets/cubyz/blocks/marigold.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x121012,

--- a/assets/cubyz/blocks/monstera.zig.zon
+++ b/assets/cubyz/blocks/monstera.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.collide = false,
 	.alwaysViewThrough = true,

--- a/assets/cubyz/blocks/moss.zig.zon
+++ b/assets/cubyz/blocks/moss.zig.zon
@@ -2,7 +2,7 @@
 	.tags = .{.leaf, .cuttable},
 	.blockHealth = 1,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
 	.rotation = "cubyz:ore",
 	.model = "cubyz:cube",

--- a/assets/cubyz/blocks/osier.zig.zon
+++ b/assets/cubyz/blocks/osier.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.collide = false,
 	.alwaysViewThrough = true,

--- a/assets/cubyz/blocks/red_leaf_pile.zig.zon
+++ b/assets/cubyz/blocks/red_leaf_pile.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable, .leaf},
 	.blockHealth = 0.1,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.collide = false,
 	.alwaysViewThrough = true,

--- a/assets/cubyz/blocks/toadstool.zig.zon
+++ b/assets/cubyz/blocks/toadstool.zig.zon
@@ -2,8 +2,9 @@
 	.tags = .{.cuttable, .mushroom},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
 	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,

--- a/assets/cubyz/blocks/trumpet_lily.zig.zon
+++ b/assets/cubyz/blocks/trumpet_lily.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,

--- a/assets/cubyz/blocks/tussock.zig.zon
+++ b/assets/cubyz/blocks/tussock.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,

--- a/assets/cubyz/blocks/vetch.zig.zon
+++ b/assets/cubyz/blocks/vetch.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable},
 	.blockHealth = 0.2,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x121012,

--- a/assets/cubyz/blocks/vine/_defaults.zig.zon
+++ b/assets/cubyz/blocks/vine/_defaults.zig.zon
@@ -3,8 +3,10 @@
 	.blockHealth = 0.3,
 	.onUpdate = .{.type = .vine_decay},
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.viewThrough = true,
 	.absorbedLight = 0x000000,

--- a/assets/cubyz/blocks/yellow_leaf_pile.zig.zon
+++ b/assets/cubyz/blocks/yellow_leaf_pile.zig.zon
@@ -2,8 +2,10 @@
 	.tags = .{.cuttable, .leaf},
 	.blockHealth = 0.1,
 	.drops = .{
-		.{.items = .{.auto}},
+		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.selectionRule = .toolEffective,
+	.replaceable = true,
 	.degradable = true,
 	.collide = false,
 	.alwaysViewThrough = true,


### PR DESCRIPTION
Fixes #1558
Fixes #2384

<img width="1988" height="1117" alt="groups" src="https://github.com/user-attachments/assets/4064bd1f-b074-4802-b110-81ce62c8dcc4" />


There are three types of foliage, which are handled differently. From left to right:

- Wood-like foliage (cactus, mushroom blocks, and their branches): 
    - Left unchanged, always allow selection and drops
- Foliage with a hitbox (leaves, lilypads, moss): 
   - Always allow selection, but only drop when using a sickle
- Replaceable foliage that you can walk through:
    - Only allow selection and drops when holding a sickle

Commits are split based on these foliage types