### PR TITLE
Use snake case in Subsystem enum

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -227,7 +227,7 @@ pub fn build(b: *std.Build) !void {
 	try addModFeatures(b, exe);
 
 	if (isRelease and target.result.os.tag == .windows) {
-		exe.subsystem = .Windows;
+		exe.subsystem = .windows;
 	}
 
 	linkLibraries(b, exe, useLocalDeps);


### PR DESCRIPTION
Pascal case enum is deprecated and will be removed after 0.16.0