### PR TITLE
Compute the max extends of SDFs inside a biome to allow skipping biomes outside the range early

### DIFF
--- a/src/server/terrain/biomes.zig
+++ b/src/server/terrain/biomes.zig
@@ -6,7 +6,7 @@ const ServerChunk = main.chunk.ServerChunk;
 const ZonElement = main.ZonElement;
 const terrain = main.server.terrain;
 const NeverFailingAllocator = main.heap.NeverFailingAllocator;
-const vec = @import("main.vec");
+const vec = main.vec;
 const Vec3f = main.vec.Vec3f;
 const Vec3d = main.vec.Vec3d;
 
@@ -246,6 +246,7 @@ pub const Biome = struct { // MARK: Biome
 	supportsRivers: bool, // TODO: Reimplement rivers.
 	/// The first members in this array will get prioritized.
 	vegetationModels: []SimpleStructureModel = &.{},
+	maxSdfExtend: vec.Boxi = .{.min = @splat(0), .max = @splat(0)},
 	caveSdfModels: []terrain.sdf.SdfModel = &.{},
 	stripes: []Stripe = &.{},
 	subBiomes: main.utils.AliasTable(SubBiomeData) = .{.items = &.{}, .aliasData = &.{}},
@@ -378,7 +379,9 @@ pub const Biome = struct { // MARK: Biome
 		defer caveSdfs.deinit(main.stackAllocator);
 		for (caves.toSlice()) |elem| {
 			const model = terrain.sdf.SdfModel.initModel(elem) orelse continue;
-			caveSdfs.append(main.stackAllocator, model);
+			const spawnOffset: vec.Vec3i = @splat(@ceil(model.model.maxBiomeCenterDistance));
+			self.maxSdfExtend = self.maxSdfExtend.merge(.{.min = model.maxExtend.min - spawnOffset, .max = model.maxExtend.max + spawnOffset});
+			caveSdfs.append(main.stackAllocator, model.model);
 		}
 		self.caveSdfModels = main.worldArena.dupe(terrain.sdf.SdfModel, caveSdfs.items);
 

--- a/src/server/terrain/cavegen/SdfCaveGenerator.zig
+++ b/src/server/terrain/cavegen/SdfCaveGenerator.zig
@@ -46,7 +46,12 @@ fn generateSdf(map: *const CaveMapFragment, biomeMap: *const CaveBiomeMapView, a
 	const biomePoints = biomeMap.getCaveBiomesInRange(main.stackAllocator, mapPos -% margin, mapPos +% margin +% Vec3i{CaveMapFragment.width*map.pos.voxelSize, CaveMapFragment.width*map.pos.voxelSize, CaveMapFragment.height*map.pos.voxelSize});
 	defer main.stackAllocator.free(biomePoints);
 
+	const mapSize = Vec3i{CaveMapFragment.width, CaveMapFragment.width, CaveMapFragment.height} << @as(@Vector(3, u5), @splat(voxelSizeShift));
+
 	for (biomePoints) |biomePoint| {
+		const distance = mapPos -% biomePoint.worldPos;
+		if (@reduce(.Or, distance +% mapSize < biomePoint.biome.maxSdfExtend.min -% @as(Vec3i, @splat(perimeter)))) continue;
+		if (@reduce(.Or, distance > biomePoint.biome.maxSdfExtend.max +% @as(Vec3i, @splat(perimeter)))) continue;
 		var seed = main.random.initSeed3D(worldSeed, biomePoint.worldPos);
 		for (biomePoint.biome.caveSdfModels) |sdfModel| {
 			switch (sdfModel.mode) {

--- a/src/server/terrain/sdf.zig
+++ b/src/server/terrain/sdf.zig
@@ -20,9 +20,10 @@ pub const SdfModel = struct { // MARK: SdfModel
 	const VTable = struct {
 		init: *const fn (parameters: ZonElement) ?*anyopaque,
 		instantiate: *const fn (self: *anyopaque, arena: NeverFailingAllocator, seed: *u64) SdfInstance,
+		maxExtend: *const fn (self: *anyopaque) vec.Boxi,
 	};
 
-	pub fn initModel(parameters: ZonElement) ?SdfModel {
+	pub fn initModel(parameters: ZonElement) ?struct { model: SdfModel, maxExtend: vec.Boxi } {
 		const id = parameters.get([]const u8, "id", "");
 		const vtable = modelRegistry.get(id) orelse {
 			std.log.err("Couldn't find SDF model with id {s}", .{id});
@@ -33,12 +34,15 @@ pub const SdfModel = struct { // MARK: SdfModel
 			return null;
 		};
 		return .{
-			.data = vtableModel,
-			.instantiateFn = vtable.instantiate,
-			.maxBiomeCenterDistance = std.math.clamp(parameters.get(f32, "maxBiomeCenterDistance", terrain.CaveBiomeMap.CaveBiomeMapFragment.caveBiomeSize/2), 0, terrain.CaveBiomeMap.CaveBiomeMapFragment.caveBiomeSize/2),
-			.minAmount = parameters.get(f32, "minAmount", 1),
-			.maxAmount = parameters.get(f32, "maxAmount", parameters.get(f32, "minAmount", 1)),
-			.mode = parameters.get(@TypeOf(@as(SdfModel, undefined).mode), "mode", .subtractive),
+			.model = .{
+				.data = vtableModel,
+				.instantiateFn = vtable.instantiate,
+				.maxBiomeCenterDistance = std.math.clamp(parameters.get(f32, "maxBiomeCenterDistance", terrain.CaveBiomeMap.CaveBiomeMapFragment.caveBiomeSize/2), 0, terrain.CaveBiomeMap.CaveBiomeMapFragment.caveBiomeSize/2),
+				.minAmount = parameters.get(f32, "minAmount", 1),
+				.maxAmount = parameters.get(f32, "maxAmount", parameters.get(f32, "minAmount", 1)),
+				.mode = parameters.get(@TypeOf(@as(SdfModel, undefined).mode), "mode", .subtractive),
+			},
+			.maxExtend = vtable.maxExtend(vtableModel),
 		};
 	}
 
@@ -70,6 +74,7 @@ pub const SdfModel = struct { // MARK: SdfModel
 		var self: VTable = undefined;
 		self.init = main.meta.castFunctionReturnToOptionalAnyopaque(Generator.init);
 		self.instantiate = main.meta.castFunctionSelfToAnyopaque(Generator.instantiate);
+		self.maxExtend = main.meta.castFunctionSelfToAnyopaque(Generator.maxExtend);
 		modelRegistry.put(main.globalArena.allocator, Generator.id, self) catch unreachable;
 	}
 };

--- a/src/server/terrain/sdf.zig
+++ b/src/server/terrain/sdf.zig
@@ -17,10 +17,11 @@ pub const SdfModel = struct { // MARK: SdfModel
 	maxAmount: f32,
 	mode: enum { additive, subtractive },
 
+	pub const InitResult = ?struct { model: *anyopaque, maxExtend: vec.Boxi };
+
 	const VTable = struct {
-		init: *const fn (parameters: ZonElement) ?*anyopaque,
+		initAndGetExtend: *const fn (parameters: ZonElement) InitResult,
 		instantiate: *const fn (self: *anyopaque, arena: NeverFailingAllocator, seed: *u64) SdfInstance,
-		maxExtend: *const fn (self: *anyopaque) vec.Boxi,
 	};
 
 	pub fn initModel(parameters: ZonElement) ?struct { model: SdfModel, maxExtend: vec.Boxi } {
@@ -29,20 +30,20 @@ pub const SdfModel = struct { // MARK: SdfModel
 			std.log.err("Couldn't find SDF model with id {s}", .{id});
 			return null;
 		};
-		const vtableModel = vtable.init(parameters) orelse {
+		const result = vtable.initAndGetExtend(parameters) orelse {
 			std.log.err("Error occurred while loading SDF model with id '{s}'. Dropping SDF from biome.", .{id});
 			return null;
 		};
 		return .{
 			.model = .{
-				.data = vtableModel,
+				.data = result.model,
 				.instantiateFn = vtable.instantiate,
 				.maxBiomeCenterDistance = std.math.clamp(parameters.get(f32, "maxBiomeCenterDistance", terrain.CaveBiomeMap.CaveBiomeMapFragment.caveBiomeSize/2), 0, terrain.CaveBiomeMap.CaveBiomeMapFragment.caveBiomeSize/2),
 				.minAmount = parameters.get(f32, "minAmount", 1),
 				.maxAmount = parameters.get(f32, "maxAmount", parameters.get(f32, "minAmount", 1)),
 				.mode = parameters.get(@TypeOf(@as(SdfModel, undefined).mode), "mode", .subtractive),
 			},
-			.maxExtend = vtable.maxExtend(vtableModel),
+			.maxExtend = result.maxExtend,
 		};
 	}
 
@@ -72,9 +73,8 @@ pub const SdfModel = struct { // MARK: SdfModel
 
 	pub fn registerGenerator(comptime Generator: type) void {
 		var self: VTable = undefined;
-		self.init = main.meta.castFunctionReturnToOptionalAnyopaque(Generator.init);
+		self.initAndGetExtend = Generator.initAndGetExtend;
 		self.instantiate = main.meta.castFunctionSelfToAnyopaque(Generator.instantiate);
-		self.maxExtend = main.meta.castFunctionSelfToAnyopaque(Generator.maxExtend);
 		modelRegistry.put(main.globalArena.allocator, Generator.id, self) catch unreachable;
 	}
 };

--- a/src/server/terrain/sdf.zig
+++ b/src/server/terrain/sdf.zig
@@ -58,9 +58,9 @@ pub const SdfModel = struct { // MARK: SdfModel
 			var pos = biomePos +% @as(Vec3i, @trunc(offsetDir*@as(Vec3f, @splat(self.maxBiomeCenterDistance))));
 			pos[2] +%= biomeMap.getCaveBiomeOffset(pos[0], pos[1]);
 			var instance = self.instantiateFn(self.data, arena, seed);
-			instance.minBounds += pos;
-			instance.maxBounds += pos;
-			instance.generate(sdf, interpolationSmoothness, sdfPos, perimeter, voxelSize, voxelSizeShift);
+			instance.minBounds +%= pos -% sdfPos;
+			instance.maxBounds +%= pos -% sdfPos;
+			instance.generate(sdf, interpolationSmoothness, perimeter, voxelSize, voxelSizeShift);
 		}
 	}
 
@@ -86,11 +86,11 @@ pub const SdfInstance = struct { // MARK: SdfInstance
 	maxBounds: Vec3i,
 	centerPosOffset: Vec3f,
 
-	pub fn generate(self: SdfInstance, sdf: main.utils.Array3D(f32), interpolationSmoothness: main.utils.Array3D(f32), sdfPos: Vec3i, perimeter: comptime_int, voxelSize: u31, voxelSizeShift: u5) void {
+	pub fn generate(self: SdfInstance, sdf: main.utils.Array3D(f32), interpolationSmoothness: main.utils.Array3D(f32), perimeter: comptime_int, voxelSize: u31, voxelSizeShift: u5) void {
 		const dimVector: Vec3i = @intCast(@Vector(3, u32){sdf.width*voxelSize, sdf.depth*voxelSize, sdf.height*voxelSize});
 		const mask: @Vector(3, u31) = @splat(voxelSize - 1);
-		const min = @max(Vec3i{0, 0, 0}, self.minBounds -% @as(Vec3i, @splat(perimeter)) -% sdfPos) & ~mask;
-		const max = @min(dimVector, self.maxBounds +% @as(Vec3i, @splat(perimeter)) -% sdfPos) + mask & ~@as(Vec3i, mask);
+		const min = @max(Vec3i{0, 0, 0}, self.minBounds -% @as(Vec3i, @splat(perimeter))) & ~mask;
+		const max = @min(dimVector, self.maxBounds +% @as(Vec3i, @splat(perimeter))) + mask & ~@as(Vec3i, mask);
 		if (@reduce(.Or, max <= min)) return;
 
 		var x = min[0] & ~(voxelSize - 1);
@@ -99,7 +99,7 @@ pub const SdfInstance = struct { // MARK: SdfInstance
 			while (y != max[1]) : (y += voxelSize) {
 				var z = min[2] & ~(voxelSize - 1);
 				while (z < max[2]) : (z += voxelSize) {
-					const pos = @as(Vec3f, @floatFromInt(Vec3i{x, y, z} +% sdfPos -% self.minBounds)) - self.centerPosOffset;
+					const pos = @as(Vec3f, @floatFromInt(Vec3i{x, y, z} -% self.minBounds)) - self.centerPosOffset;
 					const sdfSample = self.generateFn(self.data, pos);
 					if (sdfSample > perimeter) continue;
 

--- a/src/server/terrain/sdf_models/cluster.zig
+++ b/src/server/terrain/sdf_models/cluster.zig
@@ -26,20 +26,36 @@ const Instance = struct {
 	smoothness: f32,
 };
 
-pub fn init(zon: ZonElement) ?*@This() {
+pub fn initAndGetExtend(zon: ZonElement) sdf.SdfModel.InitResult {
 	var list: main.List(Entry) = .init(main.stackAllocator);
 	defer list.deinit();
+
+	var maxExtend: vec.Boxi = .{
+		.min = @splat(-1e9),
+		.max = @splat(1e9),
+	};
+
 	for (zon.getChild("children").toSlice()) |child| {
-		list.append(.{
-			.model = sdf.SdfModel.initModel(child) orelse return null,
+		const childModelAndExtend = sdf.SdfModel.initModel(child) orelse return null;
+		const childEntry: Entry = .{
+			.model = childModelAndExtend.model,
 			.positionOffset = child.get(Vec3f, "positionOffset", @splat(0)),
 			.randomOffset = child.get(Vec3f, "randomOffset", @splat(0)),
-		});
+		};
+		maxExtend.min = @min(maxExtend.min, @as(Vec3i, @floor(@as(Vec3f, @floatFromInt(childModelAndExtend.maxExtend.min)) + childEntry.positionOffset - childEntry.randomOffset)));
+		maxExtend.max = @max(maxExtend.max, @as(Vec3i, @ceil(@as(Vec3f, @floatFromInt(childModelAndExtend.maxExtend.max)) + childEntry.positionOffset + childEntry.randomOffset)));
+		list.append(childEntry);
 	}
-	const result = main.worldArena.create(@This());
-	result.children = main.worldArena.dupe(Entry, list.items);
-	result.smoothness = zon.get(f32, "smothness", 4);
-	return result;
+
+	if (list.items.len == 0) {
+		std.log.err("cubyz:cluster SDF expected at last one child SDF.", .{});
+		return null;
+	}
+
+	const self = main.worldArena.create(@This());
+	self.children = main.worldArena.dupe(Entry, list.items);
+	self.smoothness = zon.get(f32, "smothness", 4);
+	return .{.model = self, .maxExtend = maxExtend};
 }
 
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {

--- a/src/server/terrain/sdf_models/cylinder.zig
+++ b/src/server/terrain/sdf_models/cylinder.zig
@@ -24,20 +24,17 @@ const Instance = struct {
 	halfHeight: f32,
 };
 
-pub fn init(zon: ZonElement) ?*@This() {
-	const result = main.worldArena.create(@This());
-	result.minRadius = zon.get(f32, "minRadius", 16);
-	result.maxRadius = zon.get(f32, "maxRadius", result.minRadius);
-	result.minHalfHeight = zon.get(f32, "minHeight", 32)/2;
-	result.maxHalfHeight = zon.get(f32, "maxfHeight", result.minHalfHeight*2)/2;
-	return result;
-}
+pub fn initAndGetExtend(zon: ZonElement) sdf.SdfModel.InitResult {
+	const self = main.worldArena.create(@This());
+	self.minRadius = zon.get(f32, "minRadius", 16);
+	self.maxRadius = zon.get(f32, "maxRadius", self.minRadius);
+	self.minHalfHeight = zon.get(f32, "minHeight", 32)/2;
+	self.maxHalfHeight = zon.get(f32, "maxfHeight", self.minHalfHeight*2)/2;
 
-pub fn maxExtend(self: *@This()) vec.Boxi {
-	return .{
+	return .{.model = self, .maxExtend = .{
 		.min = .{@floor(-self.maxRadius), @floor(-self.maxRadius), @floor(-self.maxHalfHeight)},
 		.max = .{@ceil(self.maxRadius), @ceil(self.maxRadius), @ceil(self.maxHalfHeight)},
-	};
+	}};
 }
 
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {

--- a/src/server/terrain/sdf_models/cylinder.zig
+++ b/src/server/terrain/sdf_models/cylinder.zig
@@ -33,6 +33,13 @@ pub fn init(zon: ZonElement) ?*@This() {
 	return result;
 }
 
+pub fn maxExtend(self: *@This()) vec.Boxi {
+	return .{
+		.min = .{@floor(-self.maxRadius), @floor(-self.maxRadius), @floor(-self.maxHalfHeight)},
+		.max = .{@ceil(self.maxRadius), @ceil(self.maxRadius), @ceil(self.maxHalfHeight)},
+	};
+}
+
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {
 	const instance = arena.create(Instance);
 	instance.* = .{

--- a/src/server/terrain/sdf_models/partial_sphere.zig
+++ b/src/server/terrain/sdf_models/partial_sphere.zig
@@ -34,6 +34,13 @@ pub fn init(zon: ZonElement) ?*@This() {
 	return result;
 }
 
+pub fn maxExtend(self: *@This()) vec.Boxi {
+	return .{
+		.min = @splat(@floor(-self.maxRadius)),
+		.max = @splat(@ceil(self.maxRadius)),
+	};
+}
+
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {
 	const instance = arena.create(Instance);
 	instance.* = .{

--- a/src/server/terrain/sdf_models/partial_sphere.zig
+++ b/src/server/terrain/sdf_models/partial_sphere.zig
@@ -24,21 +24,18 @@ const Instance = struct {
 	cutDirection: Vec3f,
 };
 
-pub fn init(zon: ZonElement) ?*@This() {
-	const result = main.worldArena.create(@This());
-	result.minRadius = zon.get(f32, "minRadius", 16);
-	result.maxRadius = zon.get(f32, "maxRadius", result.minRadius);
-	result.cutPercentage = zon.get(f32, "cutPercentage", 0.5);
-	result.cutDirection = vec.normalize(zon.get(Vec3f, "cutDirection", .{0, 0, -1}));
-	result.cutDirectionRandomness = zon.get(f32, "cutDirectionRandomness", 0);
-	return result;
-}
+pub fn initAndGetExtend(zon: ZonElement) sdf.SdfModel.InitResult {
+	const self = main.worldArena.create(@This());
+	self.minRadius = zon.get(f32, "minRadius", 16);
+	self.maxRadius = zon.get(f32, "maxRadius", self.minRadius);
+	self.cutPercentage = zon.get(f32, "cutPercentage", 0.5);
+	self.cutDirection = vec.normalize(zon.get(Vec3f, "cutDirection", .{0, 0, -1}));
+	self.cutDirectionRandomness = zon.get(f32, "cutDirectionRandomness", 0);
 
-pub fn maxExtend(self: *@This()) vec.Boxi {
-	return .{
+	return .{.model = self, .maxExtend = .{
 		.min = @splat(@floor(-self.maxRadius)),
 		.max = @splat(@ceil(self.maxRadius)),
-	};
+	}};
 }
 
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {

--- a/src/server/terrain/sdf_models/rectangular_cuboid.zig
+++ b/src/server/terrain/sdf_models/rectangular_cuboid.zig
@@ -19,18 +19,15 @@ const Instance = struct {
 	radii: Vec3f,
 };
 
-pub fn init(zon: ZonElement) ?*@This() {
-	const result = main.worldArena.create(@This());
-	result.minRadii = zon.get(Vec3f, "minSideLengths", @splat(32))/@as(Vec3f, @splat(2));
-	result.maxRadii = zon.get(Vec3f, "maxSideLengths", result.minRadii*@as(Vec3f, @splat(2)))/@as(Vec3f, @splat(2));
-	return result;
-}
+pub fn initAndGetExtend(zon: ZonElement) sdf.SdfModel.InitResult {
+	const self = main.worldArena.create(@This());
+	self.minRadii = zon.get(Vec3f, "minSideLengths", @splat(32))/@as(Vec3f, @splat(2));
+	self.maxRadii = zon.get(Vec3f, "maxSideLengths", self.minRadii*@as(Vec3f, @splat(2)))/@as(Vec3f, @splat(2));
 
-pub fn maxExtend(self: *@This()) vec.Boxi {
-	return .{
+	return .{.model = self, .maxExtend = .{
 		.min = @floor(-self.maxRadii),
 		.max = @ceil(self.maxRadii),
-	};
+	}};
 }
 
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {

--- a/src/server/terrain/sdf_models/rectangular_cuboid.zig
+++ b/src/server/terrain/sdf_models/rectangular_cuboid.zig
@@ -26,6 +26,13 @@ pub fn init(zon: ZonElement) ?*@This() {
 	return result;
 }
 
+pub fn maxExtend(self: *@This()) vec.Boxi {
+	return .{
+		.min = @floor(-self.maxRadii),
+		.max = @ceil(self.maxRadii),
+	};
+}
+
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {
 	const instance = arena.create(Instance);
 	instance.* = .{

--- a/src/server/terrain/sdf_models/rotated.zig
+++ b/src/server/terrain/sdf_models/rotated.zig
@@ -32,17 +32,29 @@ const Instance = struct {
 	cos: f32,
 };
 
-pub fn init(zon: ZonElement) ?*@This() {
+pub fn initAndGetExtend(zon: ZonElement) sdf.SdfModel.InitResult {
 	const child = sdf.SdfModel.initModel(zon.getChild("child")) orelse return null;
-	const result = main.worldArena.create(@This());
-	result.child = child;
-	result.axis = zon.get(?Axis, "axis", null) orelse {
+	const self = main.worldArena.create(@This());
+	self.child = child.model;
+	self.axis = zon.get(?Axis, "axis", null) orelse {
 		std.log.err("Missing parameter axis for cubyz:rotated SDF.", .{});
 		return null;
 	};
-	result.minAngle = std.math.degreesToRadians(zon.get(f32, "minAngle", 0));
-	result.maxAngle = std.math.degreesToRadians(zon.get(f32, "maxAngle", 360));
-	return result;
+	self.minAngle = std.math.degreesToRadians(zon.get(f32, "minAngle", 0));
+	self.maxAngle = std.math.degreesToRadians(zon.get(f32, "maxAngle", 360));
+
+	const axisVector: Vec3f = switch (self.axis) {
+		.x => .{1, 0, 0},
+		.y => .{0, 1, 0},
+		.z => .{0, 0, 1},
+	};
+	const offAxisVectors = Vec3f{1, 1, 1} - axisVector;
+	const maxDiagonal: Vec3f = @splat(vec.length(@max(@as(Vec3f, @floatFromInt(child.maxExtend.min))*offAxisVectors, @as(Vec3f, @floatFromInt(child.maxExtend.max))*offAxisVectors)));
+
+	return .{.model = self, .maxExtend = .{
+		.min = @as(Vec3i, @floor(-maxDiagonal*offAxisVectors + @as(Vec3f, @floatFromInt(child.maxExtend.min))*axisVector)),
+		.max = @as(Vec3i, @ceil(maxDiagonal*offAxisVectors + @as(Vec3f, @floatFromInt(child.maxExtend.max))*axisVector)),
+	}};
 }
 
 fn rotate(axis: Axis, sin: f32, cos: f32, in: Vec3f) Vec3f {

--- a/src/server/terrain/sdf_models/sphere.zig
+++ b/src/server/terrain/sdf_models/sphere.zig
@@ -26,6 +26,13 @@ pub fn init(zon: ZonElement) ?*@This() {
 	return result;
 }
 
+pub fn maxExtend(self: *@This()) vec.Boxi {
+	return .{
+		.min = @splat(@floor(-self.maxRadius)),
+		.max = @splat(@ceil(self.maxRadius)),
+	};
+}
+
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {
 	const instance = arena.create(Instance);
 	instance.* = .{

--- a/src/server/terrain/sdf_models/sphere.zig
+++ b/src/server/terrain/sdf_models/sphere.zig
@@ -19,18 +19,15 @@ const Instance = struct {
 	radius: f32,
 };
 
-pub fn init(zon: ZonElement) ?*@This() {
-	const result = main.worldArena.create(@This());
-	result.minRadius = zon.get(f32, "minRadius", 16);
-	result.maxRadius = zon.get(f32, "maxRadius", result.minRadius);
-	return result;
-}
+pub fn initAndGetExtend(zon: ZonElement) sdf.SdfModel.InitResult {
+	const self = main.worldArena.create(@This());
+	self.minRadius = zon.get(f32, "minRadius", 16);
+	self.maxRadius = zon.get(f32, "maxRadius", self.minRadius);
 
-pub fn maxExtend(self: *@This()) vec.Boxi {
-	return .{
+	return .{.model = self, .maxExtend = .{
 		.min = @splat(@floor(-self.maxRadius)),
 		.max = @splat(@ceil(self.maxRadius)),
-	};
+	}};
 }
 
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {

--- a/src/server/terrain/sdf_models/torus.zig
+++ b/src/server/terrain/sdf_models/torus.zig
@@ -22,20 +22,17 @@ const Instance = struct {
 	thickness: f32,
 };
 
-pub fn init(zon: ZonElement) ?*@This() {
-	const result = main.worldArena.create(@This());
-	result.minRadius = zon.get(f32, "minRadius", 16);
-	result.maxRadius = zon.get(f32, "maxRadius", result.minRadius);
-	result.minThickness = zon.get(f32, "minThickness", result.minRadius/2);
-	result.maxThickness = zon.get(f32, "maxThickness", result.minThickness);
-	return result;
-}
+pub fn initAndGetExtend(zon: ZonElement) sdf.SdfModel.InitResult {
+	const self = main.worldArena.create(@This());
+	self.minRadius = zon.get(f32, "minRadius", 16);
+	self.maxRadius = zon.get(f32, "maxRadius", self.minRadius);
+	self.minThickness = zon.get(f32, "minThickness", self.minRadius/2);
+	self.maxThickness = zon.get(f32, "maxThickness", self.minThickness);
 
-pub fn maxExtend(self: *@This()) vec.Boxi {
-	return .{
+	return .{.model = self, .maxExtend = .{
 		.min = .{@floor(-self.maxRadius - self.maxThickness), @floor(-self.maxRadius - self.maxThickness), @floor(-self.maxThickness)},
 		.max = .{@ceil(-self.maxRadius - self.maxThickness), @ceil(-self.maxRadius - self.maxThickness), @ceil(-self.maxThickness)},
-	};
+	}};
 }
 
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {

--- a/src/server/terrain/sdf_models/torus.zig
+++ b/src/server/terrain/sdf_models/torus.zig
@@ -31,6 +31,13 @@ pub fn init(zon: ZonElement) ?*@This() {
 	return result;
 }
 
+pub fn maxExtend(self: *@This()) vec.Boxi {
+	return .{
+		.min = .{@floor(-self.maxRadius - self.maxThickness), @floor(-self.maxRadius - self.maxThickness), @floor(-self.maxThickness)},
+		.max = .{@ceil(-self.maxRadius - self.maxThickness), @ceil(-self.maxRadius - self.maxThickness), @ceil(-self.maxThickness)},
+	};
+}
+
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {
 	const instance = arena.create(Instance);
 	instance.* = .{

--- a/src/vec.zig
+++ b/src/vec.zig
@@ -358,3 +358,14 @@ pub const Complex = struct { // MARK: Complex
 		return complexFactor.mulScalar(realFactor);
 	}
 };
+
+// MARK: Box
+
+pub const Boxi = struct {
+	min: Vec3i,
+	max: Vec3i,
+
+	pub fn merge(self: Boxi, other: Boxi) Boxi {
+		return .{.min = @min(self.min, other.min), .max = @max(self.max, other.max)};
+	}
+};


### PR DESCRIPTION
This saves about 20-30% of SDF generation time (around 6% of total time)

- [x] rebase after the other SDF PRs are merged