### PR TITLE
Add a general way to ignore the selection rule for blocks, and let selection wand use it

### DIFF
--- a/assets/cubyz/items/selection_wand.zig.zon
+++ b/assets/cubyz/items/selection_wand.zig.zon
@@ -1,4 +1,5 @@
 .{
 	.texture = "selection_wand.png",
+	.ignoreSelectionCapabilities = true,
 	.stackSize = 1,
 }

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -96,7 +96,7 @@ const SelectionCapabilities = struct {
 	pub fn allowsSelectionByItem(self: SelectionCapabilities, block: Block, item: Item) bool {
 		if (item == .baseItem) {
 			const base = item.baseItem;
-			if (base.block() == block.typ or std.mem.eql(u8, base.id(), "cubyz:selection_wand")) {
+			if (base.ignoreSelectionCapabilities() or base.block() == block.typ) {
 				return true;
 			}
 		}

--- a/src/items.zig
+++ b/src/items.zig
@@ -248,6 +248,9 @@ pub const BaseItemIndex = enum(u16) { // MARK: BaseItemIndex
 	pub fn block(self: BaseItemIndex) ?u16 {
 		return itemList[@intFromEnum(self)].block;
 	}
+	pub fn ignoreSelectionCapabilities(self: BaseItemIndex) bool {
+		return itemList[@intFromEnum(self)].ignoreSelectionCapabilities;
+	}
 	pub fn hasTag(self: BaseItemIndex, tag: Tag) bool {
 		return itemList[@intFromEnum(self)].hasTag(tag);
 	}
@@ -274,6 +277,7 @@ pub const BaseItem = struct { // MARK: BaseItem
 	material: ?Material,
 	block: ?u16,
 	foodValue: f32, // TODO: Effects.
+	ignoreSelectionCapabilities: bool,
 
 	fn init(self: *BaseItem, allocator: NeverFailingAllocator, texturePath: []const u8, replacementTexturePath: []const u8, id: []const u8, zon: ZonElement) void {
 		self.id = allocator.dupe(u8, id);
@@ -300,6 +304,7 @@ pub const BaseItem = struct { // MARK: BaseItem
 		};
 		self.texture = null;
 		self.foodValue = zon.get(f32, "food", 0);
+		self.ignoreSelectionCapabilities = zon.get(bool, "ignoreSelectionCapabilities", false);
 
 		var tooltip: main.List(u8) = .init(allocator);
 		tooltip.appendSlice(self.name);


### PR DESCRIPTION
In essence it's an override (blocks define selectability, but items can choose to override it), but for now the only use case is ignoring it completely, so I made it a simple boolean