### PR TITLE
Allow blocks to define under what conditions they can be placed, for now only for selection

### DIFF
--- a/assets/cubyz/blocks/duckweed.zig.zon
+++ b/assets/cubyz/blocks/duckweed.zig.zon
@@ -4,6 +4,9 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.placementConstraints = .{
+		.{.allowedTags = .{.fluid}, .allowedFaces = .{.top}},
+	},
 	.selectionCapabilities = .{.toolEffective},
 	.replaceable = true,
 	.degradable = true,
@@ -21,7 +24,6 @@
 	.texture3 = "cubyz:duckweed/3",
 	.item = .{
 		.texture = "duckweed.png",
-		.tags = .{.fluidPlaceable},
 	},
 	.lodReplacement = "cubyz:air",
 }

--- a/assets/cubyz/blocks/lily_pad.zig.zon
+++ b/assets/cubyz/blocks/lily_pad.zig.zon
@@ -4,6 +4,9 @@
 	.drops = .{
 		.{.items = .{.auto}, .allowedToolTags = .{.cuttable}},
 	},
+	.placementConstraints = .{
+		.{.allowedTags = .{.fluid}, .allowedFaces = .{.top}},
+	},
 	.degradable = true,
 	.alwaysViewThrough = true,
 	.absorbedLight = 0x121012,
@@ -12,7 +15,6 @@
 	.texture = "cubyz:lily_pad",
 	.item = .{
 		.texture = "lily_pad.png",
-		.tags = .{.fluidPlaceable},
 	},
 	.lodReplacement = "cubyz:air",
 }

--- a/assets/cubyz/blocks/water.zig.zon
+++ b/assets/cubyz/blocks/water.zig.zon
@@ -1,8 +1,9 @@
 .{
 	.tags = .{.fluid},
 	.drops = .{},
-	.selectionCapabilities = .{.toolEffective},
+	.selectionCapabilities = .{.toolEffective, .placeable},
 	.replaceable = true,
+	.support = .yesThroughConstraints,
 	.degradable = true,
 	.transparent = true,
 	.hasBackFace = true,

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -68,15 +68,84 @@ pub const Ore = struct {
 	seed: u64,
 };
 
+const PlacementConstraints = struct {
+	constraints: []const PlacementConstraint,
+
+	pub const unconstrained: PlacementConstraints = .{.constraints = &.{}};
+
+	pub inline fn isConstrained(self: PlacementConstraints) bool {
+		return self.constraints.len != 0;
+	}
+
+	const PlacementConstraint = struct {
+		allowedTags: ?[]const Tag,
+		allowedFaces: ?SelectionFaceMask,
+
+		pub inline fn loadFromZon(arena: main.heap.NeverFailingAllocator, zon: main.ZonElement) PlacementConstraint {
+			return .{
+				.allowedTags = if (zon.getChildOrNull("allowedTags")) |tagsZon| Tag.loadTagsFromZon(arena, tagsZon) else null,
+				.allowedFaces = if (zon.getChildOrNull("allowedFaces")) |facesZon| SelectionFaceMask.loadFromZon(facesZon) else null,
+			};
+		}
+
+		pub fn allowsPlacementOnBlock(self: PlacementConstraint, target: Block, from: SelectionFace) bool {
+			if (self.allowedTags) |tags| {
+				for (tags) |tag| {
+					if (target.hasTag(tag)) break;
+				} else return false;
+			}
+			if (self.allowedFaces) |faces| {
+				if (!faces.has(from)) return false;
+			}
+			return true;
+		}
+	};
+
+	pub fn loadFromZon(arena: main.heap.NeverFailingAllocator, zon: main.ZonElement) PlacementConstraints {
+		var list = main.ListUnmanaged(PlacementConstraint).initCapacity(arena, zon.toSlice().len);
+		for (zon.toSlice()) |constraintZon| {
+			list.appendAssumeCapacity(PlacementConstraint.loadFromZon(arena, constraintZon));
+		}
+		return .{.constraints = list.items};
+	}
+
+	pub inline fn allowsPlacementOnBlock(self: PlacementConstraints, target: Block, from: Neighbor) bool {
+		return switch (target.support()) {
+			.no => false,
+			.yes => true,
+			.yesThroughConstraints => {
+				if (!self.isConstrained()) return false;
+
+				const selectionFace = from.toSelectionFace();
+				for (self.constraints) |constraint| {
+					if (constraint.allowsPlacementOnBlock(target, selectionFace)) return true;
+				}
+				return false;
+			},
+		};
+	}
+};
+
 const SelectionCapabilities = struct {
 	capabilities: ?[]const Capability,
 
-	const Capability = enum(u8) {
+	const Capability = enum {
 		toolEffective,
+		placeable,
 
-		pub fn allowsSelectionByItem(self: Capability, block: Block, item: Item) bool {
-			return switch (self) {
-				.toolEffective => item == .proceduralItem and item.proceduralItem.isEffectiveOn(block),
+		pub fn allowsSelectionByItem(self: Capability, block: Block, item: Item, from: Neighbor) bool {
+			return switch (item) {
+				.baseItem => |baseItem| {
+					if (std.mem.eql(u8, baseItem.id(), "cubyz:selection_wand")) return true;
+					if (baseItem.block()) |blockType| {
+						if (blockType == block.typ) return true;
+						return self == .placeable and Block.fromInt(blockType).isPlaceableOnBlock(block, from);
+					} else return false;
+				},
+
+				.proceduralItem => |proceduralItem| self == .toolEffective and proceduralItem.isEffectiveOn(block),
+
+				else => false,
 			};
 		}
 	};
@@ -93,25 +162,53 @@ const SelectionCapabilities = struct {
 		return .{.capabilities = list.items};
 	}
 
-	pub fn allowsSelectionByItem(self: SelectionCapabilities, block: Block, item: Item) bool {
-		if (item == .baseItem) {
-			const base = item.baseItem;
-			if (base.block() == block.typ or std.mem.eql(u8, base.id(), "cubyz:selection_wand")) {
-				return true;
-			}
-		}
-
-		if (block.hasTag(.fluid)) {
-			const fluidPlaceable = item == .baseItem and item.baseItem.hasTag(.fluidPlaceable);
-			return fluidPlaceable;
-		}
-
+	pub fn allowsSelectionByItem(self: SelectionCapabilities, block: Block, item: Item, from: Neighbor) bool {
 		const capabilities = self.capabilities orelse return true;
 		for (capabilities) |capability| {
-			if (capability.allowsSelectionByItem(block, item)) return true;
+			if (capability.allowsSelectionByItem(block, item, from)) return true;
 		}
 		return false;
 	}
+};
+
+pub const SelectionFace = enum {
+	top,
+	bottom,
+	side,
+};
+
+const SelectionFaceMask = packed struct(u3) {
+	top: bool = false,
+	bottom: bool = false,
+	side: bool = false,
+
+	pub fn loadFromZon(zon: main.ZonElement) SelectionFaceMask {
+		var mask: SelectionFaceMask = .{};
+		for (zon.toSlice()) |faceZon| {
+			if (faceZon.as(?SelectionFace, null)) |face| {
+				switch (face) {
+					.top => mask.top = true,
+					.bottom => mask.bottom = true,
+					.side => mask.side = true,
+				}
+			} else std.log.err("SelectionFace is invalid. Ignoring", .{});
+		}
+		return mask;
+	}
+
+	pub fn has(self: SelectionFaceMask, face: SelectionFace) bool {
+		return switch (face) {
+			.top => self.top,
+			.bottom => self.bottom,
+			.side => self.side,
+		};
+	}
+};
+
+const Support = enum {
+	no,
+	yes,
+	yesThroughConstraints,
 };
 
 var _transparent: [maxBlockCount]bool = undefined;
@@ -123,6 +220,8 @@ var _blockResistance: [maxBlockCount]f32 = undefined;
 
 /// Whether you can replace it with another block, mainly used for fluids/gases
 var _replaceable: [maxBlockCount]bool = undefined;
+var _support: [maxBlockCount]Support = undefined;
+var _placementConstraints: [maxBlockCount]PlacementConstraints = undefined;
 var _selectionCapabilities: [maxBlockCount]SelectionCapabilities = undefined;
 var _blockDrops: [maxBlockCount][]const BlockDrop = undefined;
 /// Meaning undegradable parts of trees or other structures can grow through this block.
@@ -183,6 +282,14 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 	_light[size] = zon.get(u32, "emittedLight", 0);
 	_absorption[size] = zon.get(u32, "absorbedLight", 0xffffff);
 	_degradable[size] = zon.get(bool, "degradable", false);
+	_replaceable[size] = zon.get(bool, "replaceable", false);
+	_support[size] = zon.get(Support, "support", .yes);
+
+	if (zon.getChildOrNull("placementConstraints")) |constraintsZon| {
+		_placementConstraints[size] = .loadFromZon(main.worldArena, constraintsZon);
+	} else {
+		_placementConstraints[size] = .unconstrained;
+	}
 
 	if (zon.getChildOrNull("selectionCapabilities")) |capabilitiesZon| {
 		_selectionCapabilities[size] = .loadFromZon(main.worldArena, capabilitiesZon);
@@ -190,7 +297,6 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 		_selectionCapabilities[size] = .alwaysSelectable;
 	}
 
-	_replaceable[size] = zon.get(bool, "replaceable", false);
 	_transparent[size] = zon.get(bool, "transparent", false);
 	_collide[size] = zon.get(bool, "collide", true);
 	_alwaysViewThrough[size] = zon.get(bool, "alwaysViewThrough", false);
@@ -464,6 +570,14 @@ pub const Block = packed struct(u32) { // MARK: Block
 		return _replaceable[self.typ];
 	}
 
+	pub inline fn support(self: Block) Support {
+		return _support[self.typ];
+	}
+
+	pub inline fn placementConstraints(self: Block) PlacementConstraints {
+		return _placementConstraints[self.typ];
+	}
+
 	pub inline fn selectionCapabilities(self: Block) SelectionCapabilities {
 		return _selectionCapabilities[self.typ];
 	}
@@ -576,8 +690,12 @@ pub const Block = packed struct(u32) { // MARK: Block
 		return newBlock.mode().canBeChangedInto(self, newBlock, item, shouldDropSourceBlockOnSuccess);
 	}
 
-	pub inline fn isSelectableByItem(self: Block, item: Item) bool {
-		return self.selectionCapabilities().allowsSelectionByItem(self, item);
+	pub inline fn isSelectableByItem(self: Block, item: Item, from: Neighbor) bool {
+		return self.selectionCapabilities().allowsSelectionByItem(self, item, from);
+	}
+
+	pub inline fn isPlaceableOnBlock(self: Block, target: Block, from: Neighbor) bool {
+		return self.placementConstraints().allowsPlacementOnBlock(target, from);
 	}
 };
 

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -110,19 +110,16 @@ const PlacementConstraints = struct {
 	}
 
 	pub inline fn allowsPlacementOnBlock(self: PlacementConstraints, target: Block, from: Neighbor) bool {
-		return switch (target.support()) {
-			.no => false,
-			.yes => true,
-			.yesThroughConstraints => {
-				if (!self.isConstrained()) return false;
+		const support = target.support();
+		if (support == .no) return false;
 
-				const selectionFace = from.toSelectionFace();
-				for (self.constraints) |constraint| {
-					if (constraint.allowsPlacementOnBlock(target, selectionFace)) return true;
-				}
-				return false;
-			},
-		};
+		if (!self.isConstrained()) return support == .yes;
+
+		const selectionFace = from.toSelectionFace();
+		for (self.constraints) |constraint| {
+			if (constraint.allowsPlacementOnBlock(target, selectionFace)) return true;
+		}
+		return false;
 	}
 };
 

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -69,7 +69,7 @@ pub const Ore = struct {
 };
 
 const PlacementConstraints = struct {
-	constraints: []const PlacementConstraint,
+	constraints: []const Constraint,
 
 	pub const unconstrained: PlacementConstraints = .{.constraints = &.{}};
 
@@ -77,18 +77,18 @@ const PlacementConstraints = struct {
 		return self.constraints.len != 0;
 	}
 
-	const PlacementConstraint = struct {
+	const Constraint = struct {
 		allowedTags: ?[]const Tag,
 		allowedFaces: ?SelectionFaceMask,
 
-		pub inline fn loadFromZon(arena: main.heap.NeverFailingAllocator, zon: main.ZonElement) PlacementConstraint {
+		pub inline fn loadFromZon(arena: main.heap.NeverFailingAllocator, zon: main.ZonElement) Constraint {
 			return .{
 				.allowedTags = if (zon.getChildOrNull("allowedTags")) |tagsZon| Tag.loadTagsFromZon(arena, tagsZon) else null,
 				.allowedFaces = if (zon.getChildOrNull("allowedFaces")) |facesZon| SelectionFaceMask.loadFromZon(facesZon) else null,
 			};
 		}
 
-		pub fn allowsPlacementOnBlock(self: PlacementConstraint, target: Block, from: SelectionFace) bool {
+		pub fn allowsPlacementOnBlock(self: Constraint, target: Block, from: SelectionFace) bool {
 			if (self.allowedTags) |tags| {
 				for (tags) |tag| {
 					if (target.hasTag(tag)) break;
@@ -102,9 +102,9 @@ const PlacementConstraints = struct {
 	};
 
 	pub fn loadFromZon(arena: main.heap.NeverFailingAllocator, zon: main.ZonElement) PlacementConstraints {
-		var list = main.ListUnmanaged(PlacementConstraint).initCapacity(arena, zon.toSlice().len);
+		var list = main.ListUnmanaged(Constraint).initCapacity(arena, zon.toSlice().len);
 		for (zon.toSlice()) |constraintZon| {
-			list.appendAssumeCapacity(PlacementConstraint.loadFromZon(arena, constraintZon));
+			list.appendAssumeCapacity(Constraint.loadFromZon(arena, constraintZon));
 		}
 		return .{.constraints = list.items};
 	}

--- a/src/chunk.zig
+++ b/src/chunk.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const blocks = @import("blocks.zig");
 const Block = blocks.Block;
+const SelectionFace = blocks.SelectionFace;
 const main = @import("main");
 const settings = @import("settings.zig");
 const vec = @import("vec.zig");
@@ -63,6 +64,14 @@ pub const Neighbor = enum(u3) { // MARK: Neighbor
 					else => return null,
 				},
 			},
+		};
+	}
+
+	pub fn toSelectionFace(self: Neighbor) SelectionFace {
+		return switch (self) {
+			.dirDown => .top,
+			.dirUp => .bottom,
+			else => .side,
 		};
 	}
 

--- a/src/chunk.zig
+++ b/src/chunk.zig
@@ -67,7 +67,7 @@ pub const Neighbor = enum(u3) { // MARK: Neighbor
 		};
 	}
 
-	pub fn toSelectionFace(self: Neighbor) SelectionFace {
+	pub inline fn toSelectionFace(self: Neighbor) SelectionFace {
 		return switch (self) {
 			.dirDown => .top,
 			.dirUp => .bottom,

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -942,7 +942,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 		while (total_tMax < closestDistance) {
 			const block = mesh_storage.getBlockFromRenderThread(voxelPos[0], voxelPos[1], voxelPos[2]) orelse break;
 			if (block.typ != 0) blk: {
-				if (!block.isSelectableByItem(item)) break :blk;
+				if (!block.isSelectableByItem(item, neighborOfSelection)) break :blk;
 
 				const relativePlayerPos: Vec3f = @floatCast(pos - @as(Vec3d, @floatFromInt(voxelPos)));
 				if (block.mode().rayIntersection(block, item, relativePlayerPos, _dir)) |intersection| {

--- a/src/tag.zig
+++ b/src/tag.zig
@@ -9,9 +9,8 @@ pub const Tag = enum(u32) {
 	air = 0,
 	fluid = 1,
 	sbbChild = 2,
-	fluidPlaceable = 3,
-	chiselable = 4,
-	playerModel = 5,
+	chiselable = 3,
+	playerModel = 4,
 	_,
 
 	pub fn initTags() void {


### PR DESCRIPTION
Lil demo: https://www.youtube.com/shorts/1qEEHvCX0kc

Related to #2491

Continuation of #2983

For now it's only enforced client-side through selection. But my idea for the future is that the placement constraints will get checked before placement by default through the same function when no `onPlace` callback is defined

And when you do define the callback, that you have to decide in there what to do with the placement constraint check result

Introduces a new concept for blocks, called `support`. Support is about the way other blocks can be placed against it. Soil can always be placed against, but water can only be placed against by lily pads and duckweed through defining the placement constraints

Gets rid of the `.fluidPlaceable` tag, and the case for it in selection

My plan is to make another PR later for also checking whether the neighbor is replaceable or not, so you can disable selection when underwater and holding a lily pad for example

This also opens the door for removing the same type of block check in selection (for vines, water, air, fog). You can add a new placement constraint like `allowedBlocks = .{.auto}`, something like that