### PR TITLE
Rename `__deinit` to `globalDeinit`

### DIFF
--- a/src/gui/GuiWindow.zig
+++ b/src/gui/GuiWindow.zig
@@ -137,7 +137,7 @@ pub fn globalInit() void {
 	zoomOutTexture = Texture.initFromFile("assets/cubyz/ui/window_zoom_out.png");
 }
 
-pub fn __deinit() void {
+pub fn globalDeinit() void {
 	pipeline.deinit();
 	backgroundTexture.deinit();
 	titleTexture.deinit();

--- a/src/gui/components/BagSlot.zig
+++ b/src/gui/components/BagSlot.zig
@@ -30,7 +30,7 @@ pub fn globalInit() void {
 	texture = Texture.initFromFile("assets/cubyz/ui/inventory/bag_slot.png");
 }
 
-pub fn __deinit() void {
+pub fn globalDeinit() void {
 	texture.deinit();
 }
 

--- a/src/gui/components/Button.zig
+++ b/src/gui/components/Button.zig
@@ -76,7 +76,7 @@ pub fn globalInit() void {
 	pressedTextures = Textures.init("assets/cubyz/ui/button_pressed");
 }
 
-pub fn __deinit() void {
+pub fn globalDeinit() void {
 	pipeline.deinit();
 	normalTextures.deinit();
 	hoveredTextures.deinit();

--- a/src/gui/components/CheckBox.zig
+++ b/src/gui/components/CheckBox.zig
@@ -44,7 +44,7 @@ pub fn globalInit() void {
 	textureEmptyPressed = Texture.initFromFile("assets/cubyz/ui/box_pressed.png");
 }
 
-pub fn __deinit() void {
+pub fn globalDeinit() void {
 	textureCheckedNormal.deinit();
 	textureCheckedHovered.deinit();
 	textureCheckedPressed.deinit();

--- a/src/gui/components/ContinuousSlider.zig
+++ b/src/gui/components/ContinuousSlider.zig
@@ -38,7 +38,7 @@ pub fn globalInit() void {
 	texture = Texture.initFromFile("assets/cubyz/ui/slider.png");
 }
 
-pub fn __deinit() void {
+pub fn globalDeinit() void {
 	texture.deinit();
 }
 

--- a/src/gui/components/DiscreteSlider.zig
+++ b/src/gui/components/DiscreteSlider.zig
@@ -36,7 +36,7 @@ pub fn globalInit() void {
 	texture = Texture.initFromFile("assets/cubyz/ui/slider.png");
 }
 
-pub fn __deinit() void {
+pub fn globalDeinit() void {
 	texture.deinit();
 }
 

--- a/src/gui/components/ItemSlot.zig
+++ b/src/gui/components/ItemSlot.zig
@@ -63,7 +63,7 @@ pub fn globalInit() void {
 	craftingResultTexture = Texture.initFromFile("assets/cubyz/ui/inventory/crafting_result_slot.png");
 }
 
-pub fn __deinit() void {
+pub fn globalDeinit() void {
 	defaultTexture.deinit();
 	immutableTexture.deinit();
 	craftingResultTexture.deinit();

--- a/src/gui/components/ScrollBar.zig
+++ b/src/gui/components/ScrollBar.zig
@@ -30,7 +30,7 @@ pub fn globalInit() void {
 	texture = Texture.initFromFile("assets/cubyz/ui/scrollbar.png");
 }
 
-pub fn __deinit() void {
+pub fn globalDeinit() void {
 	texture.deinit();
 }
 

--- a/src/gui/components/TextInput.zig
+++ b/src/gui/components/TextInput.zig
@@ -42,7 +42,7 @@ pub fn globalInit() void {
 	texture = Texture.initFromFile("assets/cubyz/ui/text_input.png");
 }
 
-pub fn __deinit() void {
+pub fn globalDeinit() void {
 	texture.deinit();
 }
 

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -156,15 +156,15 @@ pub fn deinit() void {
 		window.onCloseFn();
 	}
 	openWindows.clearRetainingCapacity();
-	GuiWindow.__deinit();
-	GuiComponent.BagSlot.__deinit();
-	Button.__deinit();
-	CheckBox.__deinit();
-	ItemSlot.__deinit();
-	ScrollBar.__deinit();
-	ContinuousSlider.__deinit();
-	DiscreteSlider.__deinit();
-	TextInput.__deinit();
+	GuiWindow.globalDeinit();
+	GuiComponent.BagSlot.globalDeinit();
+	Button.globalDeinit();
+	CheckBox.globalDeinit();
+	ItemSlot.globalDeinit();
+	ScrollBar.globalDeinit();
+	ContinuousSlider.globalDeinit();
+	DiscreteSlider.globalDeinit();
+	TextInput.globalDeinit();
 	inline for (@typeInfo(windowlist).@"struct".decls) |decl| {
 		const WindowStruct = @field(windowlist, decl.name);
 		if (@hasDecl(WindowStruct, "deinit")) {


### PR DESCRIPTION
Similar PR for `__init` to `globalInit` was merged few weeks ago, now its time to rename complementary `__deinit` functions.