### PR TITLE
fix using the cubyzDir two times

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -361,7 +361,7 @@ pub const World = struct { // MARK: World
 		self.entityComponentPalette = try assets.Palette.init(main.globalAllocator, zon.getChild("entityComponentPalette"), null);
 		errdefer self.entityComponentPalette.deinit();
 
-		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/serverAssets", .{main.files.cubyzDirStr()}) catch unreachable;
+		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "serverAssets", .{}) catch unreachable;
 		defer main.stackAllocator.free(path);
 		try assets.loadWorldAssets(path, self.blockPalette, self.itemPalette, self.proceduralItemPalette, self.biomePalette, self.entityModelPalette, self.entityComponentPalette);
 		Player.id = zon.get(u32, "player_id", std.math.maxInt(u32));

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -508,7 +508,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		try self.loadWorldConfig(arena, dir, worldData);
 		try self.loadPlayerLoginInfo(dir);
 
-		try main.assets.loadWorldAssets(try std.fmt.allocPrint(arena.allocator, "{s}/saves/{s}/assets/", .{files.cubyzDirStr(), path}), self.blockPalette, self.itemPalette, self.proceduralItemPalette, self.biomePalette, self.entityModelPalette, self.entityComponentPalette);
+		try main.assets.loadWorldAssets(try std.fmt.allocPrint(arena.allocator, "saves/{s}/assets/", .{path}), self.blockPalette, self.itemPalette, self.proceduralItemPalette, self.biomePalette, self.entityModelPalette, self.entityComponentPalette);
 		// Store the block palette now that everything is loaded.
 		try dir.writeZon("palette.zig.zon", self.blockPalette.storeToZon(arena));
 		try dir.writeZon("item_palette.zig.zon", self.itemPalette.storeToZon(arena));


### PR DESCRIPTION
Fixes part of #2879 

In this function the `cubyzDir` was passed even tough we call all open Dir etc directly on `cubyzDir` already. this made so that if `cubyzDir` was something diffreent than `.` (where `././` is just the same as `./`) we would go two times into a directory