### PR TITLE
Use a hexagonal grid for the biome map

### DIFF
--- a/assets/cubyz/biomes/ocean/cold/island/base.zig.zon
+++ b/assets/cubyz/biomes/ocean/cold/island/base.zig.zon
@@ -38,7 +38,7 @@
 		.{
 			.id = "cubyz:ocean/cold/island/shelf",
 			.chance = 1,
-			.parentEdgeDistance = 45,
+			.parentEdgeDistance = 37,
 		},
 	},
 }

--- a/assets/cubyz/biomes/ocean/cold/island/shelf.zig.zon
+++ b/assets/cubyz/biomes/ocean/cold/island/shelf.zig.zon
@@ -1,7 +1,7 @@
 .{
 	.minHeight = -10,
 	.maxHeight = -1,
-	.radius = 77,
+	.radius = 70,
 	.hills = 3,
 	.ground_structure = .{
 		"2 to 3 cubyz:gravel",

--- a/assets/cubyz/biomes/ocean/temperate/island/base.zig.zon
+++ b/assets/cubyz/biomes/ocean/temperate/island/base.zig.zon
@@ -52,7 +52,7 @@
 		.{
 			.id = "cubyz:ocean/temperate/island/shelf",
 			.chance = 1,
-			.parentEdgeDistance = 45,
+			.parentEdgeDistance = 37,
 		},
 	},
 }

--- a/assets/cubyz/biomes/ocean/temperate/island/shelf.zig.zon
+++ b/assets/cubyz/biomes/ocean/temperate/island/shelf.zig.zon
@@ -1,7 +1,7 @@
 .{
 	.minHeight = -10,
 	.maxHeight = -1,
-	.radius = 77,
+	.radius = 70,
 	.hills = 3,
 	.maxSubBiomeCount = 1,
 	.ground_structure = .{

--- a/assets/cubyz/biomes/ocean/warm/island/base.zig.zon
+++ b/assets/cubyz/biomes/ocean/warm/island/base.zig.zon
@@ -45,7 +45,7 @@
 		.{
 			.id = "cubyz:ocean/warm/island/shelf",
 			.chance = 1,
-			.parentEdgeDistance = 45,
+			.parentEdgeDistance = 37,
 		},
 	},
 }

--- a/assets/cubyz/biomes/ocean/warm/island/shelf.zig.zon
+++ b/assets/cubyz/biomes/ocean/warm/island/shelf.zig.zon
@@ -1,7 +1,7 @@
 .{
 	.minHeight = -10,
 	.maxHeight = -1,
-	.radius = 77,
+	.radius = 70,
 	.hills = 3,
 	.maxSubBiomeCount = 1,
 	.ground_structure = .{

--- a/src/server/terrain/climategen/NoiseBasedVoronoi.zig
+++ b/src/server/terrain/climategen/NoiseBasedVoronoi.zig
@@ -396,7 +396,7 @@ const GenerationStructure = struct {
 			for (1..preMapSize - 1) |x| {
 				for (1..preMapSize - 1) |y| {
 					const y1 = y;
-					const y2 = if (x%2 == 1) y - 1 else y + 1;
+					const y2 = if (x%2 == 1) y + 1 else y - 1;
 					const xNeighbors = neighborData[i - 1][x - 1][y1] | neighborData[i - 1][x - 1][y2] | neighborData[i - 1][x + 1][y1] | neighborData[i - 1][x + 1][y2];
 					neighborData[i][x][y] = neighborData[i - 1][x][y] | neighborData[i - 1][x][y - 1] | neighborData[i - 1][x][y + 1] | xNeighbors;
 				}

--- a/src/server/terrain/climategen/NoiseBasedVoronoi.zig
+++ b/src/server/terrain/climategen/NoiseBasedVoronoi.zig
@@ -211,7 +211,8 @@ const GenerationStructure = struct {
 
 	fn findClosestBiomeTo(prefilteredCandidates: []*BiomePoint, wx: i32, wy: i32, relX: i32, relY: i32, worldSeed: u64) BiomeSample {
 		const x = wx +% relX*terrain.SurfaceMap.MapFragment.biomeSize;
-		const y = wy +% relY*terrain.SurfaceMap.MapFragment.biomeSize;
+		var y = wy +% relY*terrain.SurfaceMap.MapFragment.biomeSize;
+		if (@mod(relX, 2) == 1) y += terrain.SurfaceMap.MapFragment.biomeSize/2;
 		var closestDist = std.math.floatMax(f32);
 		var secondClosestDist = std.math.floatMax(f32);
 		var closestBiomePoint: BiomePoint = undefined;
@@ -303,7 +304,8 @@ const GenerationStructure = struct {
 		if (skipMismatched) {
 			var x: f32 = min[0];
 			while (x < max[0]) : (x += 1) {
-				var y: f32 = min[1];
+				const yOffset: f32 = @mod(x, 2)*0.5;
+				var y: f32 = min[1] + yOffset;
 				while (y < max[1]) : (y += 1) {
 					const distSquare = vec.lengthSquare(Vec2f{x, y} - relPos);
 					if (distSquare < relRadius*relRadius) {
@@ -316,7 +318,8 @@ const GenerationStructure = struct {
 		}
 		var x: f32 = min[0];
 		while (x < max[0]) : (x += 1) {
-			var y: f32 = min[1];
+			const yOffset: f32 = @mod(x, 2)*0.5;
+			var y: f32 = min[1] + yOffset;
 			while (y < max[1]) : (y += 1) {
 				const distSquare = vec.lengthSquare(Vec2f{x, y} - relPos);
 				if (distSquare < relRadius*relRadius) {
@@ -392,7 +395,10 @@ const GenerationStructure = struct {
 		for (1..neighborData.len) |i| {
 			for (1..preMapSize - 1) |x| {
 				for (1..preMapSize - 1) |y| {
-					neighborData[i][x][y] = neighborData[i - 1][x][y] | neighborData[i - 1][x - 1][y] | neighborData[i - 1][x + 1][y] | neighborData[i - 1][x][y - 1] | neighborData[i - 1][x][y + 1];
+					const y1 = y;
+					const y2 = if (x%2 == 1) y - 1 else y + 1;
+					const xNeighbors = neighborData[i - 1][x - 1][y1] | neighborData[i - 1][x - 1][y2] | neighborData[i - 1][x + 1][y1] | neighborData[i - 1][x + 1][y2];
+					neighborData[i][x][y] = neighborData[i - 1][x][y] | neighborData[i - 1][x][y - 1] | neighborData[i - 1][x][y + 1] | xNeighbors;
 				}
 			}
 		}
@@ -457,7 +463,7 @@ const GenerationStructure = struct {
 				const wxMin = wx +% newRelX*terrain.SurfaceMap.MapFragment.biomeSize;
 				const wxMax = wxMin +% newWidth*terrain.SurfaceMap.MapFragment.biomeSize;
 				const wyMin = wy +% newRelY*terrain.SurfaceMap.MapFragment.biomeSize;
-				const wyMax = wyMin +% newHeight*terrain.SurfaceMap.MapFragment.biomeSize;
+				const wyMax = wyMin +% newHeight*terrain.SurfaceMap.MapFragment.biomeSize +% terrain.SurfaceMap.MapFragment.biomeSize;
 
 				newCandidates.clearRetainingCapacity();
 				for (biomeCandidates) |candidate| {

--- a/src/server/terrain/mapgen/MapGenV1.zig
+++ b/src/server/terrain/mapgen/MapGenV1.zig
@@ -151,9 +151,6 @@ pub fn generateMapFragment(map: *MapFragment, worldSeed: u64) void {
 			const rawXBiome = (updatedX - @as(f32, @floatFromInt(map.pos.wx)))/biomeSize;
 			const rawYBiome = (updatedY - @as(f32, @floatFromInt(map.pos.wy)))/biomeSize;
 
-			// Select a biome. Also adding some white noise to make a smoother transition.
-			//const roundedXBiome = @as(i32, @round(rawXBiome)) + offset;
-			//const roundedYBiome = @as(i32, @round(rawYBiome)) + offset;
 			const points = getNearestNeighborsInHexGrid(.{rawXBiome, rawYBiome});
 			const barycentricCoordinates: [3]f32 = computeBarycentricCoordinates(points, .{rawXBiome, rawYBiome});
 			var weights: [3]f32 = undefined;

--- a/src/server/terrain/mapgen/MapGenV1.zig
+++ b/src/server/terrain/mapgen/MapGenV1.zig
@@ -153,7 +153,7 @@ pub fn generateMapFragment(map: *MapFragment, worldSeed: u64) void {
 
 			const points = getNearestNeighborsInHexGrid(.{rawXBiome, rawYBiome});
 			const barycentricCoordinates: [3]f32 = computeBarycentricCoordinates(points, .{rawXBiome, rawYBiome});
-			var weights: [3]f32 = undefined;
+			var weights: [3]f32 = @splat(0);
 			var totalWeight: f32 = 0;
 			for (points, 0..) |point, i| {
 				const biomeSample = biomePositions.get(@intCast(point[0] + offset), @intCast(point[1] + offset));

--- a/src/server/terrain/mapgen/MapGenV1.zig
+++ b/src/server/terrain/mapgen/MapGenV1.zig
@@ -12,6 +12,7 @@ const RandomlyWeightedFractalNoise = noise.RandomlyWeightedFractalNoise;
 const PerlinNoise = noise.PerlinNoise;
 const vec = main.vec;
 const Vec2f = vec.Vec2f;
+const Vec2i = vec.Vec2i;
 
 pub const id = "cubyz:mapgen_v1";
 
@@ -19,29 +20,83 @@ pub fn init(parameters: ZonElement) void {
 	_ = parameters;
 }
 
-/// Assumes the 2 points are at tᵢ = (0, 1)
-fn interpolationWeights(t: f32, interpolation: terrain.biomes.Interpolation) Vec2f {
+fn interpolationWeights(bary: [3]f32, interpolation: terrain.biomes.Interpolation) [3]f32 {
 	switch (interpolation) {
 		.none => {
-			if (t < 0.5) {
-				return .{1, 0};
+			if (bary[0] > bary[1]) {
+				if (bary[0] > bary[2]) return .{1, 0, 0};
 			} else {
-				return .{0, 1};
+				if (bary[1] > bary[2]) return .{0, 1, 0};
 			}
+			return .{0, 0, 1};
 		},
 		.linear => {
-			return .{1 - t, t};
+			return bary;
 		},
 		.square => {
-			if (t < 0.5) {
-				const tSqr = 2*t*t;
-				return .{1 - tSqr, tSqr};
-			} else {
-				const tSqr = 2*(1 - t)*(1 - t);
-				return .{tSqr, 1 - tSqr};
+			var result: [3]f32 = undefined;
+			var total: f32 = 0;
+			for (0..3) |i| {
+				result[i] = bary[i]*bary[i];
+				total += bary[i]*bary[i];
 			}
+			for (0..3) |i| {
+				result[i] /= total;
+			}
+			return result;
 		},
 	}
+}
+
+fn getNearestNeighborsInHexGrid(in: Vec2f) [3]Vec2i {
+	var gridNearest: Vec2i = @round(in);
+	var offset = in - @as(Vec2f, @floatFromInt(gridNearest));
+	if (@mod(gridNearest[0], 2) == 1) {
+		gridNearest[1] = @round(in[1] - 0.5);
+		offset[1] = in[1] - 0.5 - @as(f32, @floatFromInt(gridNearest[1]));
+	}
+
+	var result: [3]Vec2i = undefined;
+	result[0] = gridNearest;
+
+	if (offset[0] < 0) {
+		result[1][0] = gridNearest[0] - 1;
+	} else {
+		result[1][0] = gridNearest[0] + 1;
+	}
+	if (@abs(offset[0]) < 2*@abs(offset[1])) { // We got two from the same y row
+		result[1][1] = @round(in[1] - @as(f32, if (@mod(result[1][0], 2) == 1) 0.5 else 0));
+		result[2] = gridNearest + Vec2i{0, if (offset[1] < 0) -1 else 1};
+	} else { // We got two from the other y row
+		result[1][1] = @round(in[1] - @as(f32, if (@mod(result[1][0], 2) == 1) 0.5 else 0));
+		const offset2 = in[1] - @as(f32, if (@mod(result[1][0], 2) == 1) 0.5 else 0) - @as(f32, @floatFromInt(result[1][1]));
+		result[2] = result[1] + Vec2i{0, if (offset2 < 0) -1 else 1};
+	}
+
+	return result;
+}
+
+fn computeBarycentricCoordinates(in: [3]Vec2i, pos: Vec2f) [3]f32 {
+	var real: [3]Vec2f = undefined;
+	for (in, 0..) |point, i| {
+		real[i] = @floatFromInt(point);
+		if (@mod(point[0], 2) == 1) real[i][1] += 0.5;
+	}
+	// taken from https://gamedev.stackexchange.com/a/23745
+	const v0 = real[1] - real[0];
+	const v1 = real[2] - real[0];
+	const v2 = pos - real[0];
+	const d00 = vec.dot(v0, v0);
+	const d01 = vec.dot(v0, v1);
+	const d11 = vec.dot(v1, v1);
+	const d20 = vec.dot(v2, v0);
+	const d21 = vec.dot(v2, v1);
+	const denom = d00*d11 - d01*d01;
+	var result: [3]f32 = undefined;
+	result[1] = (d11*d20 - d01*d21)/denom;
+	result[2] = (d00*d21 - d01*d20)/denom;
+	result[0] = 1.0 - result[1] - result[2];
+	return result;
 }
 
 pub fn generateMapFragment(map: *MapFragment, worldSeed: u64) void {
@@ -49,6 +104,7 @@ pub fn generateMapFragment(map: *MapFragment, worldSeed: u64) void {
 	const mapSize = scaledSize*map.pos.voxelSize;
 	const biomeSize = MapFragment.biomeSize;
 	const offset = 32;
+	std.debug.assert(offset%2 == 0);
 	const biomePositions = terrain.ClimateMap.getBiomeMap(main.stackAllocator, map.pos.wx -% offset*biomeSize, map.pos.wy -% offset*biomeSize, mapSize + 2*offset*biomeSize, mapSize + 2*offset*biomeSize);
 	defer biomePositions.deinit(main.stackAllocator);
 	var seed = random.initSeed2D(worldSeed, .{map.pos.wx, map.pos.wy});
@@ -94,39 +150,30 @@ pub fn generateMapFragment(map: *MapFragment, worldSeed: u64) void {
 			const updatedY = wy + offsetY;
 			const rawXBiome = (updatedX - @as(f32, @floatFromInt(map.pos.wx)))/biomeSize;
 			const rawYBiome = (updatedY - @as(f32, @floatFromInt(map.pos.wy)))/biomeSize;
-			const xBiome: i32 = @as(i32, @floor(rawXBiome)) + offset;
-			const yBiome: i32 = @as(i32, @floor(rawYBiome)) + offset;
-			const relXBiome = rawXBiome - @floor(rawXBiome);
-			const relYBiome = rawYBiome - @floor(rawYBiome);
-			const interpolationCoefficientsX = interpolationWeights(relXBiome, .square);
-			const interpolationCoefficientsY = interpolationWeights(relYBiome, .square);
-			var coefficientsX: vec.Vec2f = .{0, 0};
-			var coefficientsY: vec.Vec2f = .{0, 0};
+
+			// Select a biome. Also adding some white noise to make a smoother transition.
+			//const roundedXBiome = @as(i32, @round(rawXBiome)) + offset;
+			//const roundedYBiome = @as(i32, @round(rawYBiome)) + offset;
+			const points = getNearestNeighborsInHexGrid(.{rawXBiome, rawYBiome});
+			const barycentricCoordinates: [3]f32 = computeBarycentricCoordinates(points, .{rawXBiome, rawYBiome});
+			var weights: [3]f32 = undefined;
 			var totalWeight: f32 = 0;
-			for (0..2) |dx| {
-				for (0..2) |dy| {
-					const biomeMapX = @as(usize, @intCast(xBiome)) + dx;
-					const biomeMapY = @as(usize, @intCast(yBiome)) + dy;
-					const biomeSample = biomePositions.get(biomeMapX, biomeMapY);
-					const weight = @as([2]f32, interpolationCoefficientsX)[dx]*@as([2]f32, interpolationCoefficientsY)[dy]*biomeSample.biome.interpolationWeight;
-					coefficientsX += interpolationWeights(relXBiome, biomeSample.biome.interpolation)*@as(Vec2f, @splat(weight));
-					coefficientsY += interpolationWeights(relYBiome, biomeSample.biome.interpolation)*@as(Vec2f, @splat(weight));
-					totalWeight += weight;
+			for (points, 0..) |point, i| {
+				const biomeSample = biomePositions.get(@intCast(point[0] + offset), @intCast(point[1] + offset));
+				const weight = biomeSample.biome.interpolationWeight*barycentricCoordinates[i];
+				for (interpolationWeights(barycentricCoordinates, biomeSample.biome.interpolation), 0..) |interp, j| {
+					weights[j] += interp*weight;
 				}
+				totalWeight += weight;
 			}
-			coefficientsX /= @splat(totalWeight);
-			coefficientsY /= @splat(totalWeight);
-			for (0..2) |dx| {
-				for (0..2) |dy| {
-					const biomeMapX = @as(usize, @intCast(xBiome)) + dx;
-					const biomeMapY = @as(usize, @intCast(yBiome)) + dy;
-					const weight = @as([2]f32, coefficientsX)[dx]*@as([2]f32, coefficientsY)[dy];
-					const biomeSample = biomePositions.get(biomeMapX, biomeMapY);
-					height += biomeSample.height*weight;
-					roughness += biomeSample.roughness*weight;
-					hills += biomeSample.hills*weight;
-					mountains += biomeSample.mountains*weight;
-				}
+
+			for (points, 0..) |point, i| {
+				const weight = weights[i]/totalWeight;
+				const biomeSample = biomePositions.get(@intCast(point[0] + offset), @intCast(point[1] + offset));
+				height += biomeSample.height*weight;
+				roughness += biomeSample.roughness*weight;
+				hills += biomeSample.hills*weight;
+				mountains += biomeSample.mountains*weight;
 			}
 			height += (roughMap.get(x, y) - 0.5)*2*roughness;
 			height += (hillMap.get(x, y) - 0.5)*2*hills;
@@ -136,10 +183,18 @@ pub fn generateMapFragment(map: *MapFragment, worldSeed: u64) void {
 			map.minHeight = @max(map.minHeight, 0);
 			map.maxHeight = @max(map.maxHeight, @as(i32, @trunc(height)));
 
-			// Select a biome. Also adding some white noise to make a smoother transition.
-			const roundedXBiome = @as(i32, @round(rawXBiome)) + offset;
-			const roundedYBiome = @as(i32, @round(rawYBiome)) + offset;
-			const biomePoint = biomePositions.get(@intCast(roundedXBiome), @intCast(roundedYBiome));
+			var closestDist: f32 = std.math.floatMax(f32);
+			var closestPoint: Vec2i = undefined;
+			for (points) |point| {
+				var pointFloat: Vec2f = @floatFromInt(point);
+				if (@mod(point[0], 2) == 1) pointFloat[1] += 0.5;
+				const dist = vec.lengthSquare(pointFloat - Vec2f{rawXBiome, rawYBiome});
+				if (dist < closestDist) {
+					closestDist = dist;
+					closestPoint = point;
+				}
+			}
+			const biomePoint = biomePositions.get(@intCast(closestPoint[0] + offset), @intCast(closestPoint[1] + offset));
 			map.biomeMap[x][y] = biomePoint.biome;
 		}
 	}


### PR DESCRIPTION
should be barely noticable in-game, the main difference is that biome edges should be smoother and have less sharp edges, furthermore 4-way biome intersections are no longer possible

I also reduced the island shelf size and parent offset as mentioned in #2620 

fixes #213

- [x] check beaches and islands in-game
- [x] check plateau and tall mountain biomes in-game
- [x] make a benchmark → negligible compared to PerlinNoise calculation
- [x] cleanup code