### PR TITLE
Remove anyerror where easily possible and add a check for it to the format checker

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -140,7 +140,7 @@ fn addModFeatures(b: *std.Build, exe: *std.Build.Step.Compile) !void {
 	try addModFeatureModule(b, exe, "rotation");
 }
 
-pub fn makeModFeaturesStep(step: *std.Build.Step, options: std.Build.Step.MakeOptions) anyerror!void {
+pub fn makeModFeaturesStep(step: *std.Build.Step, options: std.Build.Step.MakeOptions) !void {
 	var io = std.Io.Threaded.init(options.gpa, .{});
 	defer io.deinit();
 

--- a/src/entityModel.zig
+++ b/src/entityModel.zig
@@ -260,7 +260,7 @@ pub const EntityModel = struct {
 		return getHierarchyMatrix(node.parent.*, sys).mul(currentMat);
 	}
 
-	fn getGltfError(result: gltf.cgltf_result) anyerror {
+	fn getGltfError(result: gltf.cgltf_result) error{ DataTooShort, UnknownFormat, InvalidJson, InvalidGltf, InvalidOptions, FileNotFound, IoError, OutOfMemory, LegacyGltf } {
 		return switch (result) {
 			gltf.cgltf_result_data_too_short => error.DataTooShort,
 			gltf.cgltf_result_unknown_format => error.UnknownFormat,

--- a/src/formatter/format.zig
+++ b/src/formatter/format.zig
@@ -73,7 +73,7 @@ fn checkFile(dir: std.Io.Dir, filePath: []const u8) !void {
 	}
 	if (std.mem.containsAtLeast(u8, data, 1, "anyerror" ++ "!")) {
 		if (!std.mem.eql(u8, filePath, "network/protocols.zig")) {
-			std.log.err("Found anyerror" ++ "! in file {s}. Please avoid the use of anyerror" ++ "!", .{filePath});
+			std.log.err("Found anyerror" ++ "! in file {s}. Please avoid the use of anyerror" ++ "! instead please define an error set.", .{filePath});
 		}
 	}
 	if (data.len != 0 and data[data.len - 1] != '\n' or (data.len > 2 and data[data.len - 2] == '\n')) {

--- a/src/formatter/format.zig
+++ b/src/formatter/format.zig
@@ -71,6 +71,11 @@ fn checkFile(dir: std.Io.Dir, filePath: []const u8) !void {
 			},
 		}
 	}
+	if (std.mem.containsAtLeast(u8, data, 1, "anyerror" ++ "!")) {
+		if (!std.mem.eql(u8, filePath, "network/protocols.zig")) {
+			std.log.err("Found anyerror" ++ "! in file {s}. Please avoid the use of anyerror" ++ "!", .{filePath});
+		}
+	}
 	if (data.len != 0 and data[data.len - 1] != '\n' or (data.len > 2 and data[data.len - 2] == '\n')) {
 		printError("File should end with a single empty line", filePath, data, data.len - 1);
 	}

--- a/src/network.zig
+++ b/src/network.zig
@@ -130,7 +130,7 @@ const Socket = struct {
 		if (builtin.os.tag == .windows) {
 			const result = ws2.sendto(self.socketID, data.ptr, @intCast(data.len), 0, @ptrCast(&addr), @sizeOf(posix.sockaddr.in));
 			if (result == ws2.SOCKET_ERROR) {
-				const err: anyerror = if (windowsError(ws2.WSAGetLastError())) error.Unknown else |err| err;
+				const err = if (windowsError(ws2.WSAGetLastError())) error.Unknown else |err| err;
 				std.log.warn("Got error while sending to {f}: {s}", .{destination, @errorName(err)});
 			} else {
 				std.debug.assert(@as(usize, @intCast(result)) == data.len);

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -912,7 +912,7 @@ pub const inventory = struct { // MARK: inventory
 	}
 	fn serverReceive(conn: *Connection, reader: *utils.BinaryReader) !void {
 		const user = conn.user.?;
-		if (reader.remaining[0] == 0xff) return error.InvalidPacket;
+		if (reader.remaining[0] == 0xff) return error.Invalid;
 		main.sync.ServerSide.receiveCommand(user, reader);
 	}
 	pub fn sendCommand(conn: *Connection, payloadType: main.sync.Command.PayloadType, _data: []const u8) void {

--- a/src/server/command/particles.zig
+++ b/src/server/command/particles.zig
@@ -30,16 +30,14 @@ pub fn execute(args: []const u8, source: *User) void {
 		switch (err) {
 			error.TooFewArguments => source.sendMessage("#ff0000Too few arguments for command /particles", .{}),
 			error.TooManyArguments => source.sendMessage("#ff0000Too many arguments for command /particles", .{}),
-			error.InvalidParticleId => source.sendMessage("#ff0000Invalid particle id", .{}),
 			error.InvalidBoolean => source.sendMessage("#ff0000Invalid argument. Expected \"true\" or \"false\"", .{}),
 			error.InvalidNumber => return,
-			else => source.sendMessage("#ff0000Error: {s}", .{@errorName(err)}),
 		}
 		return;
 	};
 }
 
-fn parseArguments(source: *User, args: []const u8) anyerror!void {
+fn parseArguments(source: *User, args: []const u8) !void {
 	const zonIndex = std.mem.indexOf(u8, args, " .{") orelse args.len;
 	const zonStr = args[zonIndex..];
 	var split = std.mem.splitScalar(u8, std.mem.trimEnd(u8, args[0..zonIndex], " "), ' ');
@@ -59,7 +57,7 @@ fn parseArguments(source: *User, args: []const u8) anyerror!void {
 	}
 }
 
-fn parseBool(arg: []const u8) anyerror!bool {
+fn parseBool(arg: []const u8) !bool {
 	if (std.mem.eql(u8, arg, "true")) {
 		return true;
 	} else if (std.mem.eql(u8, arg, "false")) {
@@ -69,7 +67,7 @@ fn parseBool(arg: []const u8) anyerror!bool {
 	return error.InvalidBoolean;
 }
 
-fn parseNumber(arg: []const u8, source: *User) anyerror!u32 {
+fn parseNumber(arg: []const u8, source: *User) !u32 {
 	return std.fmt.parseUnsigned(u32, arg, 0) catch |err| {
 		switch (err) {
 			error.Overflow => {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1700,7 +1700,7 @@ pub const BinaryReader = struct { // MARK: BinaryReader
 		return std.mem.readInt(T, self.remaining[0..bufSize], endian);
 	}
 
-	pub fn readVarInt(self: *BinaryReader, T: type) !T {
+	pub fn readVarInt(self: *BinaryReader, T: type) error{ OutOfBounds, IntOutOfBounds }!T {
 		comptime std.debug.assert(@typeInfo(T).int.signedness == .unsigned);
 		comptime std.debug.assert(@bitSizeOf(T) > 8); // Why would you use a VarInt for this?
 		var result: T = 0;
@@ -1708,9 +1708,9 @@ pub const BinaryReader = struct { // MARK: BinaryReader
 		while (true) {
 			const nextByte = try self.readInt(u8);
 			const value: T = nextByte & 0x7f;
-			result |= try std.math.shlExact(T, value, shift);
+			result |= std.math.shlExact(T, value, shift) catch return error.IntOutOfBounds;
 			if (nextByte & 0x80 == 0) break;
-			shift = try std.math.add(@TypeOf(shift), shift, 7);
+			shift = std.math.add(@TypeOf(shift), shift, 7) catch return error.IntOutOfBounds;
 		}
 		return result;
 	}


### PR DESCRIPTION
I removed all but 2 use-cases of anyerror:
- fmt.zig which uses it to runtime-print any error string, this is a legitimate use-cases
- protocols.zig where anyerror has been used for too long and it would be a pain to transition

To avoid having any more discussions about this in future reviews, I decided to add a check for it to the little format script

fixes #2813