### PR TITLE
Rename ClientSide and ServerSide to client and server

### DIFF
--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -22,7 +22,7 @@ const ProceduralItemTypeIndex = main.items.ProceduralItemTypeIndex;
 
 pub const InventoryId = enum(u32) { _ };
 
-pub const ClientSide = struct {
+pub const client = struct {
 	var maxId: InventoryId = @enumFromInt(0);
 	var freeIdList: main.List(InventoryId) = undefined;
 	var serverToClientMap: std.AutoHashMap(InventoryId, Inventory) = undefined;
@@ -384,7 +384,7 @@ pub const ServerSide = struct { // MARK: ServerSide
 pub fn getInventory(id: InventoryId, side: sync.Side, user: ?*main.server.User) ?Inventory {
 	sync.threadContext.assertCorrectContext(side);
 	return switch (side) {
-		.client => ClientSide.getInventory(id),
+		.client => client.getInventory(id),
 		.server => ServerSide.getInventory(user.?, id),
 	};
 }
@@ -527,7 +527,7 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 		const workbenchInv = blk: {
 			main.sync.ClientSide.mutex.lock();
 			defer main.sync.ClientSide.mutex.unlock();
-			break :blk ClientSide.getInventoryByClientId(source.type.workbenchResult);
+			break :blk client.getInventoryByClientId(source.type.workbenchResult);
 		} orelse return;
 
 		main.sync.ClientSide.executeCommand(.{.craftProceduralItem = .init(destinations, workbenchInv)});
@@ -571,7 +571,7 @@ fn _init(allocator: NeverFailingAllocator, _size: usize, source: Source, side: s
 	const self = Inventory{
 		._items = allocator.alloc(ItemStack, _size),
 		.id = switch (side) {
-			.client => ClientSide.nextId(),
+			.client => client.nextId(),
 			.server => ServerSide.nextId(),
 		},
 		.source = source,
@@ -585,7 +585,7 @@ fn _init(allocator: NeverFailingAllocator, _size: usize, source: Source, side: s
 
 pub fn _deinit(self: Inventory, allocator: NeverFailingAllocator, side: sync.Side) void {
 	switch (side) {
-		.client => ClientSide.freeId(self.id),
+		.client => client.freeId(self.id),
 		.server => ServerSide.freeId(self.id),
 	}
 	for (self._items) |*item| {

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -91,7 +91,7 @@ pub const client = struct { // MARK: client
 	}
 };
 
-pub const ServerSide = struct { // MARK: ServerSide
+pub const server = struct { // MARK: server
 	const ServerInventory = struct {
 		inv: Inventory,
 		users: main.ListUnmanaged(struct { user: *main.server.User, cliendId: InventoryId }),
@@ -274,7 +274,7 @@ pub const ServerSide = struct { // MARK: ServerSide
 					fn callback(callbackSource: Source) void {
 						std.debug.assert(callbackSource == .workbench);
 						const workbenchInventory = getInventoryFromSource(callbackSource) orelse @panic("Could not find workbench Inventory");
-						const playerInventory = ServerSide.getInventoryFromSource(.{.playerInventory = callbackSource.workbench.playerId}) orelse @panic("Could not find player Inventory");
+						const playerInventory = server.getInventoryFromSource(.{.playerInventory = callbackSource.workbench.playerId}) orelse @panic("Could not find player Inventory");
 
 						const userList = main.server.getUserListAndIncreaseRefCount(main.stackAllocator);
 						defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
@@ -385,7 +385,7 @@ pub fn getInventory(id: InventoryId, side: sync.Side, user: ?*main.server.User) 
 	sync.threadContext.assertCorrectContext(side);
 	return switch (side) {
 		.client => client.getInventory(id),
-		.server => ServerSide.getInventory(user.?, id),
+		.server => server.getInventory(user.?, id),
 	};
 }
 
@@ -572,7 +572,7 @@ fn _init(allocator: NeverFailingAllocator, _size: usize, source: Source, side: s
 		._items = allocator.alloc(ItemStack, _size),
 		.id = switch (side) {
 			.client => client.nextId(),
-			.server => ServerSide.nextId(),
+			.server => server.nextId(),
 		},
 		.source = source,
 		.callbacks = callbacks,
@@ -586,7 +586,7 @@ fn _init(allocator: NeverFailingAllocator, _size: usize, source: Source, side: s
 pub fn _deinit(self: Inventory, allocator: NeverFailingAllocator, side: sync.Side) void {
 	switch (side) {
 		.client => client.freeId(self.id),
-		.server => ServerSide.freeId(self.id),
+		.server => server.freeId(self.id),
 	}
 	for (self._items) |*item| {
 		item.deinit();

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -280,7 +280,7 @@ pub const server = struct { // MARK: server
 						defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
 						for (userList) |callbackUser| {
 							if (callbackUser.id == callbackSource.workbench.playerId) {
-								sync.ServerSide.executeCommand(.{.depositOrDrop = .initWithInventories(&.{playerInventory}, workbenchInventory, callbackUser.player().pos)}, null);
+								sync.server.executeCommand(.{.depositOrDrop = .initWithInventories(&.{playerInventory}, workbenchInventory, callbackUser.player().pos)}, null);
 								break;
 							}
 						}
@@ -347,7 +347,7 @@ pub const server = struct { // MARK: server
 		var inventoryIdIterator = user.inventoryClientToServerIdMap.valueIterator();
 		while (inventoryIdIterator.next()) |inventoryId| {
 			if (inventories.items()[@intFromEnum(inventoryId.*)].source == .playerInventory) {
-				sync.ServerSide.executeCommand(.{.clear = .{.inv = inventories.items()[@intFromEnum(inventoryId.*)].inv}}, null);
+				sync.server.executeCommand(.{.clear = .{.inv = inventories.items()[@intFromEnum(inventoryId.*)].inv}}, null);
 			}
 		}
 	}
@@ -363,14 +363,14 @@ pub const server = struct { // MARK: server
 					if (std.meta.eql(invStack.item, itemStack.item)) {
 						const amount = @min(itemStack.item.stackSize() - invStack.amount, itemStack.amount);
 						if (amount == 0) continue;
-						sync.ServerSide.executeCommand(.{.fillFromCreative = .{.dest = .{.inv = inv, .slot = @intCast(slot)}, .item = itemStack.item, .amount = invStack.amount + amount}}, null);
+						sync.server.executeCommand(.{.fillFromCreative = .{.dest = .{.inv = inv, .slot = @intCast(slot)}, .item = itemStack.item, .amount = invStack.amount + amount}}, null);
 						itemStack.amount -= amount;
 						if (itemStack.amount == 0) break :outer;
 					}
 				}
 				for (inv._items, 0..) |invStack, slot| {
 					if (invStack.item == .null) {
-						sync.ServerSide.executeCommand(.{.fillFromCreative = .{.dest = .{.inv = inv, .slot = @intCast(slot)}, .item = itemStack.item, .amount = itemStack.amount}}, null);
+						sync.server.executeCommand(.{.fillFromCreative = .{.dest = .{.inv = inv, .slot = @intCast(slot)}, .item = itemStack.item, .amount = itemStack.amount}}, null);
 						itemStack.amount = 0;
 						break :outer;
 					}

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -39,8 +39,8 @@ pub const client = struct { // MARK: client
 	}
 
 	fn nextId() InventoryId {
-		main.sync.ClientSide.mutex.lock();
-		defer main.sync.ClientSide.mutex.unlock();
+		main.sync.client.mutex.lock();
+		defer main.sync.client.mutex.unlock();
 		if (freeIdList.popOrNull()) |id| {
 			return id;
 		}
@@ -50,22 +50,22 @@ pub const client = struct { // MARK: client
 
 	fn freeId(id: InventoryId) void {
 		sync.threadContext.assertCorrectContext(.client);
-		main.utils.assertLocked(&main.sync.ClientSide.mutex);
+		main.utils.assertLocked(&main.sync.client.mutex);
 		freeIdList.append(id);
 	}
 
 	pub fn mapServerId(serverId: InventoryId, inventory: Inventory) void {
-		main.utils.assertLocked(&main.sync.ClientSide.mutex);
+		main.utils.assertLocked(&main.sync.client.mutex);
 		serverToClientMap.put(serverId, inventory) catch unreachable;
 	}
 
 	pub fn unmapServerId(serverId: InventoryId, clientId: InventoryId) void {
-		main.utils.assertLocked(&main.sync.ClientSide.mutex);
+		main.utils.assertLocked(&main.sync.client.mutex);
 		std.debug.assert(serverToClientMap.fetchRemove(serverId).?.value.id == clientId);
 	}
 
 	pub fn unmapServerIdByClientId(clientId: InventoryId) void {
-		main.utils.assertLocked(&main.sync.ClientSide.mutex);
+		main.utils.assertLocked(&main.sync.client.mutex);
 		const serverId = blk: {
 			var it = serverToClientMap.iterator();
 			while (it.next()) |entry| {
@@ -77,12 +77,12 @@ pub const client = struct { // MARK: client
 	}
 
 	fn getInventory(serverId: InventoryId) ?Inventory {
-		main.utils.assertLocked(&main.sync.ClientSide.mutex);
+		main.utils.assertLocked(&main.sync.client.mutex);
 		return serverToClientMap.get(serverId);
 	}
 
 	fn getInventoryByClientId(clientId: InventoryId) ?Inventory {
-		main.utils.assertLocked(&main.sync.ClientSide.mutex);
+		main.utils.assertLocked(&main.sync.client.mutex);
 		var it = serverToClientMap.valueIterator();
 		while (it.next()) |inv| {
 			if (inv.id == clientId) return inv.*;
@@ -428,17 +428,17 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 			.type = clientType,
 		};
 		if (clientType == .serverShared) {
-			sync.ClientSide.executeCommand(.{.open = .{.inv = self.super, .source = source}});
+			sync.client.executeCommand(.{.open = .{.inv = self.super, .source = source}});
 		}
 		return self;
 	}
 
 	pub fn deinit(self: ClientInventory, allocator: NeverFailingAllocator) void {
 		if (main.game.world.?.connected) {
-			sync.ClientSide.executeCommand(.{.close = .{.inv = self.super, .allocator = allocator}});
+			sync.client.executeCommand(.{.close = .{.inv = self.super, .allocator = allocator}});
 		} else {
-			main.sync.ClientSide.mutex.lock();
-			defer main.sync.ClientSide.mutex.unlock();
+			main.sync.client.mutex.lock();
+			defer main.sync.client.mutex.unlock();
 			self.super._deinit(allocator, .client);
 		}
 	}
@@ -450,7 +450,7 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 			return;
 		}
 		std.debug.assert(dest.type == .serverShared);
-		main.sync.ClientSide.executeCommand(.{.depositOrSwap = .{.dest = .{.inv = dest.super, .slot = destSlot}, .source = .{.inv = carried.super, .slot = 0}}});
+		main.sync.client.executeCommand(.{.depositOrSwap = .{.dest = .{.inv = dest.super, .slot = destSlot}, .source = .{.inv = carried.super, .slot = 0}}});
 	}
 
 	pub fn deposit(dest: ClientInventory, destSlot: u32, source: ClientInventory, sourceSlot: u32, amount: u16) void {
@@ -460,7 +460,7 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 			return;
 		}
 		std.debug.assert(source.type == .serverShared);
-		main.sync.ClientSide.executeCommand(.{.deposit = .{.dest = .{.inv = dest.super, .slot = destSlot}, .source = .{.inv = source.super, .slot = sourceSlot}, .amount = amount}});
+		main.sync.client.executeCommand(.{.deposit = .{.dest = .{.inv = dest.super, .slot = destSlot}, .source = .{.inv = source.super, .slot = sourceSlot}, .amount = amount}});
 	}
 
 	pub fn takeHalf(source: ClientInventory, sourceSlot: u32, carried: ClientInventory) void {
@@ -469,7 +469,7 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 			return;
 		}
 		std.debug.assert(carried.type == .serverShared);
-		main.sync.ClientSide.executeCommand(.{.takeHalf = .{.dest = .{.inv = carried.super, .slot = 0}, .source = .{.inv = source.super, .slot = sourceSlot}}});
+		main.sync.client.executeCommand(.{.takeHalf = .{.dest = .{.inv = carried.super, .slot = 0}, .source = .{.inv = source.super, .slot = sourceSlot}}});
 	}
 
 	pub fn distribute(carried: ClientInventory, destinationInventories: []const ClientInventory, destinationSlots: []const u32) void {
@@ -483,34 +483,34 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 	pub fn depositOrDrop(source: ClientInventory, destinations: []const ClientInventory) void {
 		for (destinations) |dest| std.debug.assert(dest.type == .serverShared);
 		std.debug.assert(source.type != .creative);
-		main.sync.ClientSide.executeCommand(.{.depositOrDrop = .init(destinations, source.super, undefined)});
+		main.sync.client.executeCommand(.{.depositOrDrop = .init(destinations, source.super, undefined)});
 	}
 
 	pub fn depositToAny(source: ClientInventory, sourceSlot: u32, destinations: []const ClientInventory, amount: u16) void {
 		std.debug.assert(source.type == .serverShared);
-		main.sync.ClientSide.executeCommand(.{.depositToAny = .init(destinations, .{.inv = source.super, .slot = sourceSlot}, amount)});
+		main.sync.client.executeCommand(.{.depositToAny = .init(destinations, .{.inv = source.super, .slot = sourceSlot}, amount)});
 	}
 
 	pub fn dropStack(source: ClientInventory, sourceSlot: u32) void {
 		if (source.type != .serverShared) return;
-		main.sync.ClientSide.executeCommand(.{.drop = .{.source = .{.inv = source.super, .slot = sourceSlot}}});
+		main.sync.client.executeCommand(.{.drop = .{.source = .{.inv = source.super, .slot = sourceSlot}}});
 	}
 
 	pub fn dropOne(source: ClientInventory, sourceSlot: u32) void {
 		if (source.type != .serverShared) return;
-		main.sync.ClientSide.executeCommand(.{.drop = .{.source = .{.inv = source.super, .slot = sourceSlot}, .desiredAmount = 1}});
+		main.sync.client.executeCommand(.{.drop = .{.source = .{.inv = source.super, .slot = sourceSlot}, .desiredAmount = 1}});
 	}
 
 	pub fn fillFromCreative(dest: ClientInventory, destSlot: u32, item: Item) void {
-		main.sync.ClientSide.executeCommand(.{.fillFromCreative = .{.dest = .{.inv = dest.super, .slot = destSlot}, .item = item}});
+		main.sync.client.executeCommand(.{.fillFromCreative = .{.dest = .{.inv = dest.super, .slot = destSlot}, .item = item}});
 	}
 
 	pub fn fillAmountFromCreative(dest: ClientInventory, destSlot: u32, item: Item, amount: u16) void {
-		main.sync.ClientSide.executeCommand(.{.fillFromCreative = .{.dest = .{.inv = dest.super, .slot = destSlot}, .item = item, .amount = amount}});
+		main.sync.client.executeCommand(.{.fillFromCreative = .{.dest = .{.inv = dest.super, .slot = destSlot}, .item = item, .amount = amount}});
 	}
 
 	pub fn fillAnyFromCreative(destinations: []const ClientInventory, item: Item, amount: u16) void {
-		main.sync.ClientSide.executeCommand(.{.fillAnyFromCreative = .init(destinations, item, amount)});
+		main.sync.client.executeCommand(.{.fillAnyFromCreative = .init(destinations, item, amount)});
 	}
 
 	pub fn craftFrom(source: ClientInventory, destinations: []const ClientInventory, craftingInv: ClientInventory) void {
@@ -518,19 +518,19 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 		for (destinations) |inv| std.debug.assert(inv.type == .serverShared);
 		std.debug.assert(craftingInv.type == .crafting);
 
-		main.sync.ClientSide.executeCommand(.{.craftFrom = .init(destinations, &.{source}, craftingInv.type.crafting)});
+		main.sync.client.executeCommand(.{.craftFrom = .init(destinations, &.{source}, craftingInv.type.crafting)});
 	}
 
 	pub fn craftProceduralItem(source: ClientInventory, destinations: []const ClientInventory) void {
 		std.debug.assert(source.type == .workbenchResult);
 		for (destinations) |inv| std.debug.assert(inv.type == .serverShared);
 		const workbenchInv = blk: {
-			main.sync.ClientSide.mutex.lock();
-			defer main.sync.ClientSide.mutex.unlock();
+			main.sync.client.mutex.lock();
+			defer main.sync.client.mutex.unlock();
 			break :blk client.getInventoryByClientId(source.type.workbenchResult);
 		} orelse return;
 
-		main.sync.ClientSide.executeCommand(.{.craftProceduralItem = .init(destinations, workbenchInv)});
+		main.sync.client.executeCommand(.{.craftProceduralItem = .init(destinations, workbenchInv)});
 	}
 
 	pub fn placeBlock(self: ClientInventory, slot: u32) void {

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -22,7 +22,7 @@ const ProceduralItemTypeIndex = main.items.ProceduralItemTypeIndex;
 
 pub const InventoryId = enum(u32) { _ };
 
-pub const client = struct {
+pub const client = struct { // MARK: client
 	var maxId: InventoryId = @enumFromInt(0);
 	var freeIdList: main.List(InventoryId) = undefined;
 	var serverToClientMap: std.AutoHashMap(InventoryId, Inventory) = undefined;

--- a/src/block_entity.zig
+++ b/src/block_entity.zig
@@ -246,21 +246,21 @@ pub const BlockEntityTypes = struct { // MARK: BlockEntityTypes
 
 			const data = StorageServer.getOrPut(pos, chunk);
 			std.debug.assert(!data.foundExisting);
-			data.valuePtr.invId = main.items.Inventory.ServerSide.createExternallyManagedInventory(inventorySize, .{.blockInventory = pos}, reader, inventoryCallbacks);
+			data.valuePtr.invId = main.items.Inventory.server.createExternallyManagedInventory(inventorySize, .{.blockInventory = pos}, reader, inventoryCallbacks);
 		}
 
 		pub fn onUnloadServer(entity: BlockEntity) void {
 			StorageServer.mutex.lock();
 			const data = StorageServer.removeAtIndex(entity) orelse unreachable;
 			StorageServer.mutex.unlock();
-			main.items.Inventory.ServerSide.destroyExternallyManagedInventory(data.invId);
+			main.items.Inventory.server.destroyExternallyManagedInventory(data.invId);
 		}
 		pub fn onStoreServerToDisk(entity: BlockEntity, writer: *BinaryWriter) void {
 			StorageServer.mutex.lock();
 			defer StorageServer.mutex.unlock();
 			const data = StorageServer.getByIndex(entity) orelse return;
 
-			const inv = main.items.Inventory.ServerSide.getInventoryFromId(data.invId);
+			const inv = main.items.Inventory.server.getInventoryFromId(data.invId);
 			var isEmpty: bool = true;
 			for (inv._items) |item| {
 				if (item.amount != 0) isEmpty = false;
@@ -275,7 +275,7 @@ pub const BlockEntityTypes = struct { // MARK: BlockEntityTypes
 			switch (event) {
 				.remove => {
 					const chestComponent = StorageServer.remove(pos, chunk) orelse return;
-					main.items.Inventory.ServerSide.destroyAndDropExternallyManagedInventory(chestComponent.invId, pos);
+					main.items.Inventory.server.destroyAndDropExternallyManagedInventory(chestComponent.invId, pos);
 				},
 				.update => {
 					StorageServer.mutex.lock();
@@ -283,7 +283,7 @@ pub const BlockEntityTypes = struct { // MARK: BlockEntityTypes
 					const data = StorageServer.getOrPut(pos, chunk);
 					if (data.foundExisting) return;
 					var reader = BinaryReader.init(&.{});
-					data.valuePtr.invId = main.items.Inventory.ServerSide.createExternallyManagedInventory(inventorySize, .{.blockInventory = pos}, &reader, inventoryCallbacks);
+					data.valuePtr.invId = main.items.Inventory.server.createExternallyManagedInventory(inventorySize, .{.blockInventory = pos}, &reader, inventoryCallbacks);
 				},
 			}
 		}

--- a/src/game.zig
+++ b/src/game.zig
@@ -318,7 +318,7 @@ pub const World = struct { // MARK: World
 		main.gui.init();
 		Player.inventory.deinit(main.globalAllocator);
 		main.items.clearRecipeCachedInventories();
-		main.sync.ClientSide.reset();
+		main.sync.client.reset();
 
 		main.threadPool.clear();
 		main.entity.client.clear();

--- a/src/gui/components/BagSlot.zig
+++ b/src/gui/components/BagSlot.zig
@@ -68,9 +68,9 @@ pub fn mainButtonReleased(self: *BagSlot, mousePosition: Vec2f) void {
 		if (GuiComponent.contains(self.pos, self.size, mousePosition)) {
 			const carried = gui.inventory.carried;
 			if (carried.getAmount(0) != 0) {
-				main.sync.ClientSide.executeCommand(.{.moveToPlayerBag = .{.amount = carried.getAmount(0), .source = .{.inv = carried.super, .slot = 0}}});
+				main.sync.client.executeCommand(.{.moveToPlayerBag = .{.amount = carried.getAmount(0), .source = .{.inv = carried.super, .slot = 0}}});
 			} else {
-				main.sync.ClientSide.executeCommand(.{.takeFromPlayerBag = .init(&.{carried}, std.math.maxInt(u16))});
+				main.sync.client.executeCommand(.{.takeFromPlayerBag = .init(&.{carried}, std.math.maxInt(u16))});
 			}
 		}
 	}

--- a/src/gui/windows/chat.zig
+++ b/src/gui/windows/chat.zig
@@ -263,7 +263,7 @@ pub fn sendMessage() void {
 			}
 
 			if (input.currentString.items[0] == '/') {
-				main.sync.ClientSide.executeCommand(.{.chatCommand = .{.message = main.globalAllocator.dupe(u8, input.currentString.items[1..])}});
+				main.sync.client.executeCommand(.{.chatCommand = .{.message = main.globalAllocator.dupe(u8, input.currentString.items[1..])}});
 			} else {
 				main.network.protocols.chat.send(main.game.world.?.conn, data);
 			}

--- a/src/gui/windows/players.zig
+++ b/src/gui/windows/players.zig
@@ -29,7 +29,7 @@ fn kickbyConnection(conn: *main.network.Connection) void {
 
 fn kickByPlayerIndex(playerIndex: usize) void {
 	const command = std.fmt.allocPrint(main.globalAllocator.allocator, "kick @{d}", .{playerIndex}) catch unreachable;
-	main.sync.ClientSide.executeCommand(.{.chatCommand = .{.message = command}});
+	main.sync.client.executeCommand(.{.chatCommand = .{.message = command}});
 }
 
 pub fn onOpen() void {

--- a/src/itemdrop.zig
+++ b/src/itemdrop.zig
@@ -383,7 +383,7 @@ pub const ItemDropManager = struct { // MARK: ItemDropManager
 			const dist = @max(min - itemPos, itemPos - max);
 			if (@reduce(.Max, dist) < radius + pickupRange) {
 				const itemStack = &self.list.items(.itemStack)[i];
-				main.items.Inventory.ServerSide.tryCollectingToPlayerInventory(user, itemStack);
+				main.items.Inventory.server.tryCollectingToPlayerInventory(user, itemStack);
 				if (itemStack.amount == 0) {
 					self.directRemove(i);
 					continue;

--- a/src/items.zig
+++ b/src/items.zig
@@ -1225,6 +1225,18 @@ pub fn globalInit() void {
 	Inventory.client.init();
 }
 
+pub fn globalDeinit() void {
+	Inventory.client.deinit();
+}
+
+pub fn reset() void {
+	proceduralItemTypeList = .{};
+	proceduralItemTypeIdToIndex = .{};
+	reverseIndices = .{};
+	recipeList.clearAndFree();
+	itemListSize = 0;
+}
+
 pub fn register(_: []const u8, texturePath: []const u8, replacementTexturePath: []const u8, id: []const u8, zon: ZonElement) *BaseItem {
 	const newItem = &itemList[itemListSize];
 	defer itemListSize += 1;
@@ -1373,16 +1385,4 @@ pub fn clearRecipeCachedInventories() void {
 		main.globalAllocator.free(recipe.sourceItems);
 		main.globalAllocator.free(recipe.sourceAmounts);
 	}
-}
-
-pub fn reset() void {
-	proceduralItemTypeList = .{};
-	proceduralItemTypeIdToIndex = .{};
-	reverseIndices = .{};
-	recipeList.clearAndFree();
-	itemListSize = 0;
-}
-
-pub fn deinit() void {
-	Inventory.client.deinit();
 }

--- a/src/items.zig
+++ b/src/items.zig
@@ -1222,7 +1222,7 @@ pub fn globalInit() void {
 			.printTooltip = comptime main.meta.castFunctionSelfToAnyopaque(ModifierRestrictionStruct.printTooltip),
 		}) catch unreachable;
 	}
-	Inventory.ClientSide.init();
+	Inventory.client.init();
 }
 
 pub fn register(_: []const u8, texturePath: []const u8, replacementTexturePath: []const u8, id: []const u8, zon: ZonElement) *BaseItem {
@@ -1384,5 +1384,5 @@ pub fn reset() void {
 }
 
 pub fn deinit() void {
-	Inventory.ClientSide.deinit();
+	Inventory.client.deinit();
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -493,8 +493,8 @@ pub fn main(args: std.process.Init.Minimal) void { // MARK: main()
 	items.globalInit();
 	defer items.globalDeinit();
 
-	if (!headless) sync.ClientSide.init();
-	defer if (!headless) sync.ClientSide.deinit();
+	if (!headless) sync.client.init();
+	defer if (!headless) sync.client.deinit();
 
 	if (!headless) itemdrop.ItemDropRenderer.init();
 	defer if (!headless) itemdrop.ItemDropRenderer.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -491,7 +491,7 @@ pub fn main(args: std.process.Init.Minimal) void { // MARK: main()
 	defer models.deinit();
 
 	items.globalInit();
-	defer items.deinit();
+	defer items.globalDeinit();
 
 	if (!headless) sync.ClientSide.init();
 	defer if (!headless) sync.ClientSide.deinit();

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -903,11 +903,11 @@ pub const inventory = struct { // MARK: inventory
 	fn clientReceive(_: *Connection, reader: *utils.BinaryReader) !void {
 		const typ = try reader.readInt(u8);
 		if (typ == 0xff) { // Confirmation
-			try main.sync.ClientSide.receiveConfirmation(reader);
+			try main.sync.client.receiveConfirmation(reader);
 		} else if (typ == 0xfe) { // Failure
-			main.sync.ClientSide.receiveFailure();
+			main.sync.client.receiveFailure();
 		} else {
-			try main.sync.ClientSide.receiveSyncOperation(reader);
+			try main.sync.client.receiveSyncOperation(reader);
 		}
 	}
 	fn serverReceive(conn: *Connection, reader: *utils.BinaryReader) !void {

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -913,7 +913,7 @@ pub const inventory = struct { // MARK: inventory
 	fn serverReceive(conn: *Connection, reader: *utils.BinaryReader) !void {
 		const user = conn.user.?;
 		if (reader.remaining[0] == 0xff) return error.Invalid;
-		main.sync.ServerSide.receiveCommand(user, reader);
+		main.sync.server.receiveCommand(user, reader);
 	}
 	pub fn sendCommand(conn: *Connection, payloadType: main.sync.Command.PayloadType, _data: []const u8) void {
 		std.debug.assert(conn.user == null);

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -1078,7 +1078,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 
 			const relPos: Vec3f = @floatCast(lastPos - @as(Vec3d, @floatFromInt(selectedPos)));
 
-			main.sync.ClientSide.mutex.lock();
+			main.sync.client.mutex.lock();
 			if (!game.Player.isCreative()) {
 				var damage: f32 = main.game.Player.defaultBlockDamage;
 				const isProceduralItem = stack.item == .proceduralItem;
@@ -1111,7 +1111,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 						if (currentBlockProgress != 0) {
 							mesh_storage.addBreakingAnimation(lastSelectedBlockPos, currentBlockProgress);
 						}
-						main.sync.ClientSide.mutex.unlock();
+						main.sync.client.mutex.unlock();
 
 						return;
 					} else {
@@ -1121,7 +1121,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 						currentSwingTime = 0;
 					}
 				} else {
-					main.sync.ClientSide.mutex.unlock();
+					main.sync.client.mutex.unlock();
 					return;
 				}
 			} else {
@@ -1130,7 +1130,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 
 			var newBlock = block;
 			block.mode().onBlockBreaking(inventory.getStack(slot).item, relPos, lastDir, &newBlock);
-			main.sync.ClientSide.mutex.unlock();
+			main.sync.client.mutex.unlock();
 
 			if (newBlock != block) {
 				updateBlockAndSendUpdate(inventory, slot, selectedPos, block, newBlock);
@@ -1139,7 +1139,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 	}
 
 	fn updateBlockAndSendUpdate(source: main.items.Inventory.ClientInventory, slot: u32, pos: Vec3i, oldBlock: blocks.Block, newBlock: blocks.Block) void {
-		main.sync.ClientSide.executeCommand(.{
+		main.sync.client.executeCommand(.{
 			.updateBlock = .{
 				.source = .{.inv = source.super, .slot = slot},
 				.pos = pos,

--- a/src/server/command/clear.zig
+++ b/src/server/command/clear.zig
@@ -18,7 +18,7 @@ pub fn execute(args: []const u8, source: *User) void {
 			return;
 		}
 		if (std.ascii.eqlIgnoreCase(arg, "inventory")) {
-			main.items.Inventory.ServerSide.clearPlayerInventory(source);
+			main.items.Inventory.server.clearPlayerInventory(source);
 		} else if (std.ascii.eqlIgnoreCase(arg, "chat")) {
 			main.network.protocols.genericUpdate.sendClear(source.conn, .chat);
 		} else {

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -446,7 +446,7 @@ pub const User = struct { // MARK: User
 		for (commands.items) |commandData| {
 			defer main.globalAllocator.free(commandData);
 			var reader: BinaryReader = .init(commandData);
-			main.sync.ServerSide.executeUserCommand(self, &reader) catch |err| {
+			main.sync.server.executeUserCommand(self, &reader) catch |err| {
 				if (err == error.InventoryNotFound) {
 					main.network.protocols.inventory.sendFailure(self.conn);
 				} else {
@@ -549,7 +549,7 @@ fn init(name: []const u8, singlePlayerPort: ?u16) void { // MARK: init()
 
 	main.entity.server.init();
 	main.items.Inventory.server.init();
-	main.sync.ServerSide.init();
+	main.sync.server.init();
 
 	world = ServerWorld.init(name) catch |err| {
 		std.log.err("Failed to create world: {s}", .{@errorName(err)});
@@ -596,7 +596,7 @@ fn deinit() void {
 	}
 	world = null;
 
-	main.sync.ServerSide.deinit();
+	main.sync.server.deinit();
 	main.items.Inventory.server.deinit();
 	main.entity.server.deinit();
 

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -165,7 +165,7 @@ pub const User = struct { // MARK: User
 	pub fn deinit(self: *User) void {
 		std.debug.assert(self.refCount.load(.monotonic) == 0);
 
-		main.items.Inventory.ServerSide.disconnectUser(self);
+		main.items.Inventory.server.disconnectUser(self);
 		std.debug.assert(self.inventoryClientToServerIdMap.count() == 0); // leak
 		self.inventoryClientToServerIdMap.deinit();
 
@@ -175,8 +175,8 @@ pub const User = struct { // MARK: User
 				return;
 			};
 
-			main.items.Inventory.ServerSide.destroyExternallyManagedInventory(self.inventory.?);
-			main.items.Inventory.ServerSide.destroyExternallyManagedInventory(self.handInventory.?);
+			main.items.Inventory.server.destroyExternallyManagedInventory(self.inventory.?);
+			main.items.Inventory.server.destroyExternallyManagedInventory(self.handInventory.?);
 		}
 
 		self.permissions.deinit();
@@ -548,7 +548,7 @@ fn init(name: []const u8, singlePlayerPort: ?u16) void { // MARK: init()
 	}; // TODO Configure the second argument in the server settings.
 
 	main.entity.server.init();
-	main.items.Inventory.ServerSide.init();
+	main.items.Inventory.server.init();
 	main.sync.ServerSide.init();
 
 	world = ServerWorld.init(name) catch |err| {
@@ -597,7 +597,7 @@ fn deinit() void {
 	world = null;
 
 	main.sync.ServerSide.deinit();
-	main.items.Inventory.ServerSide.deinit();
+	main.items.Inventory.server.deinit();
 	main.entity.server.deinit();
 
 	command.deinit();

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -992,7 +992,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 			readerInput = "";
 		};
 		var reader: main.utils.BinaryReader = .init(readerInput);
-		return main.items.Inventory.ServerSide.createExternallyManagedInventory(size, source, &reader, .{});
+		return main.items.Inventory.server.createExternallyManagedInventory(size, source, &reader, .{});
 	}
 
 	fn savePlayerInventory(allocator: NeverFailingAllocator, inv: main.items.Inventory) []const u8 {
@@ -1026,11 +1026,11 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 
 		{
 			main.sync.threadContext.assertCorrectContext(.server);
-			if (main.items.Inventory.ServerSide.getInventoryFromSource(.{.playerInventory = user.id})) |inv| {
+			if (main.items.Inventory.server.getInventoryFromSource(.{.playerInventory = user.id})) |inv| {
 				playerZon.put("playerInventory", ZonElement{.stringOwned = savePlayerInventory(main.stackAllocator, inv)});
 			} else @panic("The player inventory wasn't found. Cannot save player data.");
 
-			if (main.items.Inventory.ServerSide.getInventoryFromSource(.{.hand = user.id})) |inv| {
+			if (main.items.Inventory.server.getInventoryFromSource(.{.hand = user.id})) |inv| {
 				playerZon.put("hand", ZonElement{.stringOwned = savePlayerInventory(main.stackAllocator, inv)});
 			} else @panic("The player hand inventory wasn't found. Cannot save player data.");
 		}

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -128,7 +128,7 @@ pub const client = struct { // MARK: client
 	}
 };
 
-pub const ServerSide = struct { // MARK: ServerSide
+pub const server = struct { // MARK: server
 
 	pub fn init() void {
 		threadContext = .server;
@@ -210,7 +210,7 @@ pub fn addHealth(health: f32, cause: main.game.DamageType, side: Side, userId: u
 	if (side == .client) {
 		client.executeCommand(.{.addHealth = .{.target = userId, .health = health, .cause = cause}});
 	} else {
-		ServerSide.executeCommand(.{.addHealth = .{.target = userId, .health = health, .cause = cause}}, null);
+		server.executeCommand(.{.addHealth = .{.target = userId, .health = health, .cause = cause}}, null);
 	}
 }
 
@@ -218,7 +218,7 @@ pub fn setGamemode(user: ?*main.server.User, gamemode: Gamemode) void {
 	if (user == null) {
 		client.setGamemode(gamemode);
 	} else {
-		ServerSide.setGamemode(user.?, gamemode);
+		server.setGamemode(user.?, gamemode);
 	}
 }
 pub const Command = struct { // MARK: Command

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -860,7 +860,7 @@ pub const Command = struct { // MARK: Command
 			if (side != .client) return;
 			if (reader.remaining.len != 0) {
 				const serverId = try reader.readEnum(InventoryId);
-				Inventory.ClientSide.mapServerId(serverId, self.inv);
+				Inventory.client.mapServerId(serverId, self.inv);
 			}
 		}
 
@@ -920,7 +920,7 @@ pub const Command = struct { // MARK: Command
 		fn finalize(self: Close, side: Side, _: *BinaryReader) !void {
 			if (side != .client) return;
 			self.inv._deinit(self.allocator, .client);
-			Inventory.ClientSide.unmapServerIdByClientId(self.inv.id);
+			Inventory.client.unmapServerIdByClientId(self.inv.id);
 		}
 
 		fn serialize(self: Close, writer: *BinaryWriter) void {

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -23,7 +23,7 @@ const @"cubyz:bag" = main.entity.components.@"cubyz:bag";
 
 pub const Side = enum { client, server };
 
-pub const ClientSide = struct {
+pub const client = struct { // MARK: client
 	pub var mutex: main.utils.Mutex = .{};
 	var commands: utils.CircularBufferQueue(Command) = undefined;
 
@@ -208,7 +208,7 @@ pub const ServerSide = struct { // MARK: ServerSide
 pub fn addHealth(health: f32, cause: main.game.DamageType, side: Side, userId: u32) void {
 	threadContext.assertCorrectContext(side);
 	if (side == .client) {
-		ClientSide.executeCommand(.{.addHealth = .{.target = userId, .health = health, .cause = cause}});
+		client.executeCommand(.{.addHealth = .{.target = userId, .health = health, .cause = cause}});
 	} else {
 		ServerSide.executeCommand(.{.addHealth = .{.target = userId, .health = health, .cause = cause}}, null);
 	}
@@ -216,7 +216,7 @@ pub fn addHealth(health: f32, cause: main.game.DamageType, side: Side, userId: u
 
 pub fn setGamemode(user: ?*main.server.User, gamemode: Gamemode) void {
 	if (user == null) {
-		ClientSide.setGamemode(gamemode);
+		client.setGamemode(gamemode);
 	} else {
 		ServerSide.setGamemode(user.?, gamemode);
 	}

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -412,7 +412,7 @@ pub const Command = struct { // MARK: Command
 		pub fn getUsers(self: SyncOperation, allocator: NeverFailingAllocator) []*main.server.User {
 			switch (self) {
 				inline .create, .delete, .useDurability => |data| {
-					const users = Inventory.ServerSide.getServerInventory(data.inv.inv.id).users.items;
+					const users = Inventory.server.getServerInventory(data.inv.inv.id).users.items;
 					const result = allocator.alloc(*main.server.User, users.len);
 					for (0..users.len) |i| {
 						result[i] = users[i].user;
@@ -903,9 +903,9 @@ pub const Command = struct { // MARK: Command
 				.other => .{.other = {}},
 				.alreadyFreed => return error.Invalid,
 			};
-			try Inventory.ServerSide.createInventory(user.?, id, len, source);
+			try Inventory.server.createInventory(user.?, id, len, source);
 			return .{
-				.inv = Inventory.ServerSide.getInventory(user.?, id) orelse return error.InventoryNotFound,
+				.inv = Inventory.server.getInventory(user.?, id) orelse return error.InventoryNotFound,
 				.source = source,
 			};
 		}
@@ -930,7 +930,7 @@ pub const Command = struct { // MARK: Command
 		fn deserialize(reader: *BinaryReader, side: Side, user: ?*main.server.User) !Close {
 			if (side != .server or user == null) return error.Invalid;
 			const id = try reader.readEnum(InventoryId);
-			try Inventory.ServerSide.closeInventory(user.?, id);
+			try Inventory.server.closeInventory(user.?, id);
 			return undefined;
 		}
 	};


### PR DESCRIPTION
These are namespaces and should be formatted as such, and in other places we also just call them client/server

Also did a small change to items.deinit and how it's ordered in the file