### PR TITLE
Log cleanup portion 3: Allow the FallenTree to handle the "new" log rotation

### DIFF
--- a/assets/cubyz/biomes/hills/large/temperate.zig.zon
+++ b/assets/cubyz/biomes/hills/large/temperate.zig.zon
@@ -10,8 +10,7 @@
 	.structures = .{
 		.{
 			.id = "cubyz:fallen_tree",
-			.log = "cubyz:oak_log",
-			.top = "cubyz:oak_log",
+			.log = "cubyz:log/oak",
 			.height = 6,
 			.height_variation = 3,
 			.chance = 0.002,

--- a/assets/cubyz/biomes/hills/temperate.zig.zon
+++ b/assets/cubyz/biomes/hills/temperate.zig.zon
@@ -10,8 +10,7 @@
 	.structures = .{
 		.{
 			.id = "cubyz:fallen_tree",
-			.log = "cubyz:oak_log",
-			.top = "cubyz:oak_log",
+			.log = "cubyz:log/oak",
 			.height = 6,
 			.height_variation = 3,
 			.chance = 0.002,

--- a/src/server/terrain/biomes.zig
+++ b/src/server/terrain/biomes.zig
@@ -615,7 +615,7 @@ const TransitionBiome = struct {
 var unfinishedTransitionBiomes: std.StringHashMapUnmanaged([]UnfinishedTransitionBiomeData) = .{};
 
 pub fn init() void {
-	const list = @import("simple_structures/_list.zig");
+	const list = terrain.structures.simple_structures;
 	inline for (@typeInfo(list).@"struct".decls) |decl| {
 		SimpleStructureModel.registerGenerator(@field(list, decl.name));
 	}

--- a/src/server/terrain/simple_structures/FallenTree.zig
+++ b/src/server/terrain/simple_structures/FallenTree.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 const main = @import("main");
+const Block = main.blocks.Block;
 const random = main.random;
 const ZonElement = main.ZonElement;
 const terrain = main.server.terrain;
@@ -12,6 +13,8 @@ const Vec3d = vec.Vec3d;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
 const NeverFailingAllocator = main.heap.NeverFailingAllocator;
+const SimpleTreeModel = terrain.structures.simple_structures.SimpleTreeModel;
+const Neighbor = main.chunk.Neighbor;
 
 pub const id = "cubyz:fallen_tree";
 
@@ -19,45 +22,43 @@ pub const generationMode = .floor;
 
 const FallenTree = @This();
 
-woodBlock: u16,
-topWoodBlock: u16,
+woodBlock: Block,
+woodRotationModeType: SimpleTreeModel.RotationModeType = .unknown,
 height0: u32,
 deltaHeight: u31,
 
 pub fn loadModel(parameters: ZonElement) ?*FallenTree {
 	const self = main.worldArena.create(FallenTree);
 	self.* = .{
-		.woodBlock = main.blocks.getTypeById(parameters.get([]const u8, "log", "cubyz:oak_log")),
-		.topWoodBlock = main.blocks.getTypeById(parameters.get([]const u8, "top", "cubyz:oak_top")),
+		.woodBlock = main.blocks.parseBlock(parameters.get(?[]const u8, "log", null) orelse {
+			std.log.err("Missing required 'log' field for cubyz:simple_tree rotation", .{});
+			return null;
+		}),
 		.height0 = parameters.get(u32, "height", 6),
 		.deltaHeight = parameters.get(u31, "height_variation", 3),
 	};
+	if (self.woodBlock.mode() == main.rotation.getByID("cubyz:branch")) self.woodRotationModeType = .branch;
+	if (self.woodBlock.mode() == main.rotation.getByID("cubyz:log")) self.woodRotationModeType = .log;
+	if (self.woodBlock.mode() == main.rotation.getByID("cubyz:direction")) self.woodRotationModeType = .direction;
 	return self;
 }
 
 pub fn generateStump(self: *FallenTree, x: i32, y: i32, z: i32, chunk: *main.chunk.ServerChunk) void {
-	if (chunk.liesInChunk(x, y, z))
-		chunk.updateBlockIfDegradable(x, y, z, .{.typ = self.woodBlock, .data = 0});
+	if (chunk.liesInChunk(x, y, z)) {
+		var block = SimpleTreeModel.initalOrientation(self.woodBlock, .dirUp, self.woodRotationModeType);
+		block = SimpleTreeModel.addNeighbor(block, .dirUp, self.woodRotationModeType);
+		chunk.updateBlockIfDegradable(x, y, z, block);
+	}
 }
 
 pub fn generateFallen(self: *FallenTree, x: i32, y: i32, z: i32, length: u32, chunk: *main.chunk.ServerChunk, caveMap: CaveMapView, seed: *u64) void {
-	var d: ?u32 = null;
+	var d: ?Neighbor = null;
 
 	for (0..4) |_| {
-		const dir: u32 = main.random.nextIntBounded(u32, seed, 4);
+		const dir: Neighbor = @enumFromInt(main.random.nextIntBounded(u32, seed, 4) + 2);
 
-		var dx: i32 = 0;
-		var dy: i32 = 0;
-
-		if (dir == 0) {
-			dx = 1;
-		} else if (dir == 1) {
-			dx = -1;
-		} else if (dir == 2) {
-			dy = 1;
-		} else if (dir == 3) {
-			dy = -1;
-		}
+		const dx: i32 = dir.relX();
+		const dy: i32 = dir.relY();
 
 		var works = true;
 		for (0..length) |j| {
@@ -77,24 +78,15 @@ pub fn generateFallen(self: *FallenTree, x: i32, y: i32, z: i32, length: u32, ch
 	if (d == null)
 		return;
 
-	var dx: i32 = 0;
-	var dy: i32 = 0;
-
-	if (d.? == 0) {
-		dx = 1;
-	} else if (d.? == 1) {
-		dx = -1;
-	} else if (d.? == 2) {
-		dy = 1;
-	} else if (d.? == 3) {
-		dy = -1;
-	}
+	const dx: i32 = d.?.relX();
+	const dy: i32 = d.?.relY();
 
 	for (0..length) |val| {
 		const v: i32 = @intCast(val);
 		if (chunk.liesInChunk(x + dx*(v + 2), y + dy*(v + 2), z)) {
-			const typ = if (v == (length - 1)) self.topWoodBlock else self.woodBlock;
-			chunk.updateBlockIfDegradable(x + dx*(v + 2), y + dy*(v + 2), z, .{.typ = typ, .data = @intCast(d.? + 2)});
+			var block = SimpleTreeModel.initalOrientation(self.woodBlock, d.?, self.woodRotationModeType);
+			block = SimpleTreeModel.addNeighbor(block, d.?, self.woodRotationModeType);
+			chunk.updateBlockIfDegradable(x + dx*(v + 2), y + dy*(v + 2), z, block);
 		}
 	}
 }

--- a/src/server/terrain/simple_structures/SimpleTreeModel.zig
+++ b/src/server/terrain/simple_structures/SimpleTreeModel.zig
@@ -25,7 +25,7 @@ const Type = enum {
 	pyramid,
 	round,
 };
-const RotationModeType = enum {
+pub const RotationModeType = enum {
 	unknown,
 	log,
 	branch,
@@ -82,7 +82,7 @@ pub fn loadModel(parameters: ZonElement) ?*SimpleTreeModel {
 	return self;
 }
 
-fn initalOrientation(block: main.blocks.Block, orientation: Neighbor, mode: RotationModeType) main.blocks.Block {
+pub fn initalOrientation(block: main.blocks.Block, orientation: Neighbor, mode: RotationModeType) main.blocks.Block {
 	switch (mode) {
 		.log, .branch => {
 			return .{.typ = block.typ, .data = orientation.reverse().bitMask()};
@@ -94,7 +94,7 @@ fn initalOrientation(block: main.blocks.Block, orientation: Neighbor, mode: Rota
 	}
 }
 
-fn addNeighbor(block: main.blocks.Block, neighborDir: Neighbor, mode: RotationModeType) main.blocks.Block {
+pub fn addNeighbor(block: main.blocks.Block, neighborDir: Neighbor, mode: RotationModeType) main.blocks.Block {
 	switch (mode) {
 		.log, .branch => {
 			return .{.typ = block.typ, .data = block.data | neighborDir.bitMask()};

--- a/src/server/terrain/structures.zig
+++ b/src/server/terrain/structures.zig
@@ -9,6 +9,8 @@ const Assets = main.assets.Assets;
 const biomes = main.server.terrain.biomes;
 const Tag = main.Tag;
 
+pub const simple_structures = @import("simple_structures/_list.zig");
+
 pub const SimpleStructureModel = struct { // MARK: SimpleStructureModel
 	pub const GenerationMode = enum {
 		floor,


### PR DESCRIPTION
Alongside I also removed the need (and the ability) to specify a separate top block, since all existing instances didn't make use of it.
As an example, I put them in the temperate hills, there is basically no visual difference compared to the old logs.



progress towards #2117