### PR TITLE
Use static string maps in terrain generation

### DIFF
--- a/src/assets.zig
+++ b/src/assets.zig
@@ -384,8 +384,6 @@ fn createAssetStringID(
 }
 
 pub fn init() void {
-	biomes.init();
-
 	common = .init();
 	common.read(main.globalArena, main.files.cwd(), "assets/");
 	common.log(.common);

--- a/src/server/terrain/CaveBiomeMap.zig
+++ b/src/server/terrain/CaveBiomeMap.zig
@@ -17,6 +17,8 @@ const MapFragment = terrain.SurfaceMap.MapFragment;
 const Biome = terrain.biomes.Biome;
 const SurfaceMap = terrain.SurfaceMap;
 
+const cave_biome_generators = @import("cavebiomegen/_list.zig");
+
 /// Cave biome data from a big chunk of the world.
 pub const CaveBiomeMapFragment = struct { // MARK: caveBiomeMapFragment
 	pub const caveBiomeShift = 7;
@@ -102,25 +104,26 @@ pub const CaveBiomeGenerator = struct { // MARK: CaveBiomeGenerator
 	generatorSeed: u64,
 	defaultState: GeneratorState,
 
-	var generatorRegistry: std.StringHashMapUnmanaged(CaveBiomeGenerator) = .{};
-
-	pub fn registerGenerator(comptime Generator: type) void {
-		const self = CaveBiomeGenerator{
-			.init = &Generator.init,
-			.generate = &Generator.generate,
-			.priority = Generator.priority,
-			.generatorSeed = Generator.generatorSeed,
-			.defaultState = Generator.defaultState,
-		};
-		generatorRegistry.put(main.globalAllocator.allocator, Generator.id, self) catch unreachable;
-	}
+	const generatorRegistry: std.StaticStringMap(CaveBiomeGenerator) = .initComptime(blk: {
+		const decls = @typeInfo(cave_biome_generators).@"struct".decls;
+		var generators: [decls.len]struct { []const u8, CaveBiomeGenerator } = undefined;
+		for (0..decls.len) |i| {
+			const Generator = @field(cave_biome_generators, decls[i].name);
+			generators[i] = .{Generator.id, .{
+				.init = &Generator.init,
+				.generate = &Generator.generate,
+				.priority = Generator.priority,
+				.generatorSeed = Generator.generatorSeed,
+				.defaultState = Generator.defaultState,
+			}};
+		}
+		break :blk generators;
+	});
 
 	pub fn getAndInitGenerators(allocator: NeverFailingAllocator, settings: ZonElement) []CaveBiomeGenerator {
-		var list: main.ListUnmanaged(CaveBiomeGenerator) = .initCapacity(allocator, generatorRegistry.size);
-		var iterator = generatorRegistry.iterator();
-		while (iterator.next()) |generatorEntry| {
-			const generator = generatorEntry.value_ptr.*;
-			const generatorSettings = settings.getChild(generatorEntry.key_ptr.*);
+		var list: main.ListUnmanaged(CaveBiomeGenerator) = .initCapacity(allocator, generatorRegistry.values().len);
+		for (generatorRegistry.keys(), generatorRegistry.values()) |id, generator| {
+			const generatorSettings = settings.getChild(id);
 			if (generatorSettings.get(GeneratorState, "state", generator.defaultState) == .disabled) continue;
 			generator.init(generatorSettings);
 			list.appendAssumeCapacity(generator);
@@ -535,15 +538,10 @@ var profile: TerrainGenerationProfile = undefined;
 var memoryPool: main.heap.MemoryPool(CaveBiomeMapFragment) = undefined;
 
 pub fn globalInit() void {
-	const list = @import("cavebiomegen/_list.zig");
-	inline for (@typeInfo(list).@"struct".decls) |decl| {
-		CaveBiomeGenerator.registerGenerator(@field(list, decl.name));
-	}
 	memoryPool = .init(main.globalAllocator);
 }
 
 pub fn globalDeinit() void {
-	CaveBiomeGenerator.generatorRegistry.clearAndFree(main.globalAllocator.allocator);
 	memoryPool.deinit();
 }
 

--- a/src/server/terrain/CaveMap.zig
+++ b/src/server/terrain/CaveMap.zig
@@ -13,6 +13,8 @@ const terrain = @import("terrain.zig");
 const GeneratorState = terrain.GeneratorState;
 const TerrainGenerationProfile = terrain.TerrainGenerationProfile;
 
+pub const cave_generators = @import("cavegen/_list.zig");
+
 /// Cave data represented in a 1-Bit per block format, where 0 means empty and 1 means not empty.
 pub const CaveMapFragment = struct { // MARK: CaveMapFragment
 	pub const width = 1 << 6;
@@ -92,25 +94,26 @@ pub const CaveGenerator = struct { // MARK: CaveGenerator
 	generatorSeed: u64,
 	defaultState: GeneratorState,
 
-	var generatorRegistry: std.StringHashMapUnmanaged(CaveGenerator) = .{};
-
-	pub fn registerGenerator(comptime Generator: type) void {
-		const self = CaveGenerator{
-			.init = &Generator.init,
-			.generate = &Generator.generate,
-			.priority = Generator.priority,
-			.generatorSeed = Generator.generatorSeed,
-			.defaultState = Generator.defaultState,
-		};
-		generatorRegistry.put(main.globalAllocator.allocator, Generator.id, self) catch unreachable;
-	}
+	const generatorRegistry: std.StaticStringMap(CaveGenerator) = .initComptime(blk: {
+		const decls = @typeInfo(cave_generators).@"struct".decls;
+		var generators: [decls.len]struct { []const u8, CaveGenerator } = undefined;
+		for (0..decls.len) |i| {
+			const Generator = @field(cave_generators, decls[i].name);
+			generators[i] = .{Generator.id, .{
+				.init = &Generator.init,
+				.generate = &Generator.generate,
+				.priority = Generator.priority,
+				.generatorSeed = Generator.generatorSeed,
+				.defaultState = Generator.defaultState,
+			}};
+		}
+		break :blk generators;
+	});
 
 	pub fn getAndInitGenerators(allocator: NeverFailingAllocator, settings: ZonElement) []CaveGenerator {
-		var list: main.ListUnmanaged(CaveGenerator) = .initCapacity(allocator, generatorRegistry.size);
-		var iterator = generatorRegistry.iterator();
-		while (iterator.next()) |generatorEntry| {
-			const generator = generatorEntry.value_ptr.*;
-			const generatorSettings = settings.getChild(generatorEntry.key_ptr.*);
+		var list: main.ListUnmanaged(CaveGenerator) = .initCapacity(allocator, generatorRegistry.values().len);
+		for (generatorRegistry.keys(), generatorRegistry.values()) |id, generator| {
+			const generatorSettings = settings.getChild(id);
 			if (generatorSettings.get(GeneratorState, "state", generator.defaultState) == .disabled) continue;
 			generator.init(generatorSettings);
 			list.appendAssumeCapacity(generator);
@@ -285,15 +288,10 @@ fn cacheInit(pos: ChunkPosition) *CaveMapFragment {
 }
 
 pub fn globalInit() void {
-	const list = @import("cavegen/_list.zig");
-	inline for (@typeInfo(list).@"struct".decls) |decl| {
-		CaveGenerator.registerGenerator(@field(list, decl.name));
-	}
 	memoryPool = .init(main.globalAllocator);
 }
 
 pub fn globalDeinit() void {
-	CaveGenerator.generatorRegistry.clearAndFree(main.globalAllocator.allocator);
 	memoryPool.deinit();
 }
 

--- a/src/server/terrain/ClimateMap.zig
+++ b/src/server/terrain/ClimateMap.zig
@@ -11,6 +11,8 @@ const Biome = terrain.biomes.Biome;
 const MapFragment = terrain.SurfaceMap.MapFragment;
 const NeverFailingAllocator = main.heap.NeverFailingAllocator;
 
+pub const climate_generators = @import("climategen/_list.zig");
+
 pub const BiomeSample = struct {
 	biome: *const Biome,
 	height: f32,
@@ -72,15 +74,18 @@ pub const ClimateMapGenerator = struct {
 	init: *const fn (parameters: ZonElement) void,
 	generateMapFragment: *const fn (fragment: *ClimateMapFragment, seed: u64) void,
 
-	var generatorRegistry: std.StringHashMapUnmanaged(ClimateMapGenerator) = .{};
-
-	pub fn registerGenerator(comptime Generator: type) void {
-		const self = ClimateMapGenerator{
-			.init = &Generator.init,
-			.generateMapFragment = &Generator.generateMapFragment,
-		};
-		generatorRegistry.put(main.globalAllocator.allocator, Generator.id, self) catch unreachable;
-	}
+	const generatorRegistry: std.StaticStringMap(ClimateMapGenerator) = .initComptime(blk: {
+		const decls = @typeInfo(climate_generators).@"struct".decls;
+		var generators: [decls.len]struct { []const u8, ClimateMapGenerator } = undefined;
+		for (0..decls.len) |i| {
+			const Generator = @field(climate_generators, decls[i].name);
+			generators[i] = .{Generator.id, .{
+				.init = &Generator.init,
+				.generateMapFragment = &Generator.generateMapFragment,
+			}};
+		}
+		break :blk generators;
+	});
 
 	pub fn getGeneratorById(id: []const u8) !ClimateMapGenerator {
 		return generatorRegistry.get(id) orelse {
@@ -99,15 +104,10 @@ var profile: TerrainGenerationProfile = undefined;
 var memoryPool: main.heap.MemoryPool(ClimateMapFragment) = undefined;
 
 pub fn globalInit() void {
-	const list = @import("climategen/_list.zig");
-	inline for (@typeInfo(list).@"struct".decls) |decl| {
-		ClimateMapGenerator.registerGenerator(@field(list, decl.name));
-	}
 	memoryPool = .init(main.globalAllocator);
 }
 
 pub fn globalDeinit() void {
-	ClimateMapGenerator.generatorRegistry.clearAndFree(main.globalAllocator.allocator);
 	memoryPool.deinit();
 }
 

--- a/src/server/terrain/StructureMap.zig
+++ b/src/server/terrain/StructureMap.zig
@@ -14,6 +14,8 @@ const terrain = @import("terrain.zig");
 const GeneratorState = terrain.GeneratorState;
 const TerrainGenerationProfile = terrain.TerrainGenerationProfile;
 
+pub const structure_map_generators = @import("structuremapgen/_list.zig");
+
 const StructureInternal = struct {
 	generateFn: *const fn (self: *const anyopaque, chunk: *ServerChunk, caveMap: terrain.CaveMap.CaveMapView, biomeMap: terrain.CaveBiomeMap.CaveBiomeMapView) void,
 	data: *const anyopaque,
@@ -131,25 +133,26 @@ pub const StructureMapGenerator = struct {
 	generatorSeed: u64,
 	defaultState: GeneratorState,
 
-	var generatorRegistry: std.StringHashMapUnmanaged(StructureMapGenerator) = .{};
-
-	pub fn registerGenerator(comptime Generator: type) void {
-		const self = StructureMapGenerator{
-			.init = &Generator.init,
-			.generate = &Generator.generate,
-			.priority = Generator.priority,
-			.generatorSeed = Generator.generatorSeed,
-			.defaultState = Generator.defaultState,
-		};
-		generatorRegistry.put(main.globalAllocator.allocator, Generator.id, self) catch unreachable;
-	}
+	const generatorRegistry: std.StaticStringMap(StructureMapGenerator) = .initComptime(blk: {
+		const decls = @typeInfo(structure_map_generators).@"struct".decls;
+		var generators: [decls.len]struct { []const u8, StructureMapGenerator } = undefined;
+		for (0..decls.len) |i| {
+			const Generator = @field(structure_map_generators, decls[i].name);
+			generators[i] = .{Generator.id, .{
+				.init = &Generator.init,
+				.generate = &Generator.generate,
+				.priority = Generator.priority,
+				.generatorSeed = Generator.generatorSeed,
+				.defaultState = Generator.defaultState,
+			}};
+		}
+		break :blk generators;
+	});
 
 	pub fn getAndInitGenerators(allocator: NeverFailingAllocator, settings: ZonElement) []StructureMapGenerator {
-		var list: main.ListUnmanaged(StructureMapGenerator) = .initCapacity(allocator, generatorRegistry.size);
-		var iterator = generatorRegistry.iterator();
-		while (iterator.next()) |generatorEntry| {
-			const generator = generatorEntry.value_ptr.*;
-			const generatorSettings = settings.getChild(generatorEntry.key_ptr.*);
+		var list: main.ListUnmanaged(StructureMapGenerator) = .initCapacity(allocator, generatorRegistry.values().len);
+		for (generatorRegistry.keys(), generatorRegistry.values()) |id, generator| {
+			const generatorSettings = settings.getChild(id);
 			if (generatorSettings.get(GeneratorState, "state", generator.defaultState) == .disabled) continue;
 			generator.init(generatorSettings);
 			list.appendAssumeCapacity(generator);
@@ -183,15 +186,10 @@ fn cacheInit(pos: ChunkPosition) *StructureMapFragment {
 }
 
 pub fn globalInit() void {
-	const list = @import("structuremapgen/_list.zig");
-	inline for (@typeInfo(list).@"struct".decls) |decl| {
-		StructureMapGenerator.registerGenerator(@field(list, decl.name));
-	}
 	memoryPool = .init(main.globalAllocator);
 }
 
 pub fn globalDeinit() void {
-	StructureMapGenerator.generatorRegistry.clearAndFree(main.globalAllocator.allocator);
 	memoryPool.deinit();
 }
 

--- a/src/server/terrain/SurfaceMap.zig
+++ b/src/server/terrain/SurfaceMap.zig
@@ -14,6 +14,8 @@ const terrain = @import("terrain.zig");
 const TerrainGenerationProfile = terrain.TerrainGenerationProfile;
 const Biome = terrain.biomes.Biome;
 
+pub const map_generators = @import("mapgen/_list.zig");
+
 pub const MapFragmentPosition = struct {
 	wx: i32,
 	wy: i32,
@@ -239,15 +241,18 @@ pub const MapGenerator = struct {
 	init: *const fn (parameters: ZonElement) void,
 	generateMapFragment: *const fn (fragment: *MapFragment, seed: u64) void,
 
-	var generatorRegistry: std.StringHashMapUnmanaged(MapGenerator) = .{};
-
-	fn registerGenerator(comptime Generator: type) void {
-		const self = MapGenerator{
-			.init = &Generator.init,
-			.generateMapFragment = &Generator.generateMapFragment,
-		};
-		generatorRegistry.put(main.globalAllocator.allocator, Generator.id, self) catch unreachable;
-	}
+	var generatorRegistry: std.StaticStringMap(MapGenerator) = .initComptime(blk: {
+		const decls = @typeInfo(map_generators).@"struct".decls;
+		var generators: [decls.len]struct { []const u8, MapGenerator } = undefined;
+		for (0..decls.len) |i| {
+			const Generator = @field(map_generators, decls[i].name);
+			generators[i] = .{Generator.id, .{
+				.init = &Generator.init,
+				.generateMapFragment = &Generator.generateMapFragment,
+			}};
+		}
+		break :blk generators;
+	});
 
 	pub fn getGeneratorById(id: []const u8) !MapGenerator {
 		return generatorRegistry.get(id) orelse {
@@ -266,15 +271,10 @@ var profile: TerrainGenerationProfile = undefined;
 var memoryPool: main.heap.MemoryPool(MapFragment) = undefined;
 
 pub fn globalInit() void {
-	const list = @import("mapgen/_list.zig");
-	inline for (@typeInfo(list).@"struct".decls) |decl| {
-		MapGenerator.registerGenerator(@field(list, decl.name));
-	}
 	memoryPool = .init(main.globalAllocator);
 }
 
 pub fn globalDeinit() void {
-	MapGenerator.generatorRegistry.clearAndFree(main.globalAllocator.allocator);
 	memoryPool.deinit();
 }
 

--- a/src/server/terrain/SurfaceMap.zig
+++ b/src/server/terrain/SurfaceMap.zig
@@ -241,7 +241,7 @@ pub const MapGenerator = struct {
 	init: *const fn (parameters: ZonElement) void,
 	generateMapFragment: *const fn (fragment: *MapFragment, seed: u64) void,
 
-	var generatorRegistry: std.StaticStringMap(MapGenerator) = .initComptime(blk: {
+	const generatorRegistry: std.StaticStringMap(MapGenerator) = .initComptime(blk: {
 		const decls = @typeInfo(map_generators).@"struct".decls;
 		var generators: [decls.len]struct { []const u8, MapGenerator } = undefined;
 		for (0..decls.len) |i| {

--- a/src/server/terrain/biomes.zig
+++ b/src/server/terrain/biomes.zig
@@ -614,13 +614,6 @@ const TransitionBiome = struct {
 };
 var unfinishedTransitionBiomes: std.StringHashMapUnmanaged([]UnfinishedTransitionBiomeData) = .{};
 
-pub fn init() void {
-	const list = terrain.structures.simple_structures;
-	inline for (@typeInfo(list).@"struct".decls) |decl| {
-		SimpleStructureModel.registerGenerator(@field(list, decl.name));
-	}
-}
-
 pub fn reset() void {
 	finishedLoading = false;
 	biomes = .{};

--- a/src/server/terrain/sdf.zig
+++ b/src/server/terrain/sdf.zig
@@ -9,6 +9,8 @@ const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
 const ZonElement = main.ZonElement;
 
+const sdf_models = @import("sdf_models/_list.zig");
+
 pub const SdfModel = struct { // MARK: SdfModel
 	data: *anyopaque,
 	instantiateFn: *const fn (self: *anyopaque, arena: NeverFailingAllocator, seed: *u64) SdfInstance,
@@ -69,14 +71,18 @@ pub const SdfModel = struct { // MARK: SdfModel
 		return self.instantiateFn(self.data, arena, seed);
 	}
 
-	var modelRegistry: std.StringHashMapUnmanaged(VTable) = .{};
-
-	pub fn registerGenerator(comptime Generator: type) void {
-		var self: VTable = undefined;
-		self.initAndGetExtend = Generator.initAndGetExtend;
-		self.instantiate = main.meta.castFunctionSelfToAnyopaque(Generator.instantiate);
-		modelRegistry.put(main.globalArena.allocator, Generator.id, self) catch unreachable;
-	}
+	const modelRegistry: std.StaticStringMap(VTable) = .initComptime(blk: {
+		const decls = @typeInfo(sdf_models).@"struct".decls;
+		var generators: [decls.len]struct { []const u8, VTable } = undefined;
+		for (0..decls.len) |i| {
+			const Generator = @field(sdf_models, decls[i].name);
+			generators[i] = .{Generator.id, .{
+				.initAndGetExtend = Generator.initAndGetExtend,
+				.instantiate = main.meta.castFunctionSelfToAnyopaque(Generator.instantiate),
+			}};
+		}
+		break :blk generators;
+	});
 };
 
 pub const SdfInstance = struct { // MARK: SdfInstance

--- a/src/server/terrain/structures.zig
+++ b/src/server/terrain/structures.zig
@@ -56,20 +56,24 @@ pub const SimpleStructureModel = struct { // MARK: SimpleStructureModel
 		self.vtable.generate(self.data, self.generationMode, x, y, z, chunk, caveMap, biomeMap, seed, isCeiling);
 	}
 
-	var modelRegistry: std.StringHashMapUnmanaged(VTable) = .{};
-
-	pub fn registerGenerator(comptime Generator: type) void {
-		var self: VTable = undefined;
-		self.loadModel = main.meta.castFunctionReturnToOptionalAnyopaque(Generator.loadModel);
-		self.generate = main.meta.castFunctionSelfToAnyopaque(Generator.generate);
-		self.hashFunction = main.meta.castFunctionSelfToAnyopaque(struct {
-			fn hash(ptr: *Generator) u64 {
-				return biomes.hashGeneric(ptr.*);
-			}
-		}.hash);
-		self.generationMode = Generator.generationMode;
-		modelRegistry.put(main.globalArena.allocator, Generator.id, self) catch unreachable;
-	}
+	const modelRegistry: std.StaticStringMap(VTable) = .initComptime(blk: {
+		const decls = @typeInfo(simple_structures).@"struct".decls;
+		var generators: [decls.len]struct { []const u8, VTable } = undefined;
+		for (0..decls.len) |i| {
+			const Generator = @field(simple_structures, decls[i].name);
+			generators[i] = .{Generator.id, .{
+				.loadModel = main.meta.castFunctionReturnToOptionalAnyopaque(Generator.loadModel),
+				.generate = main.meta.castFunctionSelfToAnyopaque(Generator.generate),
+				.hashFunction = main.meta.castFunctionSelfToAnyopaque(struct {
+					fn hash(ptr: *Generator) u64 {
+						return biomes.hashGeneric(ptr.*);
+					}
+				}.hash),
+				.generationMode = Generator.generationMode,
+			}};
+		}
+		break :blk generators;
+	});
 
 	fn getHash(self: SimpleStructureModel) u64 {
 		return self.vtable.hashFunction(self.data);

--- a/src/server/terrain/terrain.zig
+++ b/src/server/terrain/terrain.zig
@@ -132,12 +132,6 @@ pub fn globalInit() void {
 			BlockGenerator.registerGenerator(@field(list, decl.name));
 		}
 	}
-	{
-		const list = @import("sdf_models/_list.zig");
-		inline for (@typeInfo(list).@"struct".decls) |decl| {
-			sdf.SdfModel.registerGenerator(@field(list, decl.name));
-		}
-	}
 	const t1 = main.timestamp();
 	noise.BlueNoise.load();
 	std.log.info("Blue noise took {} ms to load", .{t1.durationTo(main.timestamp()).toMilliseconds()});


### PR DESCRIPTION
These can be created at compile-time allowing the removal of runtime allocation for them, also the StaticStringMap is used for stringToEnum, so we can expect this to get some performance improvements in the future, and maybe even support for perfect hashing.

- [x] implement it for the other generators

progress towards #2748