### PR TITLE
Remove the ThreadSafeAllocator

### DIFF
--- a/src/utils/heap.zig
+++ b/src/utils/heap.zig
@@ -11,13 +11,13 @@ pub const testingAllocator = testingErrorHandlingAllocator.allocator();
 pub const allocators = struct { // MARK: allocators
 	pub var globalGpa = std.heap.DebugAllocator(.{.thread_safe = true}){};
 	pub var handledGpa = ErrorHandlingAllocator.init(globalGpa.allocator());
-	pub var globalArenaAllocator: ThreadSafeAllocator(NeverFailingArenaAllocator) = .init(.init(handledGpa.allocator()));
-	pub var worldArenaAllocator: ThreadSafeAllocator(NeverFailingArenaAllocator) = undefined;
+	pub var globalArenaAllocator: NeverFailingArenaAllocator = .init(handledGpa.allocator());
+	pub var worldArenaAllocator: NeverFailingArenaAllocator = undefined;
 	var worldArenaOpenCount: usize = 0;
 	var worldArenaMutex: main.utils.Mutex = .{};
 
 	pub fn deinit() void {
-		std.log.info("Clearing global arena with {} MiB", .{globalArenaAllocator.child.arena.queryCapacity() >> 20});
+		std.log.info("Clearing global arena with {} MiB", .{globalArenaAllocator.arena.queryCapacity() >> 20});
 		globalArenaAllocator.deinit();
 		globalArenaAllocator = undefined;
 		if (globalGpa.deinit() == .leak) {
@@ -30,7 +30,7 @@ pub const allocators = struct { // MARK: allocators
 		worldArenaMutex.lock();
 		defer worldArenaMutex.unlock();
 		if (worldArenaOpenCount == 0) {
-			worldArenaAllocator = .init(.init(handledGpa.allocator()));
+			worldArenaAllocator = .init(handledGpa.allocator());
 		}
 		worldArenaOpenCount += 1;
 	}
@@ -40,7 +40,7 @@ pub const allocators = struct { // MARK: allocators
 		defer worldArenaMutex.unlock();
 		worldArenaOpenCount -= 1;
 		if (worldArenaOpenCount == 0) {
-			std.log.info("Clearing world arena with {} MiB", .{worldArenaAllocator.child.arena.queryCapacity() >> 20});
+			std.log.info("Clearing world arena with {} MiB", .{worldArenaAllocator.arena.queryCapacity() >> 20});
 			worldArenaAllocator.deinit();
 			worldArenaAllocator = undefined;
 		}
@@ -544,82 +544,6 @@ pub const NeverFailingArenaAllocator = struct { // MARK: NeverFailingArena
 		}
 	}
 };
-
-pub fn ThreadSafeAllocator(ChildAllocatorType: type) type { // MARK: ThreadSafeAllocator
-	std.debug.assert(@TypeOf(ChildAllocatorType.allocator(undefined)) == NeverFailingAllocator);
-
-	return struct {
-		child: ChildAllocatorType,
-		mutex: main.utils.Mutex = .{},
-
-		pub fn init(childAllocator: ChildAllocatorType) @This() {
-			return .{
-				.child = childAllocator,
-			};
-		}
-
-		pub fn deinit(self: @This()) void {
-			self.child.deinit();
-		}
-
-		pub fn allocator(self: *@This()) NeverFailingAllocator {
-			return .{
-				.allocator = .{
-					.ptr = self,
-					.vtable = &.{
-						.alloc = alloc,
-						.resize = resize,
-						.remap = remap,
-						.free = free,
-					},
-				},
-				.IAssertThatTheProvidedAllocatorCantFail = {},
-			};
-		}
-
-		pub fn swapChild(self: *@This(), other: *ChildAllocatorType) void {
-			self.mutex.lock();
-			defer self.mutex.unlock();
-			std.mem.swap(ChildAllocatorType, &self.child, other);
-		}
-
-		fn alloc(context: *anyopaque, n: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
-			const self: *@This() = @ptrCast(@alignCast(context));
-
-			self.mutex.lock();
-			defer self.mutex.unlock();
-
-			return self.child.allocator().rawAlloc(n, alignment, ra);
-		}
-
-		fn resize(context: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
-			const self: *@This() = @ptrCast(@alignCast(context));
-
-			self.mutex.lock();
-			defer self.mutex.unlock();
-
-			return self.child.allocator().rawResize(buf, alignment, new_len, ret_addr);
-		}
-
-		fn remap(context: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, return_address: usize) ?[*]u8 {
-			const self: *@This() = @ptrCast(@alignCast(context));
-
-			self.mutex.lock();
-			defer self.mutex.unlock();
-
-			return self.child.allocator().rawRemap(memory, alignment, new_len, return_address);
-		}
-
-		fn free(context: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
-			const self: *@This() = @ptrCast(@alignCast(context));
-
-			self.mutex.lock();
-			defer self.mutex.unlock();
-
-			return self.child.allocator().rawFree(buf, alignment, ret_addr);
-		}
-	};
-}
 
 /// basically a copy of std.heap.MemoryPool, except it's thread-safe and has some more diagnostics.
 pub fn MemoryPool(Item: type) type { // MARK: MemoryPool


### PR DESCRIPTION
Arenas are now thread-safe by default, so the extra wrapper isn't needed anymore