### PR TITLE
Require the memory pool to be initialized with an arena

### DIFF
--- a/src/chunk.zig
+++ b/src/chunk.zig
@@ -135,18 +135,8 @@ pub const Neighbor = enum(u3) { // MARK: Neighbor
 	}
 };
 
-var memoryPool: main.heap.MemoryPool(Chunk) = undefined;
-var serverPool: main.heap.MemoryPool(ServerChunk) = undefined;
-
-pub fn init() void {
-	memoryPool = .init(main.globalAllocator);
-	serverPool = .init(main.globalAllocator);
-}
-
-pub fn deinit() void {
-	memoryPool.deinit();
-	serverPool.deinit();
-}
+var memoryPool: main.heap.MemoryPool(Chunk) = .init(main.globalArena);
+var serverPool: main.heap.MemoryPool(ServerChunk) = .init(main.globalArena);
 
 pub const Lod = enum(u5) {
 	@"1" = 0,

--- a/src/main.zig
+++ b/src/main.zig
@@ -478,9 +478,6 @@ pub fn main(args: std.process.Init.Minimal) void { // MARK: main()
 	utils.initDynamicIntArrayStorage();
 	defer utils.deinitDynamicIntArrayStorage();
 
-	chunk.init();
-	defer chunk.deinit();
-
 	rotation.init();
 	defer rotation.deinit();
 

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -75,7 +75,6 @@ pub var transparentQuadsDrawn: usize = 0;
 pub const maxQuadsInIndexBuffer = 3 << (3*chunk.chunkShift); // maximum 3 faces/block
 
 pub fn init() void {
-	lighting.init();
 	pipeline = graphics.Pipeline.init(
 		"assets/cubyz/shaders/chunks/chunk_vertex.vert",
 		"assets/cubyz/shaders/chunks/chunk_fragment.frag",
@@ -145,7 +144,6 @@ pub fn init() void {
 }
 
 pub fn deinit() void {
-	lighting.deinit();
 	pipeline.deinit();
 	transparentPipeline.deinit();
 	occlusionTestPipeline.deinit();

--- a/src/renderer/lighting.zig
+++ b/src/renderer/lighting.zig
@@ -14,15 +14,7 @@ const vec = main.vec;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
 
-var memoryPool: main.heap.MemoryPool(ChannelChunk) = undefined;
-
-pub fn init() void {
-	memoryPool = .init(main.globalAllocator);
-}
-
-pub fn deinit() void {
-	memoryPool.deinit();
-}
+var memoryPool: main.heap.MemoryPool(ChannelChunk) = .init(main.globalArena);
 
 const LightValue = packed struct(u32) {
 	r: u8,

--- a/src/renderer/mesh_storage.zig
+++ b/src/renderer/mesh_storage.zig
@@ -66,11 +66,10 @@ pub const BlockUpdate = struct {
 	}
 };
 
-pub var meshMemoryPool: main.heap.MemoryPool(chunk_meshing.ChunkMesh) = undefined;
+pub var meshMemoryPool: main.heap.MemoryPool(chunk_meshing.ChunkMesh) = .init(main.globalArena);
 
 pub fn init() void { // MARK: init()
 	lastRD = 0;
-	meshMemoryPool = .init(main.globalAllocator);
 	for (&storageLists) |*storageList| {
 		storageList.* = main.globalAllocator.create([storageSize*storageSize*storageSize]ChunkMeshNode);
 		for (storageList.*) |*val| {
@@ -110,7 +109,6 @@ pub fn deinit() void {
 	priorityMeshUpdateList.deinit();
 	meshList.clearAndFree();
 	main.heap.GarbageCollection.waitForFreeCompletion();
-	meshMemoryPool.deinit();
 }
 
 // MARK: getters

--- a/src/server/terrain/CaveBiomeMap.zig
+++ b/src/server/terrain/CaveBiomeMap.zig
@@ -535,15 +535,7 @@ var cache: Cache(CaveBiomeMapFragment, cacheSize, associativity, CaveBiomeMapFra
 
 var profile: TerrainGenerationProfile = undefined;
 
-var memoryPool: main.heap.MemoryPool(CaveBiomeMapFragment) = undefined;
-
-pub fn globalInit() void {
-	memoryPool = .init(main.globalAllocator);
-}
-
-pub fn globalDeinit() void {
-	memoryPool.deinit();
-}
+var memoryPool: main.heap.MemoryPool(CaveBiomeMapFragment) = .init(main.globalArena);
 
 pub fn init(_profile: TerrainGenerationProfile) void {
 	profile = _profile;

--- a/src/server/terrain/CaveMap.zig
+++ b/src/server/terrain/CaveMap.zig
@@ -276,7 +276,7 @@ const associativity = 8; // 1024 MiB Cache size
 var cache: Cache(CaveMapFragment, cacheSize, associativity, CaveMapFragment.deferredDeinit) = .{};
 var profile: TerrainGenerationProfile = undefined;
 
-var memoryPool: main.heap.MemoryPool(CaveMapFragment) = undefined;
+var memoryPool: main.heap.MemoryPool(CaveMapFragment) = .init(main.globalArena);
 
 fn cacheInit(pos: ChunkPosition) *CaveMapFragment {
 	const mapFragment = memoryPool.create();
@@ -285,14 +285,6 @@ fn cacheInit(pos: ChunkPosition) *CaveMapFragment {
 		generator.generate(mapFragment, profile.seed ^ generator.generatorSeed);
 	}
 	return mapFragment;
-}
-
-pub fn globalInit() void {
-	memoryPool = .init(main.globalAllocator);
-}
-
-pub fn globalDeinit() void {
-	memoryPool.deinit();
 }
 
 pub fn init(_profile: TerrainGenerationProfile) void {

--- a/src/server/terrain/ClimateMap.zig
+++ b/src/server/terrain/ClimateMap.zig
@@ -101,15 +101,7 @@ const associativity = 8; // ~400 MiB
 var cache: Cache(ClimateMapFragment, cacheSize, associativity, ClimateMapFragment.deferredDeinit) = .{};
 var profile: TerrainGenerationProfile = undefined;
 
-var memoryPool: main.heap.MemoryPool(ClimateMapFragment) = undefined;
-
-pub fn globalInit() void {
-	memoryPool = .init(main.globalAllocator);
-}
-
-pub fn globalDeinit() void {
-	memoryPool.deinit();
-}
+var memoryPool: main.heap.MemoryPool(ClimateMapFragment) = .init(main.globalArena);
 
 fn cacheInit(pos: ClimateMapFragmentPosition) *ClimateMapFragment {
 	const mapFragment = memoryPool.create();

--- a/src/server/terrain/StructureMap.zig
+++ b/src/server/terrain/StructureMap.zig
@@ -173,7 +173,7 @@ const associativity = 8;
 var cache: Cache(StructureMapFragment, cacheSize, associativity, StructureMapFragment.deferredDeinit) = .{};
 var profile: TerrainGenerationProfile = undefined;
 
-var memoryPool: main.heap.MemoryPool(StructureMapFragment) = undefined;
+var memoryPool: main.heap.MemoryPool(StructureMapFragment) = .init(main.globalArena);
 
 fn cacheInit(pos: ChunkPosition) *StructureMapFragment {
 	const mapFragment = memoryPool.create();
@@ -183,14 +183,6 @@ fn cacheInit(pos: ChunkPosition) *StructureMapFragment {
 	}
 	mapFragment.finishGeneration();
 	return mapFragment;
-}
-
-pub fn globalInit() void {
-	memoryPool = .init(main.globalAllocator);
-}
-
-pub fn globalDeinit() void {
-	memoryPool.deinit();
 }
 
 pub fn init(_profile: TerrainGenerationProfile) void {

--- a/src/server/terrain/SurfaceMap.zig
+++ b/src/server/terrain/SurfaceMap.zig
@@ -268,15 +268,7 @@ const associativity = 8; // ~400MiB MiB Cache size
 var cache: Cache(MapFragment, cacheSize, associativity, MapFragment.deferredDeinit) = .{};
 var profile: TerrainGenerationProfile = undefined;
 
-var memoryPool: main.heap.MemoryPool(MapFragment) = undefined;
-
-pub fn globalInit() void {
-	memoryPool = .init(main.globalAllocator);
-}
-
-pub fn globalDeinit() void {
-	memoryPool.deinit();
-}
+var memoryPool: main.heap.MemoryPool(MapFragment) = .init(main.globalArena);
 
 fn cacheInit(pos: MapFragmentPosition) *MapFragment {
 	const mapFragment = memoryPool.create();

--- a/src/server/terrain/terrain.zig
+++ b/src/server/terrain/terrain.zig
@@ -121,11 +121,6 @@ pub const TerrainGenerationProfile = struct {
 };
 
 pub fn globalInit() void {
-	SurfaceMap.globalInit();
-	ClimateMap.globalInit();
-	CaveBiomeMap.globalInit();
-	CaveMap.globalInit();
-	StructureMap.globalInit();
 	{
 		const list = @import("chunkgen/_list.zig");
 		inline for (@typeInfo(list).@"struct".decls) |decl| {
@@ -138,11 +133,6 @@ pub fn globalInit() void {
 }
 
 pub fn globalDeinit() void {
-	CaveBiomeMap.globalDeinit();
-	CaveMap.globalDeinit();
-	StructureMap.globalDeinit();
-	ClimateMap.globalDeinit();
-	SurfaceMap.globalDeinit();
 	BlockGenerator.generatorRegistry.clearAndFree(main.globalAllocator.allocator);
 }
 

--- a/src/utils/heap.zig
+++ b/src/utils/heap.zig
@@ -567,15 +567,16 @@ pub fn MemoryPool(Item: type) type { // MARK: MemoryPool
 		const NodePtr = *align(item_alignment) Node;
 		const ItemPtr = *align(item_alignment) Item;
 
-		arena: NeverFailingArenaAllocator,
+		arena: NeverFailingAllocator,
 		free_list: ?NodePtr = null,
 		freeAllocations: usize = 0,
 		totalAllocations: usize = 0,
 		mutex: main.utils.Mutex = .{},
 
 		/// Creates a new memory pool.
-		pub fn init(allocator: NeverFailingAllocator) Pool {
-			return .{.arena = NeverFailingArenaAllocator.init(allocator)};
+		pub fn init(arena: NeverFailingAllocator) Pool {
+			std.debug.assert(arena.allocator.vtable.alloc == comptime NeverFailingArenaAllocator.allocator(@ptrFromInt(1024)).allocator.vtable.alloc);
+			return .{.arena = arena};
 		}
 
 		/// Destroys the memory pool and frees all allocated memory.
@@ -585,7 +586,6 @@ pub fn MemoryPool(Item: type) type { // MARK: MemoryPool
 			} else if (pool.totalAllocations != 0) {
 				std.log.info("{} MiB ({} elements) in {s} Memory pool", .{pool.totalAllocations*item_size >> 20, pool.totalAllocations, @typeName(Item)});
 			}
-			pool.arena.deinit();
 			pool.* = undefined;
 		}
 
@@ -623,7 +623,7 @@ pub fn MemoryPool(Item: type) type { // MARK: MemoryPool
 			pool.mutex.assertLocked();
 			pool.totalAllocations += 1;
 			pool.freeAllocations += 1;
-			const mem = pool.arena.allocator().alignedAlloc(u8, .fromByteUnits(item_alignment), item_size);
+			const mem = pool.arena.alignedAlloc(u8, .fromByteUnits(item_alignment), item_size);
 			return mem[0..item_size]; // coerce slice to array pointer
 		}
 	};


### PR DESCRIPTION
This allows using the globalArena for it. This does mean that there is possibly more congestion than having separate arenas for each, but on the other hand it does reduce the amount of setup code we need to have, since the memory pools now no longer need to be deinited. Furthermore using the globalArena might allow us to save some memory in the future by limiting the maximums allocation size or using a backing VirtualList.

In practice no performance difference was found.

The other downside is that there now is less telemetry on where memory is allocated, since the memory pools cannot print anything on deinit anymore. I have made an issue to reintroduce a (better) leak check #3075 

progress towards #2748