### PR TITLE
Fix z fighting on transparent backfaces next to stairs and walls and the like

### DIFF
--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -94,7 +94,7 @@ pub fn init() void {
 		&transparentUniforms,
 		graphics.VertexArray.EmptyVertex,
 		&.{},
-		.{.depthBias = .{.slopeFactor = 0.002, .constantFactor = 1, .clamp = 0}},
+		.{.depthBias = .{.slopeFactor = 0.0, .constantFactor = 10, .clamp = 0}},
 		.{.depthTest = true, .depthWrite = false, .depthCompare = .less},
 		.{.attachments = &.{.{
 			.srcColorBlendFactor = .one,

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -94,8 +94,8 @@ pub fn init() void {
 		&transparentUniforms,
 		graphics.VertexArray.EmptyVertex,
 		&.{},
-		.{},
-		.{.depthTest = true, .depthWrite = false, .depthCompare = .lessOrEqual},
+		.{.depthBias = .{.slopeFactor = 0.002, .constantFactor = 1, .clamp = 0}},
+		.{.depthTest = true, .depthWrite = false, .depthCompare = .less},
 		.{.attachments = &.{.{
 			.srcColorBlendFactor = .one,
 			.dstColorBlendFactor = .src1Color,

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -83,7 +83,7 @@ pub fn init() void {
 		&uniforms,
 		graphics.VertexArray.EmptyVertex,
 		&.{},
-		.{},
+		.{.depthBias = .{.slopeFactor = -0.002, .constantFactor = -1, .clamp = 0}},
 		.{.depthTest = true, .depthWrite = true},
 		.{.attachments = &.{.noBlending}},
 	);
@@ -94,7 +94,7 @@ pub fn init() void {
 		&transparentUniforms,
 		graphics.VertexArray.EmptyVertex,
 		&.{},
-		.{.depthBias = .{.slopeFactor = 0.0, .constantFactor = 10, .clamp = 0}},
+		.{},
 		.{.depthTest = true, .depthWrite = false, .depthCompare = .less},
 		.{.attachments = &.{.{
 			.srcColorBlendFactor = .one,


### PR DESCRIPTION
A similar fix caused some issues in the past (see #765), but I think the issues were caused by residual values in other shaders, which should no longer be an issue with the new pipeline abstraction, nevertheless I would like to have some people test this, just in case.

Furthermore I decided to go for a much smaller slopeFactor, to reduce seams at the transition point.

fixes #696