### PR TITLE
disallow shifclick on creative window when not creative

### DIFF
--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1173,6 +1173,8 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn run(self: FillAnyFromCreative, ctx: Context) error{serverFailure}!void {
+			if (ctx.side == .server and ctx.user != null and ctx.gamemode != .creative) return;
+			if (ctx.side == .client and ctx.gamemode != .creative) return;
 			_ = self.destinations.putItemsInto(ctx, self.amount, .{.create = self.item});
 		}
 

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1173,8 +1173,7 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn run(self: FillAnyFromCreative, ctx: Context) error{serverFailure}!void {
-			if (ctx.side == .server and ctx.user != null and ctx.gamemode != .creative) return;
-			if (ctx.side == .client and ctx.gamemode != .creative) return;
+			if (ctx.gamemode != .creative) return;
 			_ = self.destinations.putItemsInto(ctx, self.amount, .{.create = self.item});
 		}
 

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1107,8 +1107,7 @@ pub const Command = struct { // MARK: Command
 
 		fn run(self: FillFromCreative, ctx: Context) error{serverFailure}!void {
 			if (self.dest.inv.source == .workbench and (self.dest.inv.source.workbench.proceduralItemIndex.slotInfos()[self.dest.slot].disabled or !canPutIntoWorkbench(self.item))) return;
-			if (ctx.side == .server and ctx.user != null and ctx.gamemode != .creative) return;
-			if (ctx.side == .client and ctx.gamemode != .creative) return;
+			if (ctx.gamemode != .creative) return;
 
 			if (!self.dest.ref().empty()) {
 				ctx.execute(.{.delete = .{


### PR DESCRIPTION
While testing something different, I saw that I could shift-click take items from the creative window even though I was not in creative mode and had cheats not enabled. 
This PR fixes this.