### PR TITLE
Allow rotation modes to give a custom collision model to Model.init

### DIFF
--- a/mods/cubyz/rotations/branch.zig
+++ b/mods/cubyz/rotations/branch.zig
@@ -315,7 +315,7 @@ pub fn createBlockModel(_: Block, modeData: *u16, zon: ZonElement) ModelIndex {
 			if (data.enabledConnections & Neighbor.dirUp.bitMask() != 0) boxZ.max[2] = 1;
 			boxes.appendAssumeCapacity(boxZ);
 		}
-		
+
 		if (boxes.items.len == 0) boxes.appendAssumeCapacity(innerBox);
 
 		const index = main.models.Model.initWithCollisionModel(quads.items, boxes.items);

--- a/mods/cubyz/rotations/branch.zig
+++ b/mods/cubyz/rotations/branch.zig
@@ -275,8 +275,14 @@ pub fn createBlockModel(_: Block, modeData: *u16, zon: ZonElement) ModelIndex {
 		shellModel.getRawFaces(&shellQuads);
 	}
 
+	const innerBox: main.physics.collision.Box = .{
+		.min = @splat(0.5 - radius/16.0),
+		.max = @splat(0.5 + radius/16.0),
+	};
+
 	var modelIndex: ModelIndex = undefined;
 	for (0..64) |i| {
+		const data: BranchData = @bitCast(@as(u7, @intCast(i)));
 		var quads = main.ListManaged(main.models.QuadInfo).init(main.stackAllocator);
 		defer quads.deinit();
 		quads.appendSlice(shellQuads.items);
@@ -289,7 +295,30 @@ pub fn createBlockModel(_: Block, modeData: *u16, zon: ZonElement) ModelIndex {
 			}
 		}
 
-		const index = main.models.Model.init(quads.items);
+		var boxes: main.ListUnmanaged(main.physics.collision.Box) = .initCapacity(main.stackAllocator, 3);
+		defer boxes.deinit(main.stackAllocator);
+		if (data.enabledConnections & Neighbor.dirNegX.bitMask() != 0 or data.enabledConnections & Neighbor.dirPosX.bitMask() != 0) {
+			var boxX = innerBox;
+			if (data.enabledConnections & Neighbor.dirNegX.bitMask() != 0) boxX.min[0] = 0;
+			if (data.enabledConnections & Neighbor.dirPosX.bitMask() != 0) boxX.max[0] = 1;
+			boxes.appendAssumeCapacity(boxX);
+		}
+		if (data.enabledConnections & Neighbor.dirNegY.bitMask() != 0 or data.enabledConnections & Neighbor.dirPosY.bitMask() != 0) {
+			var boxY = innerBox;
+			if (data.enabledConnections & Neighbor.dirNegY.bitMask() != 0) boxY.min[1] = 0;
+			if (data.enabledConnections & Neighbor.dirPosY.bitMask() != 0) boxY.max[1] = 1;
+			boxes.appendAssumeCapacity(boxY);
+		}
+		if (data.enabledConnections & Neighbor.dirDown.bitMask() != 0 or data.enabledConnections & Neighbor.dirUp.bitMask() != 0) {
+			var boxZ = innerBox;
+			if (data.enabledConnections & Neighbor.dirDown.bitMask() != 0) boxZ.min[2] = 0;
+			if (data.enabledConnections & Neighbor.dirUp.bitMask() != 0) boxZ.max[2] = 1;
+			boxes.appendAssumeCapacity(boxZ);
+		}
+		
+		if (boxes.items.len == 0) boxes.appendAssumeCapacity(innerBox);
+
+		const index = main.models.Model.initWithCollisionModel(quads.items, boxes.items);
 		if (i == 0) {
 			modelIndex = index;
 		}

--- a/mods/cubyz/rotations/log.zig
+++ b/mods/cubyz/rotations/log.zig
@@ -170,7 +170,7 @@ pub fn createBlockModel(_: Block, _: *u16, _: ZonElement) ModelIndex {
 			quads.append(rotateQuad(pattern, neighbor));
 		}
 
-		const index = main.models.Model.init(quads.items);
+		const index = main.models.Model.initWithCollisionModel(quads.items, &.{.{.min = @splat(0), .max = @splat(1)}});
 		if (i == 0) {
 			modelIndex = index;
 		}

--- a/mods/cubyz/rotations/stairs.zig
+++ b/mods/cubyz/rotations/stairs.zig
@@ -13,6 +13,7 @@ const vec = main.vec;
 const Mat4f = vec.Mat4f;
 const Tag = main.Tag;
 const Vec2f = vec.Vec2f;
+const Vec3d = vec.Vec3d;
 const Vec3f = vec.Vec3f;
 const Vec3i = vec.Vec3i;
 const ZonElement = main.ZonElement;
@@ -233,7 +234,38 @@ pub fn createBlockModel(_: Block, _: *u16, _: ZonElement) ModelIndex {
 				});
 			}
 		}
-		const index = main.models.Model.init(quads.items);
+		var boxes: main.ListUnmanaged(main.physics.collision.Box) = .initCapacity(main.stackAllocator, 4);
+		defer boxes.deinit(main.stackAllocator);
+		var remaining: u8 = ~@as(u8, @intCast(i));
+		for (0..2) |dx| {
+			for (0..2) |dy| {
+				for(0..2) |dz| {
+					var mask = subBlockMask(@intCast(dx), @intCast(dy), @intCast(dz));
+					if (remaining & mask == 0) continue;
+					var dx2 = dx + 1;
+					var dy2 = dy + 1;
+					var dz2 = dz + 1;
+					if (dz == 0 and remaining & (mask << 1) == (mask << 1)) {
+						dz2 += 1;
+						mask |= mask << 1;
+					}
+					if (dy == 0 and remaining & (mask << 2) == (mask << 2)) {
+						dy2 += 1;
+						mask |= mask << 2;
+					}
+					if (dx == 0 and remaining & (mask << 4) == (mask << 4)) {
+						dx2 += 1;
+						mask |= mask << 4;
+					}
+					boxes.appendAssumeCapacity(.{
+						.min = @as(Vec3d, @floatFromInt(@Vector(3, usize){dx, dy, dz}))/@as(Vec3d, @splat(2)),
+						.max = @as(Vec3d, @floatFromInt(@Vector(3, usize){dx2, dy2, dz2}))/@as(Vec3d, @splat(2)),
+					});
+					remaining &= ~mask;
+				}
+			}
+		}
+		const index = main.models.Model.initWithCollisionModel(quads.items, boxes.items);
 		if (i == 0) {
 			modelIndex = index;
 		}

--- a/mods/cubyz/rotations/stairs.zig
+++ b/mods/cubyz/rotations/stairs.zig
@@ -239,7 +239,7 @@ pub fn createBlockModel(_: Block, _: *u16, _: ZonElement) ModelIndex {
 		var remaining: u8 = ~@as(u8, @intCast(i));
 		for (0..2) |dx| {
 			for (0..2) |dy| {
-				for(0..2) |dz| {
+				for (0..2) |dz| {
 					var mask = subBlockMask(@intCast(dx), @intCast(dy), @intCast(dz));
 					if (remaining & mask == 0) continue;
 					var dx2 = dx + 1;

--- a/src/models.zig
+++ b/src/models.zig
@@ -134,7 +134,7 @@ pub const Model = struct {
 		return @popCount(@as(u3, @bitCast(hasTwoOnes))) == 2 and @popCount(@as(u3, @bitCast(hasTwoZeroes))) == 2;
 	}
 
-	pub fn init(quadInfos: []const QuadInfo) ModelIndex {
+	pub fn initWithCollisionModel(quadInfos: []const QuadInfo, collisionModel: ?[]const Box) ModelIndex {
 		const adjustedQuads = main.stackAllocator.alloc(QuadInfo, quadInfos.len);
 		defer main.stackAllocator.free(adjustedQuads);
 		for (adjustedQuads, quadInfos) |*dest, *src| {
@@ -207,8 +207,16 @@ pub const Model = struct {
 			self.allNeighborsOccluded = self.allNeighborsOccluded and self.isNeighborOccluded[neighbor];
 			self.noNeighborsOccluded = self.noNeighborsOccluded and !self.isNeighborOccluded[neighbor];
 		}
-		generateCollision(self, adjustedQuads);
+		if (collisionModel) |collision| {
+			self.collision = main.globalAllocator.dupe(Box, collision);
+		} else {
+			generateCollision(self, adjustedQuads);
+		}
 		return modelIndex;
+	}
+
+	pub fn init(quadInfos: []const QuadInfo) ModelIndex {
+		return initWithCollisionModel(quadInfos, null);
 	}
 
 	fn edgeInterp(y: f32, x0: f32, y0: f32, x1: f32, y1: f32) f32 {


### PR DESCRIPTION
I noticed that collision model calculation takes a significant part of our loading time, particularly in debug mode, so I decided to precompute it for models that are purely generated (stairs and branches).

fixes #1506