### PR TITLE
Add extra test cases for optionals parsing

### DIFF
--- a/src/argparse.zig
+++ b/src/argparse.zig
@@ -269,6 +269,25 @@ test "float int optional float missing" {
 	try std.testing.expectEqual(result.z, null);
 }
 
+test "two optionals missing" {
+	const ArgParser = Parser(struct {
+		x: f32,
+		y: ?f32,
+		z: ?f32,
+	}, .{.commandName = ""});
+
+	var errors: ListUnmanaged(u8) = .{};
+	defer errors.deinit(main.stackAllocator);
+
+	const resultOrError = ArgParser.parse(main.stackAllocator, "1.0", &errors);
+
+	try std.testing.expectEqualStrings("", errors.items);
+	const result = try resultOrError;
+	try std.testing.expectEqual(result.x, 1.0);
+	try std.testing.expectEqual(result.y, null);
+	try std.testing.expectEqual(result.z, null);
+}
+
 test "float int optional float present" {
 	const ArgParser = Parser(struct {
 		x: f64,
@@ -286,6 +305,25 @@ test "float int optional float present" {
 	try std.testing.expectEqual(result.x, 33.0);
 	try std.testing.expectEqual(result.y, 154);
 	try std.testing.expectEqual(result.z, 0.1);
+}
+
+test "optional inbetween" {
+	const ArgParser = Parser(struct {
+		x: enum { foo },
+		y: ?f32,
+		z: enum { bar },
+	}, .{.commandName = "c"});
+
+	var errors: ListUnmanaged(u8) = .{};
+	defer errors.deinit(main.stackAllocator);
+
+	const resultOrError = ArgParser.parse(main.stackAllocator, "foo bar", &errors);
+
+	try std.testing.expectEqualStrings("", errors.items);
+	const result = try resultOrError;
+	try std.testing.expectEqual(result.x, .foo);
+	try std.testing.expectEqual(result.y, null);
+	try std.testing.expectEqual(result.z, .bar);
 }
 
 test "x or xy case x" {


### PR DESCRIPTION
After looking into the implementation I got worried about few extra cases of optionals parsing. We seem to pass those, yet I would prefer to have them tested. In particular, I want to be sure that we properly continue parsing after we encounter null optionals, not only that we allow trailing optionals.