### PR TITLE
PVP | make violance doable (no raytracing)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -230,6 +230,7 @@ pub fn build(b: *std.Build) !void {
 		.name = "Cubyz",
 		.root_module = mainModule,
 		//.sanitize_thread = true,
+		.use_llvm = true, 
 	});
 	exe.root_module.addOptions("build_options", options);
 	exe.root_module.addImport("main", mainModule);

--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -541,6 +541,11 @@ pub const ClientInventory = struct { // MARK: ClientInventory
 		main.renderer.MeshSelection.breakBlock(self, slot, deltaTime);
 	}
 
+	pub fn clickEntity(self: ClientInventory, slot: u32, button:main.sync.Command.PlayerClickEntity.Button) void {
+		std.debug.assert(self.type == .serverShared);
+		main.renderer.MeshSelection.clickEntity(self, slot, button);
+	}
+
 	pub fn size(self: ClientInventory) usize {
 		return self.super.size();
 	}

--- a/src/entitySystem/modelRenderer.zig
+++ b/src/entitySystem/modelRenderer.zig
@@ -128,7 +128,14 @@ pub const client = struct {
 
 			entTexture.?.bindTo(0);
 			const blockPos: vec.Vec3i = @floor(ent.pos);
-			const lightVals: [6]u8 = main.renderer.mesh_storage.getLight(blockPos[0], blockPos[1], blockPos[2]) orelse @splat(0);
+
+			//TODO: this is only temporary to test the selection.
+			var lightVals: [6]u8 = main.renderer.mesh_storage.getLight(blockPos[0], blockPos[1], blockPos[2]) orelse @splat(0);
+			if(main.renderer.MeshSelection.selectedEntity)|selectedEntity|{
+				if(selectedEntity == @intFromEnum(id)){
+					lightVals = @splat(0);
+				}
+			}
 			const light = (@as(u32, lightVals[0] >> 3) << 25 |
 				@as(u32, lightVals[1] >> 3) << 20 |
 				@as(u32, lightVals[2] >> 3) << 15 |

--- a/src/game.zig
+++ b/src/game.zig
@@ -199,6 +199,15 @@ pub const Player = struct { // MARK: Player
 
 		inventory.placeBlock(selectedSlot);
 	}
+	
+	pub fn breakBlock(deltaTime: f64) void {
+		inventory.breakBlock(selectedSlot, deltaTime);
+	}
+
+	pub fn clickEntity(mods: main.Window.Key.Modifiers,button:main.sync.Command.PlayerClickEntity.Button)void {
+		_ = mods;
+		inventory.clickEntity(selectedSlot, button);
+	}
 
 	pub fn kill(spawnPos: Vec3d) void {
 		Player.super.pos = spawnPos;
@@ -219,10 +228,7 @@ pub const Player = struct { // MARK: Player
 		}
 	}
 
-	pub fn breakBlock(deltaTime: f64) void {
-		inventory.breakBlock(selectedSlot, deltaTime);
-	}
-
+	
 	pub fn acquireSelectedBlock() void {
 		if (main.renderer.MeshSelection.selectedBlockPos) |selectedPos| {
 			const block = main.renderer.mesh_storage.getBlockFromRenderThread(selectedPos[0], selectedPos[1], selectedPos[2]) orelse return;
@@ -305,6 +311,20 @@ pub const World = struct { // MARK: World
 		main.particles.ParticleManager.generateTextureArray();
 		main.models.uploadModels();
 		main.entityModel.loadModelsAndTexture();
+
+		// TODO: remove before merge
+		main.client.entity_manager.addEntity(main.ZonElement.parseFromString(main.globalArena, null,
+			\\ .{
+			\\    .id = 1,
+			\\    .name = "bobik",
+			\\
+			\\  }
+		)) catch unreachable;
+		var write = main.utils.BinaryWriter.init(main.stackAllocator);
+		write.writeVarInt(u32, main.entityModel.getById("cubyz:cubert").?.index);
+		defer write.deinit();
+		var reader = main.utils.BinaryReader.init(write.data.items);
+		main.entity.components.@"cubyz:model".client.load(1,&reader,0) catch unreachable;
 	}
 
 	pub fn deinit(self: *World) void {
@@ -439,19 +459,27 @@ var nextBlockPlaceTime: ?std.Io.Timestamp = null;
 var nextBlockBreakTime: ?std.Io.Timestamp = null;
 
 pub fn pressPlace(mods: main.Window.Key.Modifiers) void {
-	const time = main.timestamp();
-	nextBlockPlaceTime = time.addDuration(main.settings.updateRepeatDelay);
-	Player.placeBlock(mods);
+	if(main.renderer.MeshSelection.selectedEntity != null){
+		Player.clickEntity(mods,  .right);
+	}else{
+		const time = main.timestamp();
+		nextBlockPlaceTime = time.addDuration(main.settings.updateRepeatDelay);
+		Player.placeBlock(mods);
+	}
 }
 
 pub fn releasePlace(_: main.Window.Key.Modifiers) void {
 	nextBlockPlaceTime = null;
 }
 
-pub fn pressBreak(_: main.Window.Key.Modifiers) void {
-	const time = main.timestamp();
-	nextBlockBreakTime = time.addDuration(main.settings.updateRepeatDelay);
-	Player.breakBlock(0);
+pub fn pressBreak(mods: main.Window.Key.Modifiers) void {
+	if(main.renderer.MeshSelection.selectedEntity != null){
+		Player.clickEntity(mods, .left);
+	}else{
+		const time = main.timestamp();
+		nextBlockBreakTime = time.addDuration(main.settings.updateRepeatDelay);
+		Player.breakBlock(0);
+	}
 }
 
 pub fn releaseBreak(_: main.Window.Key.Modifiers) void {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -920,6 +920,9 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 	var selectionNormal: Vec3f = undefined;
 	var lastPos: Vec3d = undefined;
 	var lastDir: Vec3f = undefined;
+
+	pub var selectedEntity: ?u32 = null; 
+	
 	pub fn select(pos: Vec3d, _dir: Vec3f, item: main.items.Item) void {
 		lastPos = pos;
 		const dir: Vec3d = @floatCast(_dir);
@@ -939,6 +942,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 		var total_tMax: f64 = 0;
 
 		selectedBlockPos = null;
+		var blockIntersectionDistance = std.math.floatMax(f64);
 
 		while (total_tMax < closestDistance) {
 			const block = mesh_storage.getBlockFromRenderThread(voxelPos[0], voxelPos[1], voxelPos[2]) orelse break;
@@ -952,6 +956,7 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 						selectionMin = intersection.min;
 						selectionMax = intersection.max;
 						selectionNormal = intersection.normal;
+						blockIntersectionDistance = intersection.distance;
 						break;
 					}
 				}
@@ -983,7 +988,77 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 				}
 			}
 		}
-		// TODO: Test entities
+		// Test entities
+		selectedEntity = null;
+		var entDistance = std.math.floatMax(f64);
+
+		
+		entityLoop: for(main.client.entity_manager.entities.items())|ent|{
+			const entModelComp = main.entity.components.@"cubyz:model".client.get(ent.id) orelse continue;
+			const distance:main.vec.Vec3d = ent.getRenderPosition()-pos;
+			// distance[2] -= entModelComp.entityModel.get().height/2;
+			// distance[2] += 1;
+			
+			// skip the obvious ones
+			if(main.vec.lengthSquare(distance) > closestDistance*closestDistance){
+				continue;
+			}
+			// ray intersection
+			const box:main.vec.Vec3d = .{1,1,entModelComp.entityModel.get().height};
+			var t:main.vec.Vec3d = .{0,0,0};
+			var max:f64 = 0;
+			var maxComponent:u3 = 0;
+
+			inline for(0..3)|i|{
+				if(distance[i]+box[i]/2 >= 0 and distance[i]-box[i]/2 <= 0){
+					t[i] = 0;
+				}else{
+					if(dir[i]>0){
+						t[i] = (distance[i]-box[i]/2)/dir[i];	
+					}else if(dir[i]<0){
+						t[i] = (distance[i]+box[i]/2)/dir[i];	
+					}
+					else {
+						if(distance[i]+box[i]/2 >= 0 and distance[i]-box[i]/2 <= 0){
+							t[i] = 0;
+						}else{
+							t[i] = std.math.floatMax(f64);
+						}
+					}
+					if(t[i] < 0)
+						t[i] = std.math.floatMax(f64);
+				}
+				if(t[i] > max){
+					max = t[i];
+					maxComponent = i;
+				}
+			}
+
+			// range check
+			if(max > closestDistance){
+				continue;
+			}
+			if(max > blockIntersectionDistance){
+				continue;
+			}
+			// check if it didn't miss the hithox
+			inline for(0..3)|i|{
+				if(i != maxComponent){
+					if(distance[i]-dir[i]*max+box[i]/2 < 0 or distance[i]-dir[i]*max-box[i]/2 > 0){
+						continue :entityLoop;
+					}
+				}
+			}
+
+			if(max < entDistance){
+				entDistance = max;
+				selectedEntity = ent.id; 
+			}
+		}
+		if(selectedEntity != null){
+			selectedBlockPos = null;
+		}
+
 	}
 
 	fn canPlaceBlock(pos: Vec3i, block: main.blocks.Block) bool {
@@ -1138,6 +1213,10 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 		}
 	}
 
+		
+	
+
+	
 	fn updateBlockAndSendUpdate(source: main.items.Inventory.ClientInventory, slot: u32, pos: Vec3i, oldBlock: blocks.Block, newBlock: blocks.Block) void {
 		main.sync.client.executeCommand(.{
 			.updateBlock = .{
@@ -1154,6 +1233,40 @@ pub const MeshSelection = struct { // MARK: MeshSelection
 		});
 		mesh_storage.updateBlock(.{.pos = pos, .newBlock = newBlock, .blockEntityData = &.{}});
 	}
+
+	pub fn clickEntity(inventory: main.items.Inventory.ClientInventory, slot: u32, button:main.sync.Command.PlayerClickEntity.Button) void {
+		//TODO: do some animation
+		const ent = main.renderer.MeshSelection.selectedEntity orelse return;
+		//const stack = inventory.getStack(slot);
+
+		playerHitEntityAndSendUpdate(inventory, slot, lastPos, lastDir, ent, button);
+		// switch (inventory.getItem(slot)) {
+		// .baseItem => |baseItem| {
+		// if (baseItem.block()) |itemBlock| {
+		// _ = itemBlock;
+		// }
+		// },
+		// .proceduralItem => |proceduralItem| {
+		// _ = proceduralItem; 
+		// },
+		// .null => {},
+		// }
+		
+	}
+
+	fn playerHitEntityAndSendUpdate(source: main.items.Inventory.ClientInventory, slot: u32, pos: Vec3d, dir: Vec3d, entityId:u32, button:main.sync.Command.PlayerClickEntity.Button) void {
+		main.sync.client.executeCommand(.{
+			.playerClickEntity = .{
+				.source = .{.inv = source.super, .slot = slot},
+				.pos = pos,
+				.dir = dir,
+				.entityId = entityId,
+				.button = button
+			},
+		});
+		//TODO: play some clientside predicted stuff for that specific entity. maybe some animation
+	}
+
 
 	pub fn drawCube(projectionMatrix: Mat4f, viewMatrix: Mat4f, relativePositionToPlayer: Vec3d, min: Vec3f, max: Vec3f) void {
 		pipeline.bind(null);

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -238,6 +238,7 @@ pub const Command = struct { // MARK: Command
 		craftFrom = 13,
 		craftProceduralItem = 15,
 		clear = 8,
+		playerClickEntity = 18,
 		updateBlock = 9,
 		addHealth = 10,
 		chatCommand = 12,
@@ -258,6 +259,7 @@ pub const Command = struct { // MARK: Command
 		craftFrom: CraftFrom,
 		craftProceduralItem: CraftProceduralItem,
 		clear: Clear,
+		playerClickEntity :PlayerClickEntity,
 		updateBlock: UpdateBlock,
 		addHealth: AddHealth,
 		chatCommand: ChatCommand,
@@ -1513,14 +1515,71 @@ pub const Command = struct { // MARK: Command
 			};
 		}
 	};
+    pub const PlayerClickEntity = struct {
+		source: InventoryAndSlot,
+		pos: Vec3d,
+		dir: Vec3d,
+		entityId: u32,
+		button: Button,
+		
+		pub const Button = enum {
+			left, right
+		};
+		fn run(self: PlayerClickEntity, ctx: Context) error{}!void {
+			const stack = self.source.ref();
 
+			if (ctx.side == .server) {	
+				//TODO: better cheat prevention.
+				
+				addHealth(-2, .spiky, .server, self.entityId);
+
+				if(self.source.ref().item == .proceduralItem){
+					ctx.execute(.{.useDurability = .{
+						.source = self.source,
+						.durability = 1,
+					}});
+				}
+				std.debug.print(" hit got : {}\n", .{self.entityId});
+				_ = stack;
+			}
+
+			// Apply inventory changes:
+			//const handItem = self.source.inv.getItem(self.source.slot); // State should be stored before procedural item breaks
+			
+			// .yes_costsDurability => |durability| {
+				// ctx.execute(.{.useDurability = .{
+					// .source = self.source,
+					// .durability = durability,
+				// }});
+			// },
+			
+			
+		}
+		fn serialize(self: PlayerClickEntity, writer: *BinaryWriter) void {
+			self.source.write(writer);
+			writer.writeVec(Vec3d, self.pos);
+			writer.writeVec(Vec3d, self.dir);
+			writer.writeInt(u32, self.entityId);
+			writer.writeEnum(Button, self.button);
+		}
+
+		fn deserialize(reader: *BinaryReader, side: Side, user: ?*main.server.User) !PlayerClickEntity {
+			return .{
+				.source = try InventoryAndSlot.read(reader, side, user),
+				.pos = try reader.readVec(Vec3d),
+				.dir = try reader.readVec(Vec3d),
+				.entityId = try reader.readInt(u32),
+				.button = try reader.readEnum(Button),
+			};
+		}
+	};
 	const UpdateBlock = struct { // MARK: UpdateBlock
 		source: InventoryAndSlot,
 		pos: Vec3i,
 		dropLocation: BlockDropLocation,
 		oldBlock: Block,
 		newBlock: Block,
-
+		
 		const half = @as(Vec3f, @splat(0.5));
 		const itemHitBoxMargin: f32 = @floatCast(main.itemdrop.ItemDropManager.radius);
 		const itemHitBoxMarginVec: Vec3f = @splat(itemHitBoxMargin);


### PR DESCRIPTION

makes PVP possible

# hitbox todos:
[ ] entityModel.zig,zon does specify their (multiple) hitboxes
[ ] how the hitboxes are connected to certain nodes in the animated model.
[ ]  and which special properties they have (like double damage for example)

# anti cheat 
[ ] consider swing speed
[ ] consider position, velocity, range

# other todos:
[ ] item callback for attacking or interacting
[ ] make default right click be an invitation for trade (players and npc might decline)  with trade GUI
[ ] sweep attack. (hitting multiple enemies at once)
[ ] consider Armour for for damage taken
[ ] specify killer in death message "x and y with <weapon> killed z" ( x being the one who gave the final damage, and y being credited for most damage given (mentioning player y might be scratched if it turns out to be to complex))  
[ ] critical hit when jumping (with particles)
[ ] blood when hitting (also as confirmation that the server also counted it as a hit) 
[ ] knockback
[ ] cooldown indicator (in the hotbar)
[ ] make name use the depthbuffer  when shifting (i.e. name hides when shifting)

# projectiles
[ ] Bow & arrows
[ ] entitySystem Physics 
[ ] entitySystem intersection

# remove debug stuff:
[ ] remove bobik
[ ] remove use_llvm