### PR TITLE
fix: correct mapSize bounds check in SDF cave generator

### DIFF
--- a/src/server/terrain/cavegen/SdfCaveGenerator.zig
+++ b/src/server/terrain/cavegen/SdfCaveGenerator.zig
@@ -46,7 +46,7 @@ fn generateSdf(map: *const CaveMapFragment, biomeMap: *const CaveBiomeMapView, a
 	const biomePoints = biomeMap.getCaveBiomesInRange(main.stackAllocator, mapPos -% margin, mapPos +% margin +% Vec3i{CaveMapFragment.width*map.pos.voxelSize, CaveMapFragment.width*map.pos.voxelSize, CaveMapFragment.height*map.pos.voxelSize});
 	defer main.stackAllocator.free(biomePoints);
 
-	const mapSize = Vec3i{CaveMapFragment.width, CaveMapFragment.width, CaveMapFragment.height} << @as(@Vector(3, u5), @splat(voxelSizeShift));
+	const mapSize = Vec3i{ CaveMapFragment.width * map.pos.voxelSize, CaveMapFragment.width * map.pos.voxelSize, CaveMapFragment.height * map.pos.voxelSize };
 
 	for (biomePoints) |biomePoint| {
 		const distance = mapPos -% biomePoint.worldPos;
@@ -68,7 +68,7 @@ fn generateSdf(map: *const CaveMapFragment, biomeMap: *const CaveBiomeMapView, a
 
 pub fn generate(map: *CaveMapFragment, worldSeed: u64) void {
 	if (map.pos.voxelSize > 4) return;
-	const biomeMap = CaveBiomeMapView.init(main.stackAllocator, map.pos, CaveMapFragment.width*map.pos.voxelSize, 0);
+	const biomeMap = CaveBiomeMapView.init(main.stackAllocator, map.pos, CaveMapFragment.width * map.pos.voxelSize, 0);
 	defer biomeMap.deinit();
 	const outerSize = map.pos.voxelSize*interpolatedPart;
 	const outerSizeShift = std.math.log2_int(u31, outerSize);

--- a/src/server/terrain/cavegen/SdfCaveGenerator.zig
+++ b/src/server/terrain/cavegen/SdfCaveGenerator.zig
@@ -46,7 +46,7 @@ fn generateSdf(map: *const CaveMapFragment, biomeMap: *const CaveBiomeMapView, a
 	const biomePoints = biomeMap.getCaveBiomesInRange(main.stackAllocator, mapPos -% margin, mapPos +% margin +% Vec3i{CaveMapFragment.width*map.pos.voxelSize, CaveMapFragment.width*map.pos.voxelSize, CaveMapFragment.height*map.pos.voxelSize});
 	defer main.stackAllocator.free(biomePoints);
 
-	const mapSize = Vec3i{ CaveMapFragment.width * map.pos.voxelSize, CaveMapFragment.width * map.pos.voxelSize, CaveMapFragment.height * map.pos.voxelSize };
+	const mapSize = Vec3i{CaveMapFragment.width*map.pos.voxelSize, CaveMapFragment.width*map.pos.voxelSize, CaveMapFragment.height*map.pos.voxelSize};
 
 	for (biomePoints) |biomePoint| {
 		const distance = mapPos -% biomePoint.worldPos;
@@ -68,7 +68,7 @@ fn generateSdf(map: *const CaveMapFragment, biomeMap: *const CaveBiomeMapView, a
 
 pub fn generate(map: *CaveMapFragment, worldSeed: u64) void {
 	if (map.pos.voxelSize > 4) return;
-	const biomeMap = CaveBiomeMapView.init(main.stackAllocator, map.pos, CaveMapFragment.width * map.pos.voxelSize, 0);
+	const biomeMap = CaveBiomeMapView.init(main.stackAllocator, map.pos, CaveMapFragment.width*map.pos.voxelSize, 0);
 	defer biomeMap.deinit();
 	const outerSize = map.pos.voxelSize*interpolatedPart;
 	const outerSizeShift = std.math.log2_int(u31, outerSize);


### PR DESCRIPTION
Fixed a bug where **CaveBiomeMapView** was initialized with 0 margin, causing calculation artifacts or missing biome points outside the immediate map fragment boundaries during SDF cave generation.