### PR TITLE
Fix item migration issues by migrating items on load

### DIFF
--- a/src/items.zig
+++ b/src/items.zig
@@ -981,7 +981,8 @@ pub const Item = union(ItemType) { // MARK: Item
 		const typ = try reader.readEnum(ItemType);
 		switch (typ) {
 			.baseItem => {
-				return .{.baseItem = try reader.readEnum(BaseItemIndex)};
+				const index = try reader.readEnum(BaseItemIndex);
+				return .{.baseItem = realItemIndices[@intFromEnum(index)]};
 			},
 			.proceduralItem => {
 				return .{.proceduralItem = try ProceduralItem.fromBytes(reader)};
@@ -1187,6 +1188,9 @@ var modifierRestrictions: std.StringHashMapUnmanaged(*const ModifierRestriction.
 pub var itemList: [65536]BaseItem = undefined;
 pub var itemListSize: u16 = 0;
 
+// Due to migrations multiple indices can map to the same item. This must be resolved during inventory loading using this map.
+var realItemIndices: [65536]BaseItemIndex = undefined;
+
 var recipeList: main.ListManaged(Recipe) = .init(main.worldArena);
 
 pub fn hasRegistered(id: []const u8) bool {
@@ -1241,7 +1245,11 @@ pub fn register(_: []const u8, texturePath: []const u8, replacementTexturePath: 
 	defer itemListSize += 1;
 
 	newItem.init(main.worldArena, texturePath, replacementTexturePath, id, zon);
-	reverseIndices.put(main.worldArena.allocator, newItem.id, @enumFromInt(itemListSize)) catch unreachable;
+	const result = reverseIndices.getOrPut(main.worldArena.allocator, newItem.id) catch unreachable;
+	if (!result.found_existing) {
+		result.value_ptr.* = @enumFromInt(itemListSize);
+	}
+	realItemIndices[itemListSize] = result.value_ptr.*;
 
 	std.log.debug("Registered item: {d: >5} '{s}'", .{itemListSize, id});
 	return newItem;

--- a/src/items.zig
+++ b/src/items.zig
@@ -982,7 +982,7 @@ pub const Item = union(ItemType) { // MARK: Item
 		switch (typ) {
 			.baseItem => {
 				const index = try reader.readEnum(BaseItemIndex);
-				return .{.baseItem = realItemIndices[@intFromEnum(index)]};
+				return .{.baseItem = itemDeduplicationMap[@intFromEnum(index)]};
 			},
 			.proceduralItem => {
 				return .{.proceduralItem = try ProceduralItem.fromBytes(reader)};
@@ -1189,7 +1189,7 @@ pub var itemList: [65536]BaseItem = undefined;
 pub var itemListSize: u16 = 0;
 
 // Due to migrations multiple indices can map to the same item. This must be resolved during inventory loading using this map.
-var realItemIndices: [65536]BaseItemIndex = undefined;
+var itemDeduplicationMap: [65536]BaseItemIndex = undefined;
 
 var recipeList: main.ListManaged(Recipe) = .init(main.worldArena);
 
@@ -1249,7 +1249,7 @@ pub fn register(_: []const u8, texturePath: []const u8, replacementTexturePath: 
 	if (!result.found_existing) {
 		result.value_ptr.* = @enumFromInt(itemListSize);
 	}
-	realItemIndices[itemListSize] = result.value_ptr.*;
+	itemDeduplicationMap[itemListSize] = result.value_ptr.*;
 
 	std.log.debug("Registered item: {d: >5} '{s}'", .{itemListSize, id});
 	return newItem;


### PR DESCRIPTION
We saw everyone's iron turn into an uncraftable and unstackable version after the last migration in #2095, this was not severe since iron is mainly used in tool crafting, so no resources are lost.

For #2117 this would be more annoying since you possibly (depending on how your palette is ordered) couldn't craft your logs into anything.

Since there is no nice solution for this and I don't want to iterate through everything, I decided to go with the easiest/least effort solution: Just migrate duplicate ids on load using a direct map to the real index. This should only have a small performance impact since item loading is done rarely.

I'd be happy to hear if anyone has a better idea. (Also did we not have an issue for this problem?)