### PR TITLE
Fix crash on server exit

### DIFF
--- a/src/network.zig
+++ b/src/network.zig
@@ -1410,7 +1410,7 @@ pub const Connection = struct { // MARK: Connection
 		awaitingServerResponse,
 		awaitingClientAcknowledgement,
 		connected,
-		disconnectDesired,
+		disconnected,
 	};
 
 	pub const HandShakeState = enum(u8) {
@@ -1508,8 +1508,10 @@ pub const Connection = struct { // MARK: Connection
 	}
 
 	pub fn deinit(self: *Connection) void {
-		self.disconnect();
-		self.manager.finishCurrentReceive(); // Wait until all currently received packets are done.
+		if (self.connectionState.load(.monotonic) != .disconnected) {
+			self.disconnect();
+			self.manager.finishCurrentReceive(); // Wait until all currently received packets are done.
+		}
 		self.lossyChannel.deinit();
 		self.secureChannel.deinit();
 		self.slowChannel.deinit();
@@ -1686,7 +1688,7 @@ pub const Connection = struct { // MARK: Connection
 						return;
 					}
 				},
-				.disconnectDesired => {},
+				.disconnected => {},
 			}
 			// Acknowledge the packet on the client:
 			if (self.user == null) {
@@ -1777,7 +1779,7 @@ pub const Connection = struct { // MARK: Connection
 				return;
 			},
 			.connected => {},
-			.disconnectDesired => return,
+			.disconnected => return,
 		}
 
 		self.handlePacketLoss(self.lossyChannel.checkForLosses(self, timestamp));
@@ -1820,7 +1822,7 @@ pub const Connection = struct { // MARK: Connection
 
 	pub fn disconnect(self: *Connection) void {
 		self.manager.send(&.{@intFromEnum(ChannelId.disconnect)}, self.remoteAddress, null);
-		self.connectionState.store(.disconnectDesired, .monotonic);
+		self.connectionState.store(.disconnected, .monotonic);
 		if (builtin.os.tag == .windows and !self.isServerSide() and main.server.world != null) {
 			main.io.sleep(.fromMilliseconds(10), .awake) catch {}; // Windows is too eager to close the socket, without waiting here we get a ConnectionResetByPeer on the other side.
 		}

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -217,7 +217,7 @@ pub const handShake = struct { // MARK: handShake
 			};
 			break;
 		}
-		if (conn.connectionState.load(.monotonic) == .disconnectDesired) return error.DisconnectedByServer;
+		if (conn.connectionState.load(.monotonic) == .disconnected) return error.DisconnectedByServer;
 		conn.mutex.unlock();
 	}
 };

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -579,6 +579,8 @@ fn init(name: []const u8, singlePlayerPort: ?u16) void { // MARK: init()
 }
 
 fn deinit() void {
+	connectionManager.deinit();
+	connectionManager = undefined;
 	users.clearAndFree();
 	while (userDeinitList.popFront()) |user| {
 		user.clearJobQueue();
@@ -591,11 +593,6 @@ fn deinit() void {
 	}
 	userDeinitList.deinit();
 	userConnectList.deinit();
-	for (connectionManager.connections.items) |conn| {
-		conn.user.?.decreaseRefCount();
-	}
-	connectionManager.deinit();
-	connectionManager = undefined;
 
 	if (world) |_world| {
 		_world.deinit();


### PR DESCRIPTION
I observed this crash after the last play session:
```
#0  0x000000000137d1a7 in utils.CircularBufferQueue(*server.server.User).pushBack (self=0x23e1630 <server.server[userDeinitList]>, elem=0x7ff9bd0ad000) at utils.zig:512
#1  utils.ConcurrentQueue(*server.server.User).pushBack (self=0x23e1630 <server.server[userDeinitList]>, elem=0x7ff9bd0ad000) at utils.zig:614
#2  0x000000000137cc1a in server.server.disconnect (user=0x7ff9bd0ad000) at /home/mint/Cubyz/src/server/server.zig:724
#3  network.Connection.disconnect (self=0x7ff9bd0e3000) at network.zig:1831
#4  0x000000000137c30a in network.Connection.deinit (self=0x7ff9bd0e3000) at network.zig:1513
#5  server.server.User.deinit (self=0x7ff9bd0ad000) at /home/mint/Cubyz/src/server/server.zig:189
#6  0x00000000013f77f5 in server.server.User.decreaseRefCount (self=0x23e1630 <server.server[userDeinitList]>) at /home/mint/Cubyz/src/server/server.zig:209
#7  server.server.deinit () at /home/mint/Cubyz/src/server/server.zig:589
#8  server.server.startFromExistingThread (port=...) at /home/mint/Cubyz/src/server/server.zig:701
#9  0x000000000156d548 in server.server.startFromNewThread (port=...) at /home/mint/Cubyz/src/server/server.zig:695
#10 Thread.callFn__anon_469235 (args=...) at /home/mint/Cubyz/compiler/zig/lib/std/Thread.zig:422
#11 Thread.PosixThreadImpl.spawn__anon_469217.Instance.entryFn (raw_arg=0x7f155e0) at /home/mint/Cubyz/compiler/zig/lib/std/Thread.zig:752
#12 0x00007ffff7c94ac3 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#13 0x00007ffff7d268d0 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```

The problem was that a disconnect tried to add to the `userDeinitList`, but the userDeinitList was cleaned just before.

To fix this I moved the connection manager first, which also makes more sense since it avoids receiving new connections while already starting to clean things.