### PR TITLE
clear and free the chest

### DIFF
--- a/src/gui/windows/chest.zig
+++ b/src/gui/windows/chest.zig
@@ -30,7 +30,7 @@ const padding: f32 = 8;
 var itemSlots: main.List(*ItemSlot) = .empty;
 
 pub fn deinit() void {
-	itemSlots.deinit(main.globalAllocator);
+	itemSlots.clearAndFree(main.globalAllocator);
 }
 
 pub var openInventory: main.items.Inventory.ClientInventory = undefined;


### PR DESCRIPTION
Fixes: #3183
`deinit` for windows is called twice. once on world exit and once on game exit. 
Thats why we need to not only free but also clear