### PR TITLE
Use a fixed rate to correct the bandwidth used by congestion control

### DIFF
--- a/src/network.zig
+++ b/src/network.zig
@@ -749,6 +749,7 @@ pub const Connection = struct { // MARK: Connection
 	const congestionControl_historySize = 16;
 	const congestionControl_historyMask = congestionControl_historySize - 1;
 	const minimumBandWidth = 10_000;
+	const congestionBandwidthIncrement = 100_000.0/(1000.0*ms); // bytes/s²
 
 	const receiveBufferSize = 8 << 20;
 
@@ -1561,7 +1562,7 @@ pub const Connection = struct { // MARK: Connection
 		if (self.slowStart) {
 			self.bandwidthEstimateInBytesPerRtt += fullPacketLen;
 		} else {
-			self.bandwidthEstimateInBytesPerRtt += fullPacketLen/self.bandwidthEstimateInBytesPerRtt*@as(f32, @floatFromInt(self.mtuEstimate)) + fullPacketLen/100.0;
+			self.bandwidthEstimateInBytesPerRtt += fullPacketLen/self.bandwidthEstimateInBytesPerRtt*self.rttEstimate*congestionBandwidthIncrement;
 		}
 	}
 


### PR DESCRIPTION
It was observed that connections with low RTT could starve connections with high RTT. This happens because low RTT connections could increment their bandwidth faster after a loss happens.

This is fixed here by making the increment RTT-independent, it now is set to a fixed value of 100 kB/s per second (which is the increment a 50 ms connection had in the previous code).
I tested this on the server side in the last play session and I didn't see any issues.

- [ ] Double check the math (I think it should be 10k)
- [ ] Test it during the next play session again to make sure I didn't make any stupid mistakes while transformation the math of my makeshift implementation used in the previous play session