### PR TITLE
Use `main.entity.Entity` instead of u32 when referring to entities

### DIFF
--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -403,10 +403,10 @@ pub const SourceType = enum(u8) {
 };
 pub const Source = union(SourceType) {
 	alreadyFreed: void,
-	playerInventory: u32,
-	hand: u32,
+	playerInventory: main.entity.Entity,
+	hand: main.entity.Entity,
 	blockInventory: Vec3i,
-	workbench: struct { playerId: u32, proceduralItemIndex: ProceduralItemTypeIndex },
+	workbench: struct { playerId: main.entity.Entity, proceduralItemIndex: ProceduralItemTypeIndex },
 	other: void,
 };
 

--- a/src/client/Entity.zig
+++ b/src/client/Entity.zig
@@ -28,12 +28,12 @@ height: f64,
 pos: Vec3d = undefined,
 rot: Vec3f = undefined,
 
-id: u32,
+id: main.entity.Entity,
 name: []const u8,
 
 pub fn init(self: *@This(), zon: ZonElement, allocator: NeverFailingAllocator) !void {
 	self.* = @This(){
-		.id = zon.get(u32, "id", std.math.maxInt(u32)),
+		.id = @enumFromInt(zon.get(u32, "id", std.math.maxInt(u32))),
 		.width = zon.get(f64, "width", 1),
 		.height = zon.get(f64, "height", 1),
 		.name = allocator.dupe(u8, zon.get([]const u8, "name", "")),

--- a/src/client/entity_manager.zig
+++ b/src/client/entity_manager.zig
@@ -74,30 +74,30 @@ pub fn addEntity(zon: ZonElement) !void {
 
 	try ent.init(zon, main.globalAllocator);
 }
-pub fn getEntity(id: u32) ?*main.client.Entity {
+pub fn getEntity(entity: main.entity.Entity) ?*main.client.Entity {
 	mutex.assertLocked();
-	if (id >= idMapping.items.len) return null;
-	return &entities.items()[idMapping.items[id] orelse return null];
+	if (@intFromEnum(entity) >= idMapping.items.len) return null;
+	return &entities.items()[idMapping.items[@intFromEnum(entity)] orelse return null];
 }
-pub fn removeEntity(id: u32) void {
+pub fn removeEntity(entity: main.entity.Entity) void {
 	mutex.lock();
 	defer mutex.unlock();
 
-	if (idMapping.items.len <= id) return;
-	const index: u32 = idMapping.items[id] orelse return;
+	if (idMapping.items.len <= @intFromEnum(entity)) return;
+	const index: u32 = idMapping.items[@intFromEnum(entity)] orelse return;
 	const ent = entities.items()[index];
 
 	// remove id
-	idMapping.items[id] = null;
+	idMapping.items[@intFromEnum(entity)] = null;
 
 	// remove entity
 	{
-		std.debug.assert(ent.id == id);
+		std.debug.assert(ent.id == entity);
 		ent.deinit(main.globalAllocator);
 		_ = entities.swapRemove(index);
 
 		if (index != entities.len) {
-			idMapping.items[entities.items()[index].id] = index;
+			idMapping.items[@intFromEnum(entities.items()[index].id)] = index;
 			entities.items()[index].interpolatedValues.outPos = &entities.items()[index]._interpolationPos;
 			entities.items()[index].interpolatedValues.outVel = &entities.items()[index]._interpolationVel;
 		}

--- a/src/entity.zig
+++ b/src/entity.zig
@@ -10,7 +10,7 @@ pub const components = @import("entityComponent/_list.zig");
 pub const systems = @import("entitySystem/_list.zig");
 
 pub const EntityNetworkData = struct {
-	id: u32,
+	id: main.entity.Entity,
 	pos: Vec3d,
 	vel: Vec3d,
 	rot: Vec3f,
@@ -30,10 +30,10 @@ pub const Entity = enum(u32) {
 };
 pub const EntityComponentId = u32;
 const EntityComponentVTable = struct {
-	serverLoad: *const fn (entityId: u32, reader: *main.utils.BinaryReader, version: u32) EntityComponentLoadError!void,
-	clientLoad: *const fn (entityId: u32, reader: *main.utils.BinaryReader, version: u32) EntityComponentLoadError!void,
-	serverUnload: *const fn (entityId: u32) void,
-	clientUnload: *const fn (entityId: u32) void,
+	serverLoad: *const fn (entity: Entity, reader: *main.utils.BinaryReader, version: u32) EntityComponentLoadError!void,
+	clientLoad: *const fn (entity: Entity, reader: *main.utils.BinaryReader, version: u32) EntityComponentLoadError!void,
+	serverUnload: *const fn (entity: Entity) void,
+	clientUnload: *const fn (entity: Entity) void,
 };
 var componentList: []?EntityComponentVTable = undefined;
 
@@ -62,7 +62,7 @@ pub fn initComponents() void {
 pub fn deinitComponents() void {
 	componentList = undefined;
 }
-pub fn loadComponent(comptime side: main.sync.Side, componentId: EntityComponentId, entityId: u32, componentData: []const u8, componentVersion: u32) EntityComponentLoadError!void {
+pub fn loadComponent(comptime side: main.sync.Side, componentId: EntityComponentId, entity: Entity, componentData: []const u8, componentVersion: u32) EntityComponentLoadError!void {
 	if (componentId >= componentList.len) {
 		std.log.err("unknown Component Id {} ", .{componentId});
 		return error.UnknownComponentId;
@@ -70,10 +70,10 @@ pub fn loadComponent(comptime side: main.sync.Side, componentId: EntityComponent
 	var componentReader = main.utils.BinaryReader.init(componentData);
 	if (componentList[componentId]) |vtable| {
 		switch (side) {
-			.server => vtable.serverLoad(entityId, &componentReader, componentVersion) catch |err| {
+			.server => vtable.serverLoad(entity, &componentReader, componentVersion) catch |err| {
 				return err;
 			},
-			.client => vtable.clientLoad(entityId, &componentReader, componentVersion) catch |err| {
+			.client => vtable.clientLoad(entity, &componentReader, componentVersion) catch |err| {
 				return err;
 			},
 		}
@@ -82,15 +82,15 @@ pub fn loadComponent(comptime side: main.sync.Side, componentId: EntityComponent
 		return error.UnknownComponentId;
 	}
 }
-pub fn unloadComponent(comptime side: main.sync.Side, componentId: EntityComponentId, entityId: u32) EntityComponentLoadError!void {
+pub fn unloadComponent(comptime side: main.sync.Side, componentId: EntityComponentId, entity: Entity) EntityComponentLoadError!void {
 	if (componentId >= componentList.len) {
 		std.log.err("unknown Component Id {} ", .{componentId});
 		return error.UnknownComponentId;
 	}
 	if (componentList[componentId]) |vtable| {
 		switch (side) {
-			.server => vtable.serverUnload(entityId),
-			.client => vtable.clientUnload(entityId),
+			.server => vtable.serverUnload(entity),
+			.client => vtable.clientUnload(entity),
 		}
 	} else {
 		std.log.err("unknown Component Id {} ", .{componentId});
@@ -126,10 +126,10 @@ pub const client = struct {
 			@field(systems, decl.name).client.clear();
 		}
 	}
-	pub fn removeAllComponents(id: u32) void {
+	pub fn removeAllComponents(entity: Entity) void {
 		const list = main.entity.components;
 		inline for (@typeInfo(list).@"struct".decls) |decl| {
-			@field(list, decl.name).client.unload(id);
+			@field(list, decl.name).client.unload(entity);
 		}
 	}
 	pub fn render(projMatrix: Mat4f, ambientLight: Vec3f, playerPos: Vec3d, deltaTime: f64) void {
@@ -166,12 +166,12 @@ pub const server = struct {
 			@field(systems, decl.name).server.update();
 		}
 	}
-	pub fn componentsToBase64(allocator: main.heap.NeverFailingAllocator, entityId: u32, audience: main.entity.AudienceInfo) main.utils.Base64 {
+	pub fn componentsToBase64(allocator: main.heap.NeverFailingAllocator, entity: Entity, audience: main.entity.AudienceInfo) main.utils.Base64 {
 		var writer = main.utils.BinaryWriter.init(main.stackAllocator);
 		defer writer.deinit();
 
 		inline for (@typeInfo(main.entity.components).@"struct".decls) |decl| {
-			if (@field(main.entity.components, decl.name).server.get(entityId)) |component| {
+			if (@field(main.entity.components, decl.name).server.get(entity)) |component| {
 				var writerComponent = main.utils.BinaryWriter.init(main.stackAllocator);
 				defer writerComponent.deinit();
 
@@ -185,14 +185,14 @@ pub const server = struct {
 		return main.utils.Base64.toBase64(allocator, writer.data.items);
 	}
 
-	pub fn removeAllComponents(entityId: u32) void {
+	pub fn removeAllComponents(entity: Entity) void {
 		const list = main.entity.components;
 		inline for (@typeInfo(list).@"struct".decls) |decl| {
-			@field(list, decl.name).server.unload(entityId);
+			@field(list, decl.name).server.unload(entity);
 		}
 	}
 
-	pub fn transmitChange(EntityComponent: type, entity: u32) void {
+	pub fn transmitChange(EntityComponent: type, entity: Entity) void {
 		var binaryWriter = main.utils.BinaryWriter.init(main.stackAllocator);
 		defer binaryWriter.deinit();
 
@@ -213,7 +213,7 @@ pub const server = struct {
 	}
 };
 
-pub fn loadComponentsFromBase64(base64Data: []const u8, entityId: u32, comptime side: main.sync.Side) EntityComponentLoadError!void {
+pub fn loadComponentsFromBase64(base64Data: []const u8, entity: Entity, comptime side: main.sync.Side) EntityComponentLoadError!void {
 	const data = main.utils.fromBase64(main.stackAllocator, base64Data) catch return EntityComponentLoadError.DecodingBase64;
 	defer main.stackAllocator.free(data);
 
@@ -224,7 +224,7 @@ pub fn loadComponentsFromBase64(base64Data: []const u8, entityId: u32, comptime 
 		const componentVersion: u32 = reader.readVarInt(u32) catch return EntityComponentLoadError.UnreadableVersion;
 		const componentData = reader.readSliceWithSize() catch return EntityComponentLoadError.UnreadableComponentData;
 
-		lastError = loadComponent(side, componentId, entityId, componentData, componentVersion);
+		lastError = loadComponent(side, componentId, entity, componentData, componentVersion);
 	}
 	return lastError;
 }

--- a/src/entityComponent/_template.zig
+++ b/src/entityComponent/_template.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const main = @import("main");
 const chunk = main.chunk;
+const Entity = main.entity.Entity;
 const ServerChunk = chunk.ServerChunk;
 const game = main.game;
 const graphics = main.graphics;
@@ -32,13 +33,13 @@ pub const entityComponentVersion = 0;
 
 // ############################# Client only stuff ################################
 pub const client = struct {
-	pub fn load(entityId: u32, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
-		_ = entityId;
+	pub fn load(entity: Entity, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
+		_ = entity;
 		_ = reader;
 		_ = version;
 	}
-	pub fn unload(entityId: u32) void {
-		_ = entityId;
+	pub fn unload(entity: Entity) void {
+		_ = entity;
 	}
 	pub fn init() void {}
 	pub fn deinit() void {}
@@ -57,16 +58,16 @@ pub const server = struct {
 	};
 	pub fn init() void {}
 	pub fn deinit() void {}
-	pub fn get(entityId: u32) ?ExampleComponent {
-		_ = entityId;
+	pub fn get(entity: Entity) ?ExampleComponent {
+		_ = entity;
 		return null;
 	}
-	pub fn loadFromData(entityId: u32, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
-		_ = entityId;
+	pub fn loadFromData(entity: Entity, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
+		_ = entity;
 		_ = reader;
 		_ = version;
 	}
-	pub fn unload(entityId: u32) void {
-		_ = entityId;
+	pub fn unload(entity: Entity) void {
+		_ = entity;
 	}
 };

--- a/src/entityComponent/bag.zig
+++ b/src/entityComponent/bag.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const main = @import("main");
 const chunk = main.chunk;
+const Entity = main.entity.Entity;
 const ServerChunk = chunk.ServerChunk;
 const game = main.game;
 const graphics = main.graphics;
@@ -37,7 +38,7 @@ pub const client = struct {
 	const Component = struct {
 		bag: items.Inventory.BagInventory,
 	};
-	pub var components: main.utils.SparseSet(Component, main.entity.Entity) = .{};
+	pub var components: main.utils.SparseSet(Component, Entity) = .{};
 
 	pub fn init() void {}
 	pub fn deinit() void {
@@ -47,18 +48,18 @@ pub const client = struct {
 		components.clear();
 	}
 
-	pub fn getBag(entityId: u32) ?*items.Inventory.BagInventory {
-		return &(components.get(@enumFromInt(entityId)) orelse return null).bag;
+	pub fn getBag(entity: Entity) ?*items.Inventory.BagInventory {
+		return &(components.get(entity) orelse return null).bag;
 	}
 
-	pub fn load(entityId: u32, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
+	pub fn load(entity: Entity, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
 		if (version != entityComponentVersion) return error.InvalidComponentVersion;
-		const bag = &components.add(main.globalAllocator, @enumFromInt(entityId)).bag;
+		const bag = &components.add(main.globalAllocator, entity).bag;
 		bag.* = .init(main.globalAllocator, playerBagSizeLimit);
 		bag.fromBytes(reader) catch return error.UnreadableComponentData;
 	}
-	pub fn unload(entityId: u32) void {
-		const bag = components.fetchRemove(@enumFromInt(entityId)) catch return;
+	pub fn unload(entity: Entity) void {
+		const bag = components.fetchRemove(entity) catch return;
 		bag.bag.deinit();
 	}
 };
@@ -73,7 +74,7 @@ pub const server = struct {
 			return .save;
 		}
 	};
-	pub var components: main.utils.SparseSet(Component, main.entity.Entity) = .{};
+	pub var components: main.utils.SparseSet(Component, Entity) = .{};
 
 	pub fn init() void {
 		components = .{};
@@ -82,24 +83,24 @@ pub const server = struct {
 		components.deinit(main.globalAllocator);
 	}
 
-	pub fn get(entityId: u32) ?Component {
-		return (components.get(@enumFromInt(entityId)) orelse return null).*;
+	pub fn get(entity: Entity) ?Component {
+		return (components.get(entity) orelse return null).*;
 	}
-	pub fn getBag(entityId: u32) ?*items.Inventory.BagInventory {
-		return &(components.get(@enumFromInt(entityId)) orelse return null).bag;
+	pub fn getBag(entity: Entity) ?*items.Inventory.BagInventory {
+		return &(components.get(entity) orelse return null).bag;
 	}
-	pub fn loadFromData(entityId: u32, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
+	pub fn loadFromData(entity: Entity, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
 		if (version != entityComponentVersion) return error.InvalidComponentVersion;
-		const bag = &components.add(main.globalAllocator, @enumFromInt(entityId)).bag;
+		const bag = &components.add(main.globalAllocator, entity).bag;
 		bag.* = .init(main.globalAllocator, playerBagSizeLimit);
 		bag.fromBytes(reader) catch return error.UnreadableComponentData;
 	}
-	pub fn loadEmpty(entityId: u32) void {
-		const bag = &components.add(main.globalAllocator, @enumFromInt(entityId)).bag;
+	pub fn loadEmpty(entity: Entity) void {
+		const bag = &components.add(main.globalAllocator, entity).bag;
 		bag.* = .init(main.globalAllocator, playerBagSizeLimit);
 	}
-	pub fn unload(entityId: u32) void {
-		const bag = components.fetchRemove(@enumFromInt(entityId)) catch return;
+	pub fn unload(entity: Entity) void {
+		const bag = components.fetchRemove(entity) catch return;
 		bag.bag.deinit();
 	}
 };

--- a/src/entityComponent/model.zig
+++ b/src/entityComponent/model.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const main = @import("main");
 const chunk = main.chunk;
+const Entity = main.entity.Entity;
 const game = main.game;
 const graphics = main.graphics;
 const ZonElement = main.ZonElement;
@@ -27,7 +28,7 @@ pub const client = struct {
 	const Component = struct {
 		entityModel: main.entityModel.EntityModelIndex,
 	};
-	pub var components: main.utils.SparseSet(Component, main.entity.Entity) = .{};
+	pub var components: main.utils.SparseSet(Component, Entity) = .{};
 
 	pub fn init() void {}
 	pub fn deinit() void {
@@ -36,21 +37,21 @@ pub const client = struct {
 	pub fn clear() void {
 		components.clear();
 	}
-	pub fn load(entity: u32, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
+	pub fn load(entity: Entity, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
 		if (version != 0) return error.InvalidComponentVersion;
 
 		const entityModel = reader.readVarInt(u32) catch return error.UnreadableComponentData;
 
-		const ptr = components.get(@enumFromInt(entity)) orelse components.add(main.globalAllocator, @enumFromInt(entity));
+		const ptr = components.get(entity) orelse components.add(main.globalAllocator, entity);
 		ptr.* = Component{
 			.entityModel = .{.index = entityModel},
 		};
 	}
-	pub fn unload(entity: u32) void {
-		components.remove(@enumFromInt(entity)) catch {};
+	pub fn unload(entity: Entity) void {
+		components.remove(entity) catch {};
 	}
-	pub fn get(entity: u32) ?*Component {
-		return components.get(@enumFromInt(entity));
+	pub fn get(entity: Entity) ?*Component {
+		return components.get(entity);
 	}
 };
 
@@ -65,14 +66,14 @@ pub const server = struct {
 			return .save;
 		}
 	};
-	var components: main.utils.SparseSet(Component, main.entity.Entity) = undefined;
+	var components: main.utils.SparseSet(Component, Entity) = undefined;
 	pub fn init() void {
 		components = .{};
 	}
 	pub fn deinit() void {
 		components.deinit(main.globalAllocator);
 	}
-	pub fn loadFromData(entity: u32, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
+	pub fn loadFromData(entity: Entity, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
 		if (version != 0) return error.InvalidComponentVersion;
 		const entityModel = reader.readVarInt(u32) catch return error.UnreadableComponentData;
 
@@ -80,15 +81,15 @@ pub const server = struct {
 			.entityModel = .{.index = entityModel},
 		});
 	}
-	pub fn unload(entity: u32) void {
-		components.remove(@enumFromInt(entity)) catch {};
+	pub fn unload(entity: Entity) void {
+		components.remove(entity) catch {};
 	}
-	pub fn put(entity: u32, renderComponent: Component) void {
-		const ptr = components.get(@enumFromInt(entity)) orelse components.add(main.globalAllocator, @enumFromInt(entity));
+	pub fn put(entity: Entity, renderComponent: Component) void {
+		const ptr = components.get(entity) orelse components.add(main.globalAllocator, entity);
 		ptr.* = renderComponent;
 		main.entity.server.transmitChange(Self, entity);
 	}
-	pub fn get(entity: u32) ?*const Component {
-		return components.get(@enumFromInt(entity));
+	pub fn get(entity: Entity) ?*const Component {
+		return components.get(entity);
 	}
 };

--- a/src/entityComponent/player.zig
+++ b/src/entityComponent/player.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const main = @import("main");
 const chunk = main.chunk;
+const Entity = main.entity.Entity;
 const game = main.game;
 const graphics = main.graphics;
 const c = graphics.c;
@@ -26,7 +27,7 @@ pub const client = struct {
 	const Component = struct {
 		playerIndex: u32,
 	};
-	pub var components: main.utils.SparseSet(Component, main.entity.Entity) = .{};
+	pub var components: main.utils.SparseSet(Component, Entity) = .{};
 
 	pub fn init() void {}
 	pub fn deinit() void {
@@ -35,20 +36,20 @@ pub const client = struct {
 	pub fn clear() void {
 		components.clear();
 	}
-	pub fn load(entity: u32, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
+	pub fn load(entity: Entity, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
 		if (version != 0) return error.InvalidComponentVersion;
 		const playerIndex = reader.readVarInt(u32) catch return error.UnreadableComponentData;
 
-		const ptr = components.get(@enumFromInt(entity)) orelse components.add(main.globalAllocator, @enumFromInt(entity));
+		const ptr = components.get(entity) orelse components.add(main.globalAllocator, entity);
 		ptr.* = Component{
 			.playerIndex = playerIndex,
 		};
 	}
-	pub fn unload(entity: u32) void {
-		components.remove(@enumFromInt(entity)) catch {};
+	pub fn unload(entity: Entity) void {
+		components.remove(entity) catch {};
 	}
-	pub fn get(entity: u32) ?*Component {
-		return components.get(@enumFromInt(entity));
+	pub fn get(entity: Entity) ?*Component {
+		return components.get(entity);
 	}
 };
 
@@ -63,32 +64,32 @@ pub const server = struct {
 			return .save;
 		}
 	};
-	var components: main.utils.SparseSet(Component, main.entity.Entity) = undefined;
+	var components: main.utils.SparseSet(Component, Entity) = undefined;
 	pub fn init() void {
 		components = .{};
 	}
 	pub fn deinit() void {
 		components.deinit(main.globalAllocator);
 	}
-	pub fn loadFromData(entity: u32, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
+	pub fn loadFromData(entity: Entity, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
 		if (version != 0) return error.InvalidComponentVersion;
 		const playerIndex = reader.readVarInt(u32) catch return error.UnreadableComponentData;
 
 		load(entity, playerIndex);
 	}
-	pub fn load(entity: u32, playerIndex: u32) void {
+	pub fn load(entity: Entity, playerIndex: u32) void {
 		put(entity, Component{
 			.playerIndex = playerIndex,
 		});
 	}
-	pub fn unload(entity: u32) void {
-		components.remove(@enumFromInt(entity)) catch {};
+	pub fn unload(entity: Entity) void {
+		components.remove(entity) catch {};
 	}
-	pub fn put(entity: u32, renderComponent: Component) void {
-		const ptr = components.get(@enumFromInt(entity)) orelse components.add(main.globalAllocator, @enumFromInt(entity));
+	pub fn put(entity: Entity, renderComponent: Component) void {
+		const ptr = components.get(entity) orelse components.add(main.globalAllocator, entity);
 		ptr.* = renderComponent;
 	}
-	pub fn get(entity: u32) ?*Component {
-		return components.get(@enumFromInt(entity));
+	pub fn get(entity: Entity) ?*Component {
+		return components.get(entity);
 	}
 };

--- a/src/entitySystem/modelRenderer.zig
+++ b/src/entitySystem/modelRenderer.zig
@@ -116,10 +116,10 @@ pub const client = struct {
 		c.glUniform1f(uniforms.contrast, 0.12);
 
 		for (entity.components.@"cubyz:model".client.components.dense.items, entity.components.@"cubyz:model".client.components.denseToSparseIndex.items) |component, id| {
-			if (@intFromEnum(id) == game.Player.id) continue; // don't render local player
+			if (id == game.Player.id) continue; // don't render local player
 
 			const entModel = component.entityModel.get();
-			const ent = main.client.entity_manager.getEntity(@intFromEnum(id)) orelse continue;
+			const ent = main.client.entity_manager.getEntity(id) orelse continue;
 
 			entModel.bind();
 			const entTexture = entModel.defaultTexture;

--- a/src/game.zig
+++ b/src/game.zig
@@ -81,7 +81,7 @@ pub const Player = struct { // MARK: Player
 	pub var super: main.server.Entity = .{};
 	pub var eye: EyeData = .{};
 	pub var crouching: bool = false;
-	pub var id: u32 = 0;
+	pub var id: main.entity.Entity = .noValue;
 	pub var gamemode: Atomic(Gamemode) = .init(.creative);
 	pub var isFlying: Atomic(bool) = .init(false);
 	pub var isGhost: Atomic(bool) = .init(false);
@@ -364,7 +364,7 @@ pub const World = struct { // MARK: World
 		const path = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/serverAssets", .{main.files.cubyzDirStr()}) catch unreachable;
 		defer main.stackAllocator.free(path);
 		try assets.loadWorldAssets(path, self.blockPalette, self.itemPalette, self.proceduralItemPalette, self.biomePalette, self.entityModelPalette, self.entityComponentPalette);
-		Player.id = zon.get(u32, "player_id", std.math.maxInt(u32));
+		Player.id = @enumFromInt(zon.get(u32, "player_id", @intFromEnum(main.entity.Entity.noValue)));
 		Player.inventory = ClientInventory.init(main.globalAllocator, Player.inventorySize, .serverShared, .{.playerInventory = Player.id}, .{});
 		self.playerBiome = .init(main.server.terrain.biomes.getPlaceholderBiome());
 		main.audio.setMusic(self.playerBiome.raw.preferredMusic);

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -183,7 +183,7 @@ pub const handShake = struct { // MARK: handShake
 		const zonObject = ZonElement.initObject(main.stackAllocator);
 		defer zonObject.deinit(main.stackAllocator);
 		zonObject.put("player", conn.user.?.player().save(main.stackAllocator, .playerHimself));
-		zonObject.put("player_id", conn.user.?.id);
+		zonObject.put("player_id", @intFromEnum(conn.user.?.id));
 		zonObject.put("blockPalette", main.server.world.?.blockPalette.storeToZon(main.stackAllocator));
 		zonObject.put("itemPalette", main.server.world.?.itemPalette.storeToZon(main.stackAllocator));
 		zonObject.put("toolPalette", main.server.world.?.proceduralItemPalette.storeToZon(main.stackAllocator));
@@ -405,7 +405,7 @@ pub const entityPosition = struct { // MARK: entityPosition
 								.f32VelocityEntity => @floatCast(try reader.readVec(@Vector(3, f32))),
 								else => unreachable,
 							},
-							.id = try reader.readInt(u32),
+							.id = try reader.readEnum(main.entity.Entity),
 							.pos = playerPos + try reader.readVec(Vec3f),
 							.rot = try reader.readVec(Vec3f),
 						});
@@ -445,7 +445,7 @@ pub const entityPosition = struct { // MARK: entityPosition
 				writer.writeEnum(Type, .f16VelocityEntity);
 				writer.writeVec(@Vector(3, f16), @floatCast(data.vel));
 			}
-			writer.writeInt(u32, data.id);
+			writer.writeEnum(main.entity.Entity, data.id);
 			writer.writeVec(Vec3f, @floatCast(data.pos - playerPos));
 			writer.writeVec(Vec3f, data.rot);
 		}
@@ -504,7 +504,7 @@ pub const entity = struct { // MARK: entity
 			const elem = zonArray.array.items[i];
 			switch (elem) {
 				.int => {
-					main.client.entity_manager.removeEntity(elem.as(u32, 0));
+					main.client.entity_manager.removeEntity(@enumFromInt(elem.as(u32, 0)));
 				},
 				.object => {
 					try main.client.entity_manager.addEntity(elem);
@@ -1009,7 +1009,7 @@ pub const EntityComponentUpdate = struct { // MARK: EntityComponentUpdate
 	};
 
 	fn clientReceive(_: *Connection, reader: *utils.BinaryReader) !void {
-		const entityId = try reader.readVarInt(u32);
+		const entityId: main.entity.Entity = @enumFromInt(try reader.readVarInt(u32));
 		const componentId = try reader.readVarInt(u32);
 		const actionType: ActionType = try reader.readEnum(ActionType);
 
@@ -1020,21 +1020,21 @@ pub const EntityComponentUpdate = struct { // MARK: EntityComponentUpdate
 			try main.entity.unloadComponent(.client, componentId, entityId);
 		}
 	}
-	pub fn unload(conn: *Connection, entityId: u32, componentId: u32) void {
+	pub fn unload(conn: *Connection, entityId: main.entity.Entity, componentId: u32) void {
 		var writer = utils.BinaryWriter.init(main.stackAllocator);
 		defer writer.deinit();
 
-		writer.writeVarInt(u32, entityId);
+		writer.writeVarInt(u32, @intFromEnum(entityId));
 		writer.writeVarInt(u32, componentId);
 		writer.writeEnum(ActionType, ActionType.unload);
 
 		conn.send(.secure, id, writer.data.items);
 	}
-	pub fn load(conn: *Connection, entityId: u32, componentId: u32, version: u32, componentData: []const u8) void {
+	pub fn load(conn: *Connection, entityId: main.entity.Entity, componentId: u32, version: u32, componentData: []const u8) void {
 		var writer = utils.BinaryWriter.init(main.stackAllocator);
 		defer writer.deinit();
 
-		writer.writeVarInt(u32, entityId);
+		writer.writeVarInt(u32, @intFromEnum(entityId));
 		writer.writeVarInt(u32, componentId);
 		writer.writeEnum(ActionType, ActionType.load);
 		// specific to `load`

--- a/src/server/Entity.zig
+++ b/src/server/Entity.zig
@@ -16,9 +16,9 @@ maxHealth: f32 = 8,
 energy: f32 = 8,
 maxEnergy: f32 = 8,
 name: ?[]const u8 = null,
-id: u32 = 0,
+id: main.entity.Entity = .noValue,
 
-pub fn loadFrom(self: *@This(), id: u32, zon: ZonElement, comptime side: main.sync.Side) !void {
+pub fn loadFrom(self: *@This(), id: main.entity.Entity, zon: ZonElement, comptime side: main.sync.Side) !void {
 	self.id = id;
 	self.pos = zon.get(Vec3d, "position", .{0, 0, 0});
 	self.vel = zon.get(Vec3d, "velocity", .{0, 0, 0});
@@ -51,7 +51,7 @@ pub fn save(self: *const @This(), allocator: NeverFailingAllocator, audience: ma
 	zon.put("rotation", self.rot);
 	zon.put("health", self.health);
 	zon.put("energy", self.energy);
-	zon.put("id", self.id);
+	zon.put("id", @intFromEnum(self.id));
 
 	var base64 = main.entity.server.componentsToBase64(allocator, self.id, audience);
 	defer base64.deinit(allocator);

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -111,7 +111,7 @@ pub const User = struct { // MARK: User
 	clientUpdatePos: Vec3i = .{0, 0, 0},
 	receivedFirstEntityData: bool = false,
 	isLocal: bool = false,
-	id: u32 = 0, // TODO: Use entity id.
+	id: main.entity.Entity = .noValue,
 	// TODO: ipPort: []const u8,
 	loadedChunks: [simulationSize][simulationSize][simulationSize]*SimulationChunk = undefined,
 	lastRenderDistance: u16 = 0,
@@ -247,9 +247,9 @@ pub const User = struct { // MARK: User
 		}
 	}
 
-	var freeId: u32 = 0;
+	var freeId: u32 = 0; // TODO: Use id provided by the ECS.
 	pub fn initPlayer(self: *User) void {
-		self.id = freeId;
+		self.id = @enumFromInt(freeId);
 		freeId += 1;
 
 		world.?.loadPlayer(self) catch {
@@ -748,7 +748,7 @@ pub fn removePlayer(user: *User) void { // MARK: removePlayer()
 	// Let the other clients know about that this new one left.
 	const zonArray = main.ZonElement.initArray(main.stackAllocator);
 	defer zonArray.deinit(main.stackAllocator);
-	zonArray.array.append(.{.int = user.id});
+	zonArray.array.append(.{.int = @intFromEnum(user.id)});
 	const data = zonArray.toStringEfficient(main.stackAllocator, &.{});
 	defer main.stackAllocator.free(data);
 	const userList = getUserListAndIncreaseRefCount(main.stackAllocator);

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -205,12 +205,12 @@ pub const server = struct { // MARK: server
 	}
 };
 
-pub fn addHealth(health: f32, cause: main.game.DamageType, side: Side, userId: u32) void {
+pub fn addHealth(health: f32, cause: main.game.DamageType, side: Side, entity: main.entity.Entity) void {
 	threadContext.assertCorrectContext(side);
 	if (side == .client) {
-		client.executeCommand(.{.addHealth = .{.target = userId, .health = health, .cause = cause}});
+		client.executeCommand(.{.addHealth = .{.target = entity, .health = health, .cause = cause}});
 	} else {
-		server.executeCommand(.{.addHealth = .{.target = userId, .health = health, .cause = cause}}, null);
+		server.executeCommand(.{.addHealth = .{.target = entity, .health = health, .cause = cause}}, null);
 	}
 }
 
@@ -876,13 +876,13 @@ pub const Command = struct { // MARK: Command
 			writer.writeEnum(Inventory.SourceType, self.source);
 			switch (self.source) {
 				.playerInventory, .hand => |val| {
-					writer.writeInt(u32, val);
+					writer.writeEnum(main.entity.Entity, val);
 				},
 				.blockInventory => |val| {
 					writer.writeVec(Vec3i, val);
 				},
 				.workbench => |val| {
-					writer.writeInt(u32, val.playerId);
+					writer.writeEnum(main.entity.Entity, val.playerId);
 					writer.writeEnum(main.items.ProceduralItemTypeIndex, val.proceduralItemIndex);
 				},
 				.other => {},
@@ -896,10 +896,10 @@ pub const Command = struct { // MARK: Command
 			const len = try reader.readInt(u64);
 			const sourceType = try reader.readEnum(Inventory.SourceType);
 			const source: Inventory.Source = switch (sourceType) {
-				.playerInventory => .{.playerInventory = try reader.readInt(u32)},
-				.hand => .{.hand = try reader.readInt(u32)},
+				.playerInventory => .{.playerInventory = try reader.readEnum(main.entity.Entity)},
+				.hand => .{.hand = try reader.readEnum(main.entity.Entity)},
 				.blockInventory => .{.blockInventory = try reader.readVec(Vec3i)},
-				.workbench => .{.workbench = .{.playerId = try reader.readInt(u32), .proceduralItemIndex = try reader.readEnum(main.items.ProceduralItemTypeIndex)}},
+				.workbench => .{.workbench = .{.playerId = try reader.readEnum(main.entity.Entity), .proceduralItemIndex = try reader.readEnum(main.items.ProceduralItemTypeIndex)}},
 				.other => .{.other = {}},
 				.alreadyFreed => return error.Invalid,
 			};
@@ -1691,7 +1691,7 @@ pub const Command = struct { // MARK: Command
 	};
 
 	const AddHealth = struct { // MARK: AddHealth
-		target: u32,
+		target: main.entity.Entity,
 		health: f32,
 		cause: main.game.DamageType,
 
@@ -1724,14 +1724,14 @@ pub const Command = struct { // MARK: Command
 		}
 
 		fn serialize(self: AddHealth, writer: *BinaryWriter) void {
-			writer.writeInt(u32, self.target);
+			writer.writeEnum(main.entity.Entity, self.target);
 			writer.writeInt(u32, @bitCast(self.health));
 			writer.writeEnum(main.game.DamageType, self.cause);
 		}
 
 		fn deserialize(reader: *BinaryReader, _: Side, user: ?*main.server.User) !AddHealth {
 			const result: AddHealth = .{
-				.target = try reader.readInt(u32),
+				.target = try reader.readEnum(main.entity.Entity),
 				.health = @bitCast(try reader.readInt(u32)),
 				.cause = try reader.readEnum(main.game.DamageType),
 			};


### PR DESCRIPTION
This has bothered me for a while, and this has lead to using `0` instead of `.noValue` for initialization (and the same mistake is present on the client side), so it is at least partly responsible for #3179 which is why I decided to fix it now despite possibly causing more conflicts with future ECS PRs.

This also incorporates the important change from #3182