### PR TITLE
remove .{} for lists forever

### DIFF
--- a/src/server/command/worldedit/deselect.zig
+++ b/src/server/command/worldedit/deselect.zig
@@ -13,7 +13,7 @@ const Args = union(enum) {
 const ArgParser = main.argparse.Parser(Args, .{.commandName = "/deselect"});
 
 pub fn execute(args: []const u8, source: *User) void {
-	var errorMessage: main.List(u8) = .{};
+	var errorMessage: main.List(u8) = .empty;
 	defer errorMessage.deinit(main.stackAllocator);
 
 	_ = ArgParser.parse(main.stackAllocator, args, &errorMessage) catch {

--- a/src/server/command/worldedit/mask.zig
+++ b/src/server/command/worldedit/mask.zig
@@ -33,7 +33,7 @@ const Args = union(enum) {
 const ArgParser = main.argparse.Parser(Args, .{.commandName = "/mask"});
 
 pub fn execute(args: []const u8, source: *User) void {
-	var errorMessage: main.List(u8) = .{};
+	var errorMessage: main.List(u8) = .empty;
 	defer errorMessage.deinit(main.stackAllocator);
 
 	const result = ArgParser.parse(main.stackAllocator, args, &errorMessage) catch {

--- a/src/server/command/worldedit/paste.zig
+++ b/src/server/command/worldedit/paste.zig
@@ -20,7 +20,7 @@ const Args = union(enum) {
 const ArgParser = main.argparse.Parser(Args, .{.commandName = "/paste"});
 
 pub fn execute(args: []const u8, source: *User) void {
-	var errorMessage: main.List(u8) = .{};
+	var errorMessage: main.List(u8) = .empty;
 	defer errorMessage.deinit(main.stackAllocator);
 
 	const result = ArgParser.parse(main.stackAllocator, args, &errorMessage) catch {

--- a/src/utils/list.zig
+++ b/src/utils/list.zig
@@ -219,8 +219,8 @@ pub fn ListManaged(comptime T: type) type {
 
 pub fn List(comptime T: type) type {
 	return struct {
-		items: []T = &.{},
-		capacity: usize = 0,
+		items: []T,
+		capacity: usize,
 
 		pub const empty: @This() = .{
 			.items = &.{},


### PR DESCRIPTION
This can be merged when the time is right. Before merging it must be made sure that no `.{}` appeared in that time