### PR TITLE
Only deinit the player entity if there is one

### DIFF
--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -186,7 +186,9 @@ pub const User = struct { // MARK: User
 
 		self.worldEditData.deinit();
 
-		self.player().deinit(.server);
+		if (self.player().id != .noValue) {
+			self.player().deinit(.server);
+		}
 
 		self.unloadOldChunk(.{0, 0, 0}, 0);
 		self.conn.deinit();


### PR DESCRIPTION
Should fix #3179 (after #3193 it still would have been an assertion failure)