### PR TITLE
Switch draw.color to set/restore pattern

### DIFF
--- a/assets/cubyz/shaders/graphics/Text.vert
+++ b/assets/cubyz/shaders/graphics/Text.vert
@@ -11,8 +11,7 @@ layout(location = 1) uniform vec2 scene;
 layout(location = 2) uniform vec2 offset;
 layout(location = 3) uniform float ratio;
 layout(location = 4) uniform int fontEffects;
-
-layout(location = 5) uniform float alpha;
+layout(location = 5) uniform uint inColor;
 
 vec2 convert2Proportional(vec2 original, vec2 full) {
 	return vec2(original.x/full.x, original.y/full.y);
@@ -33,5 +32,6 @@ void main() {
 
 	gl_Position = vec4(position, 0, 1);
 	frag_face_pos = face_pos;
-	color = vec4(vec3((fontEffects & 0xff0000)>>16, (fontEffects & 0xff00)>>8, fontEffects & 0xff)/255.0, alpha);
+	color = vec4(vec3((fontEffects & 0xff0000)>>16, (fontEffects & 0xff00)>>8, fontEffects & 0xff)/255.0, 1.0);
+	color *= vec4((inColor & 0xff0000)>>16, (inColor & 0xff00)>>8, inColor & 0xff, inColor >> 24)/255.0;
 }

--- a/assets/cubyz/shaders/ui/button.frag
+++ b/assets/cubyz/shaders/ui/button.frag
@@ -11,6 +11,5 @@ layout(location = 4) uniform float scale;
 
 void main() {
 	frag_color = texture(image, (gl_FragCoord.xy - startCoord)/(2*scale)/textureSize(image, 0));
-	frag_color.a *= fColor.a;
-	frag_color.rgb += fColor.rgb;
+	frag_color *= fColor;
 }

--- a/src/entitySystem/modelRenderer.zig
+++ b/src/entitySystem/modelRenderer.zig
@@ -93,7 +93,8 @@ pub const client = struct {
 
 			const transparency = 38.0*std.math.log10(vec.lengthSquare(pos3d) + 1) - 80.0;
 			const alpha: u32 = @trunc(std.math.clamp(0xff - transparency, 0, 0xff));
-			graphics.draw.setColor(alpha << 24);
+			const oldColor = graphics.draw.setColor(alpha << 24 | 0xffffff);
+			defer graphics.draw.restoreColor(oldColor);
 
 			const renderedName = std.fmt.allocPrint(main.stackAllocator.allocator, "{f}", .{ent}) catch unreachable;
 			defer main.stackAllocator.free(renderedName);

--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -2047,10 +2047,14 @@ pub const CubeMapTexture = struct { // MARK: CubeMapTexture
 };
 
 pub const Color = packed struct(u32) { // MARK: Color
-	b: u8,
-	g: u8,
 	r: u8,
+	g: u8,
+	b: u8,
 	a: u8,
+
+	pub fn toArgb(self: Color) u32 {
+		return @as(u32, self.a) << 24 | @as(u32, self.r) << 16 | @as(u32, self.g) << 8 | @as(u32, self.b);
+	}
 };
 
 pub const Image = struct { // MARK: Image

--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -24,17 +24,30 @@ pub const Pipeline = pipelines.Pipeline;
 pub const vulkan = @import("graphics/vulkan.zig");
 
 pub const draw = struct { // MARK: draw
-	var color: u32 = 0;
+	var color: Vec4f = @splat(1);
 	var clip: ?Vec4i = null;
 	var translation: Vec2f = Vec2f{0, 0};
 	var scale: f32 = 1;
 
-	pub fn setColor(newColor: u32) void {
-		color = newColor;
+	pub fn setColor(newColorRgba: u32) Vec4f {
+		const newColor: Color = @bitCast(newColorRgba);
+		const oldColor = color;
+		color[0] *= @as(f32, @floatFromInt(newColor.r))/255.0;
+		color[1] *= @as(f32, @floatFromInt(newColor.g))/255.0;
+		color[2] *= @as(f32, @floatFromInt(newColor.b))/255.0;
+		color[3] *= @as(f32, @floatFromInt(newColor.a))/255.0;
+		return oldColor;
 	}
-
-	pub fn setColorSameAlpha(newColor: u24) void {
-		color = (color & 0xff000000) | newColor;
+	pub fn restoreColor(oldColor: Vec4f) void {
+		color = oldColor;
+	}
+	pub fn getColor() Color {
+		return .{
+			.r = @round(color[0]*255.0),
+			.g = @round(color[1]*255.0),
+			.b = @round(color[2]*255.0),
+			.a = @round(color[3]*255.0),
+		};
 	}
 
 	/// Returns the previous translation.
@@ -177,7 +190,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(rectUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
 		c.glUniform2f(rectUniforms.start, pos[0], pos[1]);
 		c.glUniform2f(rectUniforms.size, dim[0], dim[1]);
-		c.glUniform1i(rectUniforms.rectColor, @bitCast(color));
+		c.glUniform1i(rectUniforms.rectColor, @bitCast(getColor()));
 
 		rectVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
@@ -255,7 +268,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(rectBorderUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
 		c.glUniform2f(rectBorderUniforms.start, pos[0], pos[1]);
 		c.glUniform2f(rectBorderUniforms.size, dim[0], dim[1]);
-		c.glUniform1i(rectBorderUniforms.rectColor, @bitCast(color));
+		c.glUniform1i(rectBorderUniforms.rectColor, @bitCast(getColor()));
 		c.glUniform1f(rectBorderUniforms.lineWidth, width);
 
 		rectBorderVao.bind();
@@ -313,7 +326,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(lineUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
 		c.glUniform2f(lineUniforms.start, pos1[0], pos1[1]);
 		c.glUniform2f(lineUniforms.direction, pos2[0] - pos1[0], pos2[1] - pos1[1]);
-		c.glUniform1i(lineUniforms.lineColor, @bitCast(color));
+		c.glUniform1i(lineUniforms.lineColor, @bitCast(getColor()));
 
 		lineVao.bind();
 		c.glDrawArrays(c.GL_LINE_STRIP, 0, 2);
@@ -333,7 +346,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(lineUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
 		c.glUniform2f(lineUniforms.start, pos[0], pos[1]); // Move the coordinates, so they are in the center of a pixel.
 		c.glUniform2f(lineUniforms.direction, dim[0] - 1, dim[1] - 1); // The height is a lot smaller because the inner edge of the rect is drawn.
-		c.glUniform1i(lineUniforms.lineColor, @bitCast(color));
+		c.glUniform1i(lineUniforms.lineColor, @bitCast(getColor()));
 
 		lineVao.bind();
 		c.glDrawArrays(c.GL_LINE_LOOP, 0, 5);
@@ -390,7 +403,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(circleUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
 		c.glUniform2f(circleUniforms.center, center[0], center[1]); // Move the coordinates, so they are in the center of a pixel.
 		c.glUniform1f(circleUniforms.radius, radius); // The height is a lot smaller because the inner edge of the rect is drawn.
-		c.glUniform1i(circleUniforms.circleColor, @bitCast(color));
+		c.glUniform1i(circleUniforms.circleColor, @bitCast(getColor()));
 
 		circleVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
@@ -449,7 +462,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(imageUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
 		c.glUniform2f(imageUniforms.start, pos[0], pos[1]);
 		c.glUniform2f(imageUniforms.size, dim[0], dim[1]);
-		c.glUniform1i(imageUniforms.color, @bitCast(color));
+		c.glUniform1i(imageUniforms.color, @bitCast(getColor()));
 		c.glUniform2f(imageUniforms.uvOffset, uvOffset[0], 1 - uvOffset[1] - uvDim[1]);
 		c.glUniform2f(imageUniforms.uvDim, uvDim[0], uvDim[1]);
 
@@ -471,7 +484,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(uniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
 		c.glUniform2f(uniforms.start, pos[0], pos[1]);
 		c.glUniform2f(uniforms.size, dim[0], dim[1]);
-		c.glUniform1i(uniforms.color, @bitCast(color));
+		c.glUniform1i(uniforms.color, @bitCast(getColor()));
 		c.glUniform2f(uniforms.uvOffset, 0, 0);
 		c.glUniform2f(uniforms.uvDim, 1, 1);
 
@@ -496,7 +509,7 @@ pub const draw = struct { // MARK: draw
 		c.glUniform2f(uniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
 		c.glUniform2f(uniforms.start, pos[0], pos[1]);
 		c.glUniform2f(uniforms.size, dim[0], dim[1]);
-		c.glUniform1i(uniforms.color, @bitCast(color));
+		c.glUniform1i(uniforms.color, @bitCast(getColor()));
 		c.glUniform1f(uniforms.scale, scale);
 
 		rectVao.bind();
@@ -507,7 +520,7 @@ pub const draw = struct { // MARK: draw
 	// MARK: text()
 
 	pub fn text(_text: []const u8, x: f32, y: f32, fontSize: f32, alignment: TextBuffer.Alignment) void {
-		TextRendering.renderText(_text, x, y, fontSize, .{.color = @truncate(@as(u32, @bitCast(color)))}, alignment);
+		TextRendering.renderText(_text, x, y, fontSize, .{}, alignment);
 	}
 
 	pub inline fn print(comptime format: []const u8, args: anytype, x: f32, y: f32, fontSize: f32, alignment: TextBuffer.Alignment) void {
@@ -969,7 +982,7 @@ pub const TextBuffer = struct { // MARK: TextBuffer
 		c.glGetIntegerv(c.GL_VIEWPORT, &viewport);
 		c.glUniform2f(TextRendering.uniforms.scene, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
 		c.glUniform1f(TextRendering.uniforms.ratio, draw.scale);
-		c.glUniform1f(TextRendering.uniforms.alpha, @as(f32, @floatFromInt(draw.color >> 24))/255.0);
+		c.glUniform1ui(TextRendering.uniforms.inColor, @bitCast(draw.getColor()));
 		c.glActiveTexture(c.GL_TEXTURE0);
 		c.glBindTexture(c.GL_TEXTURE_2D, TextRendering.glyphTexture[0]);
 		draw.rectVao.bind();
@@ -995,9 +1008,8 @@ pub const TextBuffer = struct { // MARK: TextBuffer
 			var line: Line = _line;
 			y = 0;
 			y += if (line.isUnderline) 15 else 8;
-			const oldColor = draw.color;
-			draw.setColor(line.color | (@as(u32, 0xff000000) & draw.color));
-			defer draw.setColor(oldColor);
+			const oldColor = draw.setColor(line.color | (@as(u32, 0xff000000)));
+			defer draw.restoreColor(oldColor);
 			for (lineWraps, 0..) |lineWrap, j| {
 				const lineStart = @max(0, line.start);
 				const lineEnd = @min(lineWrap, line.end);
@@ -1037,7 +1049,7 @@ pub const TextBuffer = struct { // MARK: TextBuffer
 		c.glGetIntegerv(c.GL_VIEWPORT, &viewport);
 		c.glUniform2f(TextRendering.uniforms.scene, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
 		c.glUniform1f(TextRendering.uniforms.ratio, draw.scale);
-		c.glUniform1f(TextRendering.uniforms.alpha, @as(f32, @floatFromInt(draw.color >> 24))/255.0);
+		c.glUniform1ui(TextRendering.uniforms.inColor, @bitCast(draw.getColor()));
 		c.glActiveTexture(c.GL_TEXTURE0);
 		c.glBindTexture(c.GL_TEXTURE_2D, TextRendering.glyphTexture[0]);
 		draw.rectVao.bind();
@@ -1065,9 +1077,8 @@ pub const TextBuffer = struct { // MARK: TextBuffer
 			var line: Line = _line;
 			y = 0;
 			y += if (line.isUnderline) 15 else 8;
-			const oldColor = draw.color;
-			draw.setColor(shadowColor(line.color) | (@as(u32, 0xff000000) & draw.color));
-			defer draw.setColor(oldColor);
+			const oldColor = draw.setColor(shadowColor(line.color) | (@as(u32, 0xff000000)));
+			defer draw.restoreColor(oldColor);
 			for (lineWraps, 0..) |lineWrap, j| {
 				const lineStart = @max(0, line.start);
 				const lineEnd = @min(lineWrap, line.end);
@@ -1099,8 +1110,8 @@ const TextRendering = struct { // MARK: TextRendering
 		offset: c_int,
 		ratio: c_int,
 		fontEffects: c_int,
+		inColor: c_int,
 		fontSize: c_int,
-		alpha: c_int,
 	} = undefined;
 
 	var freetypeLib: c.FT_Library = undefined;
@@ -1136,7 +1147,6 @@ const TextRendering = struct { // MARK: TextRendering
 		);
 		pipeline.bind(null);
 		errdefer pipeline.deinit();
-		c.glUniform1f(uniforms.alpha, 1.0);
 		c.glUniform2f(uniforms.fontSize, @floatFromInt(textureWidth), @floatFromInt(textureHeight));
 		try ftError(c.FT_Init_FreeType(&freetypeLib));
 		try ftError(c.FT_New_Face(freetypeLib, "assets/cubyz/fonts/unscii-16-full.ttf", 0, &freetypeFace));
@@ -2036,15 +2046,11 @@ pub const CubeMapTexture = struct { // MARK: CubeMapTexture
 	}
 };
 
-pub const Color = extern struct { // MARK: Color
-	r: u8,
-	g: u8,
+pub const Color = packed struct(u32) { // MARK: Color
 	b: u8,
+	g: u8,
+	r: u8,
 	a: u8,
-
-	pub fn toARBG(self: Color) u32 {
-		return @as(u32, self.a) << 24 | @as(u32, self.r) << 16 | @as(u32, self.g) << 8 | @as(u32, self.b);
-	}
 };
 
 pub const Image = struct { // MARK: Image
@@ -2102,7 +2108,8 @@ pub const Image = struct { // MARK: Image
 			return error.FileNotFound;
 		};
 		main.stackAllocator.free(nullTerminatedPath);
-		result.imageData = allocator.dupe(Color, @as([*]Color, @ptrCast(data))[0 .. result.width*result.height]);
+		result.imageData = allocator.alloc(Color, result.width*result.height);
+		@memcpy(result.imageData, @as([*]align(1) Color, @ptrCast(data))[0 .. result.width*result.height]);
 		c.stbi_image_free(data);
 		return result;
 	}

--- a/src/gui/GuiWindow.zig
+++ b/src/gui/GuiWindow.zig
@@ -452,7 +452,8 @@ pub fn updateWindowPosition(self: *GuiWindow) void {
 }
 
 fn drawOrientationLines(self: *const GuiWindow) void {
-	draw.setColor(0x80000000);
+	const oldColor = draw.setColor(0x80000000);
+	defer draw.restoreColor(oldColor);
 	const windowSize = main.Window.getWindowSize()/@as(Vec2f, @splat(gui.scale));
 	inline for (self.relativePosition, 0..) |relPos, i| _continue: {
 		switch (relPos) {
@@ -492,7 +493,6 @@ fn drawOrientationLines(self: *const GuiWindow) void {
 }
 
 pub fn drawIcons(self: *const GuiWindow) void {
-	draw.setColor(0xffffffff);
 	var x = self.size[0]/self.scale;
 	if (self.closeable) {
 		x -= iconWidth;
@@ -509,7 +509,6 @@ pub fn render(self: *const GuiWindow, mousePosition: Vec2f) void {
 	const oldTranslation = draw.setTranslation(self.pos);
 	const oldScale = draw.setScale(self.scale);
 	if (self.hasBackground) {
-		draw.setColor(0xff000000);
 		pipeline.bind(draw.getScissor());
 		backgroundTexture.bindTo(0);
 		draw.customShadedRect(windowUniforms, .{0, 0}, self.size/@as(Vec2f, @splat(self.scale)));
@@ -521,12 +520,12 @@ pub fn render(self: *const GuiWindow, mousePosition: Vec2f) void {
 	if (self.showTitleBar or gui.reorderWindows) {
 		pipeline.bind(draw.getScissor());
 		titleTexture.bindTo(0);
-		draw.setColor(0xff000000);
 		draw.customShadedRect(windowUniforms, .{0, 0}, .{self.size[0]/self.scale, titleBarHeight});
 		self.drawIcons();
 	}
 	if (self.hasBackground or (!main.Window.grabbed and gui.reorderWindows)) {
-		draw.setColor(0xff2d2d2d);
+		const oldColor = draw.setColor(0xff2d2d2d);
+		defer draw.restoreColor(oldColor);
 		draw.rectBorder(.{-2, -2}, self.size/@as(Vec2f, @splat(self.scale)) + Vec2f{4, 4}, 2.0);
 	}
 	draw.restoreTranslation(oldTranslation);

--- a/src/gui/components/BagSlot.zig
+++ b/src/gui/components/BagSlot.zig
@@ -77,7 +77,6 @@ pub fn mainButtonReleased(self: *BagSlot, mousePosition: Vec2f) void {
 }
 
 pub fn render(self: *BagSlot, _: Vec2f) void {
-	draw.setColor(0xffffffff);
 	texture.bindTo(0);
 	draw.boundImage(self.pos, @splat(sizeWithBorder));
 
@@ -86,7 +85,8 @@ pub fn render(self: *BagSlot, _: Vec2f) void {
 		const item = self.inventory.peek(i).item;
 		if (item == .null) continue;
 		const opacity: f32 = std.math.pow(f32, 0.5, @as(f32, @floatFromInt(i)));
-		draw.setColor(0xffffff | @as(u32, @trunc(opacity*255)) << 24);
+		const oldColor = draw.setColor(0xffffff | @as(u32, @trunc(opacity*255)) << 24);
+		defer draw.restoreColor(oldColor);
 		item.render(self.pos, @splat(sizeWithBorder), border);
 	}
 
@@ -112,12 +112,12 @@ pub fn render(self: *BagSlot, _: Vec2f) void {
 		text.render(self.pos[0] + sizeWithBorder - textSize[0] - border, self.pos[1] + sizeWithBorder - textSize[1] - border, 8);
 	}
 
-	draw.setColor(0xffffffff);
 	draw.print("{}/{}", .{self.inventory.slots.items.len, self.inventory.sizeLimit}, self.pos[0], self.pos[1] + sizeWithBorder, 8, .left);
 
 	if (self.hovered) {
 		self.hovered = false;
-		draw.setColor(0x300000ff);
+		const oldColor = draw.setColor(0x300000ff);
+		defer draw.restoreColor(oldColor);
 		draw.rect(self.pos, @splat(sizeWithBorder));
 	}
 }

--- a/src/gui/components/Button.zig
+++ b/src/gui/components/Button.zig
@@ -145,18 +145,18 @@ pub fn render(self: *Button, mousePosition: Vec2f) void {
 		}
 		break :blk normalTextures;
 	};
-	draw.setColor(0xff000000);
-	textures.texture.bindTo(0);
-	pipeline.bind(draw.getScissor());
-	self.hovered = false;
-	draw.customShadedRect(buttonUniforms, self.pos + Vec2f{2, 2}, self.size - Vec2f{4, 4});
+	{
+		textures.texture.bindTo(0);
+		pipeline.bind(draw.getScissor());
+		self.hovered = false;
+		draw.customShadedRect(buttonUniforms, self.pos + Vec2f{2, 2}, self.size - Vec2f{4, 4});
+	}
 	{ // Draw the outline using the 9-slice texture.
 		const cornerSize = (textures.outlineTextureSize - Vec2f{1, 1});
 		const cornerSizeUV = (textures.outlineTextureSize - Vec2f{1, 1})/Vec2f{2, 2}/textures.outlineTextureSize;
 		const lowerTexture = (textures.outlineTextureSize - Vec2f{1, 1})/Vec2f{2, 2}/textures.outlineTextureSize;
 		const upperTexture = (textures.outlineTextureSize + Vec2f{1, 1})/Vec2f{2, 2}/textures.outlineTextureSize;
 		textures.outlineTexture.bindTo(0);
-		draw.setColor(0xffffffff);
 		// Corners:
 		graphics.draw.boundSubImage(self.pos + Vec2f{0, 0}, cornerSize, .{0, 0}, cornerSizeUV);
 		graphics.draw.boundSubImage(self.pos + Vec2f{self.size[0], 0} - Vec2f{cornerSize[0], 0}, cornerSize, .{upperTexture[0], 0}, cornerSizeUV);

--- a/src/gui/components/ContinuousSlider.zig
+++ b/src/gui/components/ContinuousSlider.zig
@@ -143,11 +143,13 @@ pub fn mainButtonReleased(self: *ContinuousSlider, _: Vec2f) void {
 pub fn render(self: *ContinuousSlider, mousePosition: Vec2f) void {
 	texture.bindTo(0);
 	Button.pipeline.bind(draw.getScissor());
-	draw.setColor(0xff000000);
 	draw.customShadedRect(Button.buttonUniforms, self.pos, self.size);
 
-	draw.setColor(0x80000000);
-	draw.rect(self.pos + self.getBarPos(), self.getBarSize());
+	{
+		const oldColor = draw.setColor(0x80000000);
+		defer draw.restoreColor(oldColor);
+		draw.rect(self.pos + self.getBarPos(), self.getBarSize());
+	}
 
 	self.label.pos = self.pos + @as(Vec2f, @splat(1.5*border));
 	self.label.render(mousePosition);

--- a/src/gui/components/DiscreteSlider.zig
+++ b/src/gui/components/DiscreteSlider.zig
@@ -155,11 +155,13 @@ pub fn mainButtonReleased(self: *DiscreteSlider, _: Vec2f) void {
 pub fn render(self: *DiscreteSlider, mousePosition: Vec2f) void {
 	texture.bindTo(0);
 	Button.pipeline.bind(draw.getScissor());
-	draw.setColor(0xff000000);
 	draw.customShadedRect(Button.buttonUniforms, self.pos, self.size);
 
-	draw.setColor(0x80000000);
-	draw.rect(self.pos + self.getBarPos(), self.getBarSize());
+	{
+		const oldColor = draw.setColor(0x80000000);
+		defer draw.restoreColor(oldColor);
+		draw.rect(self.pos + self.getBarPos(), self.getBarSize());
+	}
 
 	self.label.pos = self.pos + @as(Vec2f, @splat(1.5*border));
 	self.label.render(mousePosition);

--- a/src/gui/components/Icon.zig
+++ b/src/gui/components/Icon.zig
@@ -44,9 +44,9 @@ pub fn updateTexture(self: *Icon, newTexture: Texture) !void {
 
 pub fn render(self: *Icon, _: Vec2f) void {
 	if (self.hasShadow) {
-		draw.setColor(0xff000000);
+		const oldColor = draw.setColor(0xff000000);
+		defer draw.restoreColor(oldColor);
 		self.texture.render(self.pos + Vec2f{1, 1}, self.size);
 	}
-	draw.setColor(0xffffffff);
 	self.texture.render(self.pos, self.size);
 }

--- a/src/gui/components/ItemSlot.zig
+++ b/src/gui/components/ItemSlot.zig
@@ -131,7 +131,6 @@ pub fn mainButtonReleased(self: *ItemSlot, _: Vec2f) void {
 
 pub fn render(self: *ItemSlot, _: Vec2f) void {
 	self.refreshText();
-	draw.setColor(0xffffffff);
 	if (self.renderFrame and self.texture != null) {
 		self.texture.?.bindTo(0);
 		draw.boundImage(self.pos, self.size);
@@ -147,7 +146,8 @@ pub fn render(self: *ItemSlot, _: Vec2f) void {
 	if (self.mode != .immutable) {
 		if (self.hovered) {
 			self.hovered = false;
-			draw.setColor(0x300000ff);
+			const oldColor = draw.setColor(0x300000ff);
+			defer draw.restoreColor(oldColor);
 			draw.rect(self.pos, self.size);
 		}
 	}

--- a/src/gui/components/Label.zig
+++ b/src/gui/components/Label.zig
@@ -47,6 +47,7 @@ pub fn updateText(self: *Label, newText: []const u8) void {
 }
 
 pub fn render(self: *Label, _: Vec2f) void {
-	draw.setColor(@as(u32, @trunc(self.alpha*255)) << 24);
+	const oldColor = draw.setColor(@as(u32, @trunc(self.alpha*255)) << 24 | 0xffffff);
+	defer draw.restoreColor(oldColor);
 	self.text.render(self.pos[0], self.pos[1], fontSize);
 }

--- a/src/gui/components/ScrollBar.zig
+++ b/src/gui/components/ScrollBar.zig
@@ -99,7 +99,6 @@ pub fn mainButtonReleased(self: *ScrollBar, mousePosition: Vec2f) void {
 pub fn render(self: *ScrollBar, mousePosition: Vec2f) void {
 	texture.bindTo(0);
 	Button.pipeline.bind(draw.getScissor());
-	draw.setColor(0xff000000);
 	draw.customShadedRect(Button.buttonUniforms, self.pos, self.size);
 
 	const range: f32 = self.size[1] - self.button.size[1];

--- a/src/gui/components/TextInput.zig
+++ b/src/gui/components/TextInput.zig
@@ -516,7 +516,6 @@ fn getRenderCursorPos(self: *const TextInput, pos: u32) u32 {
 pub fn render(self: *TextInput, mousePosition: Vec2f) void {
 	texture.bindTo(0);
 	Button.pipeline.bind(draw.getScissor());
-	draw.setColor(0xff000000);
 	draw.customShadedRect(Button.buttonUniforms, self.pos, self.size);
 	const oldTranslation = draw.setTranslation(self.pos);
 	defer draw.restoreTranslation(oldTranslation);
@@ -550,7 +549,8 @@ pub fn render(self: *TextInput, mousePosition: Vec2f) void {
 		const cursorPos = textPos + textBuffer.indexToCursorPos(cursor);
 		if (self.selectionStart) |_selectionStart| {
 			const selectionStart = self.getRenderCursorPos(_selectionStart);
-			draw.setColor(0x440000ff);
+			const oldColor = draw.setColor(0x440000ff);
+			defer draw.restoreColor(oldColor);
 			textBuffer.drawSelection(textPos, @min(selectionStart, cursor), @max(selectionStart, cursor));
 		}
 
@@ -561,7 +561,8 @@ pub fn render(self: *TextInput, mousePosition: Vec2f) void {
 		}
 
 		if (self.showCusor) {
-			draw.setColor(0xff000000);
+			const oldColor = draw.setColor(0xff000000);
+			defer draw.restoreColor(oldColor);
 			const thickness = @min(@ceil(fontSize/8), 1);
 			draw.rect(cursorPos, Vec2f{thickness, fontSize});
 		}

--- a/src/gui/gamepad_cursor.zig
+++ b/src/gui/gamepad_cursor.zig
@@ -22,7 +22,6 @@ pub fn deinit() void {
 pub fn render() void {
 	if (main.Window.lastUsedMouse or main.Window.grabbed) return;
 	texture.bindTo(0);
-	graphics.draw.setColor(0xffffffff);
 	const mousePos = main.Window.getMousePosition();
 	graphics.draw.boundImage(@as(Vec2f, @splat(-size/2.0)) + (mousePos/@as(Vec2f, @splat(gui.scale))), .{size, size});
 }

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -558,7 +558,8 @@ pub fn updateAndRenderGui() void {
 	}
 	if (!hideGui) {
 		if (!main.Window.grabbed) {
-			draw.setColor(0x80000000);
+			const oldColor = draw.setColor(0x80000000);
+			defer draw.restoreColor(oldColor);
 			GuiWindow.borderPipeline.bind(draw.getScissor());
 			c.glUniform2f(GuiWindow.borderUniforms.effectLength, main.Window.getWindowSize()[0]/6, main.Window.getWindowSize()[1]/6);
 			draw.customShadedRect(GuiWindow.borderUniforms, .{0, 0}, main.Window.getWindowSize());
@@ -804,10 +805,16 @@ pub const inventory = struct { // MARK: inventory
 				}
 				pos[1] = @min(pos[1] - fontSize, windowSize[1] - size[1] - border);
 				pos = @max(pos, Vec2f{border, border});
-				draw.setColor(0xffffff00);
-				draw.rect(pos - @as(Vec2f, @splat(border)), size + @as(Vec2f, @splat(2*border)));
-				draw.setColor(0xff000000);
-				draw.rect(pos - @as(Vec2f, @splat(padding)), size + @as(Vec2f, @splat(2*padding)));
+				{
+					const oldColor = draw.setColor(0xffffff00);
+					defer draw.restoreColor(oldColor);
+					draw.rect(pos - @as(Vec2f, @splat(border)), size + @as(Vec2f, @splat(2*border)));
+				}
+				{
+					const oldColor = draw.setColor(0xff000000);
+					defer draw.restoreColor(oldColor);
+					draw.rect(pos - @as(Vec2f, @splat(padding)), size + @as(Vec2f, @splat(2*padding)));
+				}
 				textBuffer.render(pos[0], pos[1], fontSize);
 			}
 		}

--- a/src/gui/windows/chat.zig
+++ b/src/gui/windows/chat.zig
@@ -242,7 +242,8 @@ pub fn update() void {
 
 pub fn render() void {
 	if (!hideInput) {
-		main.graphics.draw.setColor(0x80000000);
+		const oldColor = main.graphics.draw.setColor(0x80000000);
+		defer main.graphics.draw.restoreColor(oldColor);
 		main.graphics.draw.rect(.{0, 0}, window.contentSize);
 	}
 }

--- a/src/gui/windows/clipboard_deleted.zig
+++ b/src/gui/windows/clipboard_deleted.zig
@@ -35,6 +35,7 @@ pub fn render() void {
 		gui.closeWindowFromRef(&window);
 		return;
 	}
-	draw.setColor(0xffff8080);
+	const oldColor = draw.setColor(0xffff8080);
+	defer draw.restoreColor(oldColor);
 	draw.print("Your clipboard was cleared.", .{}, 0, 0, 16, .left);
 }

--- a/src/gui/windows/crosshair.zig
+++ b/src/gui/windows/crosshair.zig
@@ -61,7 +61,6 @@ pub fn deinit() void {
 
 pub fn render() void {
 	texture.bindTo(0);
-	graphics.draw.setColor(0xffffffff);
 	pipeline.bind(graphics.draw.getScissor());
 	graphics.draw.customShadedImage(&uniforms, .{0, 0}, .{size, size});
 }

--- a/src/gui/windows/debug.zig
+++ b/src/gui/windows/debug.zig
@@ -28,7 +28,6 @@ pub var window = GuiWindow{
 };
 
 pub fn render() void {
-	draw.setColor(0xffffffff);
 	var y: f32 = 0;
 	const fpsCapText = if (main.settings.fpsCap) |fpsCap| std.fmt.allocPrint(main.stackAllocator.allocator, " (limit: {d:.0} Hz)", .{fpsCap}) catch unreachable else "";
 	defer main.stackAllocator.allocator.free(fpsCapText);

--- a/src/gui/windows/debug_network.zig
+++ b/src/gui/windows/debug_network.zig
@@ -24,7 +24,6 @@ pub var window = GuiWindow{
 };
 
 pub fn render() void {
-	draw.setColor(0xffffffff);
 	var y: f32 = 0;
 	if (main.game.world != null) {
 		if (main.server.world != null) {

--- a/src/gui/windows/debug_network_advanced.zig
+++ b/src/gui/windows/debug_network_advanced.zig
@@ -40,7 +40,6 @@ fn renderConnectionData(conn: *main.network.Connection, name: []const u8, y: *f3
 }
 
 pub fn render() void {
-	draw.setColor(0xffffffff);
 	var y: f32 = 0;
 	if (main.game.world != null) {
 		renderConnectionData(main.game.world.?.conn, "Client", &y);

--- a/src/gui/windows/debug_vulkan_info.zig
+++ b/src/gui/windows/debug_vulkan_info.zig
@@ -29,7 +29,6 @@ pub var window = GuiWindow{
 };
 
 pub fn render() void {
-	draw.setColor(0xffffffff);
 	var y: f32 = 0;
 	draw.print("Vulkan Version: {d}.{d}", .{vulkan.version.major, vulkan.version.minor}, 0, y, 8, .left);
 	y += 8;

--- a/src/gui/windows/energybar.zig
+++ b/src/gui/windows/energybar.zig
@@ -45,7 +45,6 @@ pub fn deinit() void {
 pub fn render() void {
 	if (main.game.Player.isCreative()) return;
 
-	draw.setColor(0xffffffff);
 	var y: f32 = 0;
 	var x: f32 = 0;
 	var energy: f32 = 0;

--- a/src/gui/windows/gpu_performance_measuring.zig
+++ b/src/gui/windows/gpu_performance_measuring.zig
@@ -96,7 +96,6 @@ pub var window = GuiWindow{
 
 pub fn render() void {
 	curBuffer +%= 1;
-	draw.setColor(0xffffffff);
 	var sum: isize = 0;
 	var y: f32 = 8;
 	inline for (0..queryObjects[curBuffer].len) |i| {

--- a/src/gui/windows/healthbar.zig
+++ b/src/gui/windows/healthbar.zig
@@ -45,7 +45,6 @@ pub fn deinit() void {
 pub fn render() void {
 	if (main.game.Player.isCreative()) return;
 
-	draw.setColor(0xffffffff);
 	const displayHealth = @max(0, main.game.Player.super.health);
 	const halfHeartUnits: usize = @ceil(displayHealth*2);
 	const wholeHearts = halfHeartUnits/2;

--- a/src/gui/windows/performance_graph.zig
+++ b/src/gui/windows/performance_graph.zig
@@ -63,15 +63,16 @@ pub fn deinit() void {
 pub fn render() void {
 	lastFrameTime[index] = @floatCast(main.lastFrameTime.load(.monotonic)*1000.0);
 	index = (index + 1)%@as(u31, @intCast(lastFrameTime.len));
-	draw.setColor(0xffffffff);
 	draw.text("32 ms", 0, 16, 8, .left);
 	draw.text("16 ms", 0, 32, 8, .left);
 	draw.text("00 ms", 0, 48, 8, .left);
-	draw.setColor(0x80ffffff);
-	draw.line(.{border, 24}, .{window.contentSize[0] - border, 24});
-	draw.line(.{border, 40}, .{window.contentSize[0] - border, 40});
-	draw.line(.{border, 56}, .{window.contentSize[0] - border, 56});
-	draw.setColor(0xffffffff);
+	{
+		const oldColor = draw.setColor(0x80ffffff);
+		defer draw.restoreColor(oldColor);
+		draw.line(.{border, 24}, .{window.contentSize[0] - border, 24});
+		draw.line(.{border, 40}, .{window.contentSize[0] - border, 40});
+		draw.line(.{border, 56}, .{window.contentSize[0] - border, 56});
+	}
 	pipeline.bind(null);
 	c.glUniform1i(uniforms.points, lastFrameTime.len);
 	c.glUniform1i(uniforms.offset, index);

--- a/src/itemdrop.zig
+++ b/src/itemdrop.zig
@@ -586,7 +586,7 @@ pub const ItemDropRenderer = struct { // MARK: ItemDropRenderer
 					while (x < img.width) : (x += 1) {
 						var y: u32 = 0;
 						while (y < img.height) : (y += 1) {
-							dataSection[i] = @bitCast(img.getRGB(x, y));
+							dataSection[i] = img.getRGB(x, y).toArgb();
 							i += 1;
 						}
 					}

--- a/src/itemdrop.zig
+++ b/src/itemdrop.zig
@@ -586,7 +586,7 @@ pub const ItemDropRenderer = struct { // MARK: ItemDropRenderer
 					while (x < img.width) : (x += 1) {
 						var y: u32 = 0;
 						while (y < img.height) : (y += 1) {
-							dataSection[i] = img.getRGB(x, y).toARBG();
+							dataSection[i] = @bitCast(img.getRGB(x, y));
 							i += 1;
 						}
 					}

--- a/src/items.zig
+++ b/src/items.zig
@@ -1061,14 +1061,20 @@ pub const Item = union(ItemType) { // MARK: Item
 
 			if (durabilityPercentage < 1) {
 				const width = durabilityPercentage*(slotSize[0] - 2*border);
-				graphics.draw.setColorSameAlpha(0x000000);
-				graphics.draw.rect(pos + Vec2f{border, 15*(slotSize[1] - border)/16.0}, .{slotSize[0] - 2*border, (slotSize[1] - 2*border)/16.0});
+				{
+					const oldColor = graphics.draw.setColor(0xff000000);
+					defer graphics.draw.restoreColor(oldColor);
+					graphics.draw.rect(pos + Vec2f{border, 15*(slotSize[1] - border)/16.0}, .{slotSize[0] - 2*border, (slotSize[1] - 2*border)/16.0});
+				}
 
 				const red = std.math.lossyCast(u8, (2 - durabilityPercentage*2)*255);
 				const green = std.math.lossyCast(u8, durabilityPercentage*2*255);
 
-				graphics.draw.setColorSameAlpha((@as(u24, @intCast(red)) << 16) | (@as(u24, @intCast(green)) << 8));
-				graphics.draw.rect(pos + Vec2f{border, 15*(slotSize[1] - border)/16.0}, .{width, (slotSize[1] - 2*border)/16.0});
+				{
+					const oldColor = graphics.draw.setColor(0xff000000 | (@as(u32, red) << 16) | (@as(u32, green) << 8));
+					defer graphics.draw.restoreColor(oldColor);
+					graphics.draw.rect(pos + Vec2f{border, 15*(slotSize[1] - border)/16.0}, .{width, (slotSize[1] - 2*border)/16.0});
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This makes color state spill less (→no draw.setColor(0xffffffff) everywhere to restore incorrect state) and allows GUI components to color their children.

Demo (VerticalList is red, HorizontalList is green):
<img width="1280" height="745" alt="Screenshot at 2026-06-12 20-29-36" src="https://github.com/user-attachments/assets/83e8049f-5768-46d0-a442-19c5df2bc8a6" />

This is required for https://github.com/PixelGuys/Cubyz/pull/3203#issuecomment-4684311051 to make the text/icon darker