### PR TITLE
Don't starve the secure network channel

### DIFF
--- a/src/network.zig
+++ b/src/network.zig
@@ -1811,15 +1811,15 @@ pub const Connection = struct { // MARK: Connection
 			const dataLen = blk: {
 				self.mutex.lock();
 				defer self.mutex.unlock();
-				for (0..3) |_| {
+				for (0..2) |_| {
 					permutation +%= 1;
-					break :blk switch (permutation%3) {
+					break :blk switch (permutation%2) {
 						0 => self.lossyChannel.sendNextPacketAndGetSize(self, timestamp, considerForCongestionControl),
 						1 => self.secureChannel.sendNextPacketAndGetSize(self, timestamp, considerForCongestionControl),
-						2 => self.slowChannel.sendNextPacketAndGetSize(self, timestamp, considerForCongestionControl),
 						else => unreachable,
 					} orelse continue;
 				}
+				if (self.slowChannel.sendNextPacketAndGetSize(self, timestamp, considerForCongestionControl)) |dataLen| break :blk dataLen;
 				break;
 			};
 			const networkLen: f32 = @floatFromInt(dataLen + headerOverhead);

--- a/src/network.zig
+++ b/src/network.zig
@@ -1804,16 +1804,22 @@ pub const Connection = struct { // MARK: Connection
 			self.sendConfirmationPacket(timestamp);
 		}
 
+		var permutation: usize = main.random.nextInt(usize, &main.seed);
 		while (timestamp -% self.nextPacketTimestamp > 0) {
 			// Only attempt to increase the congestion bandwidth if we actual use the bandwidth, to prevent unbounded growth
 			const considerForCongestionControl = @divFloor(self.relativeSendTime, 2) > self.relativeIdleTime;
 			const dataLen = blk: {
 				self.mutex.lock();
 				defer self.mutex.unlock();
-				if (self.lossyChannel.sendNextPacketAndGetSize(self, timestamp, considerForCongestionControl)) |dataLen| break :blk dataLen;
-				if (self.secureChannel.sendNextPacketAndGetSize(self, timestamp, considerForCongestionControl)) |dataLen| break :blk dataLen;
-				if (self.slowChannel.sendNextPacketAndGetSize(self, timestamp, considerForCongestionControl)) |dataLen| break :blk dataLen;
-
+				for (0..3) |_| {
+					permutation +%= 1;
+					break :blk switch (permutation%3) {
+						0 => self.lossyChannel.sendNextPacketAndGetSize(self, timestamp, considerForCongestionControl),
+						1 => self.secureChannel.sendNextPacketAndGetSize(self, timestamp, considerForCongestionControl),
+						2 => self.slowChannel.sendNextPacketAndGetSize(self, timestamp, considerForCongestionControl),
+						else => unreachable,
+					} orelse continue;
+				}
 				break;
 			};
 			const networkLen: f32 = @floatFromInt(dataLen + headerOverhead);


### PR DESCRIPTION
This was an oversight in #3211, by rejecting messages from the lossy channel (which gets priority on the sender side), it could basically stuck itself thinking it has no bandwidth and repeatedly trying to resend the item drop packets instead of sending important data.

This is fixed here by removing the priority between the two.
They are still prioritized over the slow channel, so there should be no negative impact from this.