### PR TITLE
Remove obsolete clearRecipeCachedInventories

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -317,7 +317,6 @@ pub const World = struct { // MARK: World
 		main.gui.deinit();
 		main.gui.init();
 		Player.inventory.deinit(main.globalAllocator);
-		main.items.clearRecipeCachedInventories();
 		main.sync.client.reset();
 
 		main.threadPool.clear();

--- a/src/items.zig
+++ b/src/items.zig
@@ -1353,37 +1353,13 @@ fn parseRecipeItem(zon: ZonElement) !ItemStack {
 	return result;
 }
 
-fn parseRecipe(zon: ZonElement) !Recipe {
-	const inputs = zon.getChild("inputs").toSlice();
-	const output = try parseRecipeItem(zon.getChild("output"));
-	const recipe = Recipe{
-		.sourceItems = main.worldArena.alloc(BaseItemIndex, inputs.len),
-		.sourceAmounts = main.worldArena.alloc(u16, inputs.len),
-		.resultItem = output.item.baseItem,
-		.resultAmount = output.amount,
-	};
-	for (inputs, 0..) |inputZon, i| {
-		const input = try parseRecipeItem(inputZon);
-		recipe.sourceItems[i] = input.item.baseItem;
-		recipe.sourceAmounts[i] = input.amount;
-	}
-	return recipe;
-}
-
 pub fn registerRecipes(zon: ZonElement) void {
 	for (zon.toSlice()) |recipeZon| {
-		recipes.parseRecipe(main.globalAllocator, recipeZon, &recipeList) catch |err| {
+		recipes.parseRecipe(recipeZon, &recipeList) catch |err| {
 			const recipeString = recipeZon.toString(main.stackAllocator);
 			defer main.stackAllocator.free(recipeString);
 			std.log.err("Skipping recipe with error {s}:\n{s}", .{@errorName(err), recipeString});
 			continue;
 		};
-	}
-}
-
-pub fn clearRecipeCachedInventories() void {
-	for (recipeList.items) |recipe| {
-		main.globalAllocator.free(recipe.sourceItems);
-		main.globalAllocator.free(recipe.sourceAmounts);
 	}
 }

--- a/src/items/recipes.zig
+++ b/src/items/recipes.zig
@@ -190,12 +190,12 @@ fn generateItemCombos(allocator: NeverFailingAllocator, recipe: []const ZonEleme
 	return newInputCombos;
 }
 
-pub fn addRecipe(allocator: NeverFailingAllocator, itemCombo: []const ItemWithAmount, list: *main.ListManaged(Recipe)) void {
+pub fn addRecipe(itemCombo: []const ItemWithAmount, list: *main.ListManaged(Recipe)) void {
 	const inputs = itemCombo[0 .. itemCombo.len - 1];
 	const output = itemCombo[itemCombo.len - 1];
 	const recipe = Recipe{
-		.sourceItems = allocator.alloc(BaseItemIndex, inputs.len),
-		.sourceAmounts = allocator.alloc(u16, inputs.len),
+		.sourceItems = main.worldArena.alloc(BaseItemIndex, inputs.len),
+		.sourceAmounts = main.worldArena.alloc(u16, inputs.len),
 		.resultItem = output.item,
 		.resultAmount = output.amount,
 	};
@@ -206,7 +206,7 @@ pub fn addRecipe(allocator: NeverFailingAllocator, itemCombo: []const ItemWithAm
 	list.append(recipe);
 }
 
-pub fn parseRecipe(allocator: NeverFailingAllocator, zon: ZonElement, list: *main.ListManaged(Recipe)) !void {
+pub fn parseRecipe(zon: ZonElement, list: *main.ListManaged(Recipe)) !void {
 	const arena = main.stackAllocator.createArena();
 	defer main.stackAllocator.destroyArena(arena);
 
@@ -220,9 +220,9 @@ pub fn parseRecipe(allocator: NeverFailingAllocator, zon: ZonElement, list: *mai
 
 	const itemCombos = try generateItemCombos(arena, recipeItems);
 	for (itemCombos) |itemCombo| {
-		addRecipe(allocator, itemCombo, list);
+		addRecipe(itemCombo, list);
 		if (reversible) {
-			addRecipe(allocator, &.{itemCombo[1], itemCombo[0]}, list);
+			addRecipe(&.{itemCombo[1], itemCombo[0]}, list);
 		}
 	}
 }


### PR DESCRIPTION
recipe data is now allocated with the worldArena, and a leftover duplicate of addRecipe is removed

this functions was causing problems in #3219, and this is likely relevant for #2293