### PR TITLE
Don't allow logout when the player entered text into the password field

### DIFF
--- a/src/gui/windows/authentication/unlock.zig
+++ b/src/gui/windows/authentication/unlock.zig
@@ -23,6 +23,7 @@ pub var window = GuiWindow{
 const padding: f32 = 8;
 
 var textComponent: *TextInput = undefined;
+var logoutButton: *Button = undefined;
 
 var incorrectPasswordLabel: *Label = undefined;
 
@@ -67,6 +68,14 @@ fn logout() void {
 	gui.openWindow("authentication/login");
 }
 
+fn onTextUpdate() void {
+	if (textComponent.currentString.items.len == 0) {
+		logoutButton.disabled = false;
+	} else {
+		logoutButton.disabled = true;
+	}
+}
+
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 320, 8);
 	const width = 420;
@@ -75,7 +84,7 @@ pub fn onOpen() void {
 	incorrectPasswordLabel = Label.init(.{0, 0}, width, "", .left);
 	list.add(incorrectPasswordLabel);
 	const passwordRow = HorizontalList.init();
-	textComponent = TextInput.init(.{0, 0}, width - 80, 22, "", .{.onNewline = .init(apply)});
+	textComponent = TextInput.init(.{0, 0}, width - 80, 22, "", .{.onNewline = .init(apply), .onUpdate = .init(onTextUpdate)});
 	textComponent.obfuscated = true;
 	textComponent.select();
 	passwordRow.add(textComponent);
@@ -83,7 +92,8 @@ pub fn onOpen() void {
 	passwordRow.finish(.{0, 0}, .center);
 	list.add(passwordRow);
 	const buttonRow = HorizontalList.init();
-	buttonRow.add(Button.initText(.{0, 0}, 200, "Logout", .{.onAction = .init(logout)}));
+	logoutButton = Button.initText(.{0, 0}, 200, "Logout", .{.onAction = .init(logout), .disabled = false});
+	buttonRow.add(logoutButton);
 	buttonRow.add(Button.initText(.{padding, 0}, 200, "Unlock", .{.onAction = .init(apply)}));
 	list.add(buttonRow);
 	list.finish(.center);


### PR DESCRIPTION
I could swear there was an issue with intense discussion with @Argmaster on whether to use color or size this, but I couldn't find anything. Anyways the goal is to prevent the player from misclicking the wrong button and then having to spend a few minutes to enter their accoutn code again.

While working on disabled buttons I had the idea to just disable the button once you type text. No matter what state of mind you are in or how you are conditioned by the latest cookie banner reverse psychology tech, you cannot click the wrong button if you cannot click it. (luckily the cookie banner people haven't discovered this trick yet)
<img width="1280" height="745" alt="Screenshot at 2026-06-13 15-11-22" src="https://github.com/user-attachments/assets/26ab5c85-a81d-41ae-8382-9f2f52f364df" />
The logout button is only clickable when no password is entered:
<img width="1280" height="745" alt="Screenshot at 2026-06-13 15-17-28" src="https://github.com/user-attachments/assets/a6277937-0abf-4464-b663-0b9131190d44" />

related to #3192