### PR TITLE
Distinguish between joining a world as singleplayer and hosting a world for multiplayer

### DIFF
--- a/src/gui/windows/_list.zig
+++ b/src/gui/windows/_list.zig
@@ -24,6 +24,7 @@ pub const invite = @import("invite.zig");
 pub const main = @import("main.zig");
 pub const players = @import("players.zig");
 pub const multiplayer = @import("multiplayer.zig");
+pub const multiplayer_join = @import("multiplayer_join.zig");
 pub const notification = @import("notification.zig");
 pub const pause = @import("pause.zig");
 pub const pause_gear = @import("pause_gear.zig");

--- a/src/gui/windows/main.zig
+++ b/src/gui/windows/main.zig
@@ -23,6 +23,7 @@ fn exitGame() void {
 }
 fn singleplayerSelection() void {
 	gui.windowlist.save_selection.mode = .singleplayer;
+	gui.closeWindow("save_selection");
 	gui.openWindow("save_selection");
 }
 pub fn onOpen() void {

--- a/src/gui/windows/main.zig
+++ b/src/gui/windows/main.zig
@@ -21,9 +21,13 @@ const padding: f32 = 8;
 fn exitGame() void {
 	c.glfwSetWindowShouldClose(main.Window.window, c.GLFW_TRUE);
 }
+fn singleplayerSelection() void {
+	gui.windowlist.save_selection.mode = .singleplayer;
+	gui.openWindow("save_selection");
+}
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
-	list.add(Button.initText(.{0, 0}, 128, "Singleplayer", .{.onAction = gui.openWindowCallback("save_selection")}));
+	list.add(Button.initText(.{0, 0}, 128, "Singleplayer", .{.onAction = .init(singleplayerSelection)}));
 	list.add(Button.initText(.{0, 0}, 128, "Multiplayer", .{.onAction = gui.openWindowCallback("multiplayer")}));
 	list.add(Button.initText(.{0, 0}, 128, "Settings", .{.onAction = gui.openWindowCallback("settings")}));
 	list.add(Button.initText(.{0, 0}, 128, "Touch Grass", .{.onAction = .init(exitGame)}));

--- a/src/gui/windows/multiplayer.zig
+++ b/src/gui/windows/multiplayer.zig
@@ -16,6 +16,7 @@ const padding: f32 = 8;
 
 fn multiplayerSelection() void {
 	gui.windowlist.save_selection.mode = .multiplayer;
+	gui.closeWindow("save_selection");
 	gui.openWindow("save_selection");
 }
 pub fn onOpen() void {

--- a/src/gui/windows/multiplayer.zig
+++ b/src/gui/windows/multiplayer.zig
@@ -1,140 +1,35 @@
 const std = @import("std");
 
 const main = @import("main");
-const ConnectionManager = main.network.ConnectionManager;
-const settings = main.settings;
-const Vec2f = main.vec.Vec2f;
-
-const gui = @import("../gui.zig");
+const gui = main.gui;
 const GuiComponent = gui.GuiComponent;
 const GuiWindow = gui.GuiWindow;
-const Button = @import("../components/Button.zig");
-const Label = @import("../components/Label.zig");
-const TextInput = @import("../components/TextInput.zig");
-const VerticalList = @import("../components/VerticalList.zig");
+const Button = GuiComponent.Button;
+const VerticalList = GuiComponent.VerticalList;
+const Vec2f = main.vec.Vec2f;
 
 pub var window = GuiWindow{
 	.contentSize = Vec2f{128, 256},
 };
 
-var ipAddressLabel: *Label = undefined;
-var ipAddressEntry: *TextInput = undefined;
-
 const padding: f32 = 8;
 
-var connection: ?*ConnectionManager = null;
-var ipAddress: []const u8 = "";
-var gotIpAddress: std.atomic.Value(bool) = .init(false);
-var thread: ?std.Thread = null;
-const width: f32 = 420;
-
-fn discoverIpAddress() void {
-	connection = ConnectionManager.init(main.settings.defaultPort, true) catch |err| {
-		std.log.err("Could not open Connection: {s}", .{@errorName(err)});
-		ipAddress = main.globalAllocator.dupe(u8, @errorName(err));
-		return;
-	};
-	ipAddress = std.fmt.allocPrint(main.globalAllocator.allocator, "{f}", .{connection.?.externalAddress}) catch unreachable;
-	gotIpAddress.store(true, .release);
+fn multiplayerSelection() void {
+	gui.windowlist.save_selection.mode = .multiplayer;
+	gui.openWindow("save_selection");
 }
-
-fn discoverIpAddressFromNewThread() void {
-	main.initThreadLocals();
-	defer main.deinitThreadLocals();
-
-	discoverIpAddress();
-}
-
-fn join() void {
-	if (thread) |_thread| {
-		_thread.join();
-		thread = null;
-	}
-	if (ipAddress.len != 0) {
-		main.globalAllocator.free(ipAddress);
-		ipAddress = "";
-	}
-	if (connection) |_connection| {
-		_connection.world = &main.game.testWorld;
-		main.game.world = &main.game.testWorld;
-		std.log.info("Connecting to server: {s}", .{ipAddressEntry.currentString.items});
-		main.game.testWorld.init(ipAddressEntry.currentString.items, _connection) catch |err| {
-			std.log.err("Encountered error while opening world: {s}", .{@errorName(err)});
-			main.gui.windowlist.notification.raiseNotification("Encountered error while opening world: {s}", .{@errorName(err)});
-			main.game.world = null;
-			_connection.world = null;
-			return;
-		};
-		main.globalAllocator.free(settings.lastUsedIPAddress);
-		settings.lastUsedIPAddress = main.globalAllocator.dupe(u8, ipAddressEntry.currentString.items);
-		settings.save();
-		connection = null;
-	} else {
-		std.log.err("No connection found. Cannot connect.", .{});
-		main.gui.windowlist.notification.raiseNotification("No connection found. Cannot connect.", .{});
-	}
-	for (gui.openWindows.items) |openWindow| {
-		gui.closeWindowFromRef(openWindow);
-	}
-	gui.openHud();
-}
-
-fn copyIp() void {
-	main.Window.setClipboardString(ipAddress);
-}
-
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
-	list.add(Label.init(.{0, 0}, width, "Please send your IP to the host of the game and enter the host's IP below.", .center));
-	//                                               255.255.255.255:?65536 (longest possible ip address)
-	ipAddressLabel = Label.init(.{0, 0}, width, "                      ", .center);
-	list.add(ipAddressLabel);
-	list.add(Button.initText(.{0, 0}, 100, "Copy IP", .{.onAction = .init(copyIp)}));
-	ipAddressEntry = TextInput.init(.{0, 0}, width, 32, settings.lastUsedIPAddress, .{.onNewline = .init(join)});
-	ipAddressEntry.obfuscated = main.settings.streamerMode;
-	list.add(ipAddressEntry);
-	list.add(Button.initText(.{0, 0}, 100, "Join", .{.onAction = .init(join)}));
+	list.add(Button.initText(.{0, 0}, 128, "Host World", .{.onAction = .init(multiplayerSelection)}));
+	list.add(Button.initText(.{0, 0}, 128, "Join Server", .{.onAction = gui.openWindowCallback("multiplayer_join")}));
 	list.finish(.center);
 	window.rootComponent = list.toComponent();
 	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));
 	gui.updateWindowPositions();
-
-	thread = std.Thread.spawn(.{}, discoverIpAddressFromNewThread, .{}) catch |err| blk: {
-		std.log.err("Error spawning thread: {s}. Doing it in the current thread instead.", .{@errorName(err)});
-		discoverIpAddress();
-		break :blk null;
-	};
 }
 
 pub fn onClose() void {
-	if (thread) |_thread| {
-		_thread.join();
-		thread = null;
-	}
-	if (connection) |_connection| {
-		_connection.deinit();
-		connection = null;
-	}
-	if (ipAddress.len != 0) {
-		main.globalAllocator.free(ipAddress);
-		ipAddress = "";
-	}
-
 	if (window.rootComponent) |*comp| {
 		comp.deinit();
-	}
-}
-
-pub fn update() void {
-	if (gotIpAddress.load(.acquire)) {
-		gotIpAddress.store(false, .monotonic);
-
-		if (main.settings.streamerMode) {
-			const obfuscatedIp = main.utils.obfuscateString(main.stackAllocator, ipAddress);
-			defer main.stackAllocator.free(obfuscatedIp);
-			ipAddressLabel.updateText(obfuscatedIp);
-		} else {
-			ipAddressLabel.updateText(ipAddress);
-		}
 	}
 }

--- a/src/gui/windows/multiplayer_join.zig
+++ b/src/gui/windows/multiplayer_join.zig
@@ -1,0 +1,140 @@
+const std = @import("std");
+
+const main = @import("main");
+const ConnectionManager = main.network.ConnectionManager;
+const settings = main.settings;
+const Vec2f = main.vec.Vec2f;
+
+const gui = @import("../gui.zig");
+const GuiComponent = gui.GuiComponent;
+const GuiWindow = gui.GuiWindow;
+const Button = @import("../components/Button.zig");
+const Label = @import("../components/Label.zig");
+const TextInput = @import("../components/TextInput.zig");
+const VerticalList = @import("../components/VerticalList.zig");
+
+pub var window = GuiWindow{
+	.contentSize = Vec2f{128, 256},
+};
+
+var ipAddressLabel: *Label = undefined;
+var ipAddressEntry: *TextInput = undefined;
+
+const padding: f32 = 8;
+
+var connection: ?*ConnectionManager = null;
+var ipAddress: []const u8 = "";
+var gotIpAddress: std.atomic.Value(bool) = .init(false);
+var thread: ?std.Thread = null;
+const width: f32 = 420;
+
+fn discoverIpAddress() void {
+	connection = ConnectionManager.init(main.settings.defaultPort, true) catch |err| {
+		std.log.err("Could not open Connection: {s}", .{@errorName(err)});
+		ipAddress = main.globalAllocator.dupe(u8, @errorName(err));
+		return;
+	};
+	ipAddress = std.fmt.allocPrint(main.globalAllocator.allocator, "{f}", .{connection.?.externalAddress}) catch unreachable;
+	gotIpAddress.store(true, .release);
+}
+
+fn discoverIpAddressFromNewThread() void {
+	main.initThreadLocals();
+	defer main.deinitThreadLocals();
+
+	discoverIpAddress();
+}
+
+fn join() void {
+	if (thread) |_thread| {
+		_thread.join();
+		thread = null;
+	}
+	if (ipAddress.len != 0) {
+		main.globalAllocator.free(ipAddress);
+		ipAddress = "";
+	}
+	if (connection) |_connection| {
+		_connection.world = &main.game.testWorld;
+		main.game.world = &main.game.testWorld;
+		std.log.info("Connecting to server: {s}", .{ipAddressEntry.currentString.items});
+		main.game.testWorld.init(ipAddressEntry.currentString.items, _connection) catch |err| {
+			std.log.err("Encountered error while opening world: {s}", .{@errorName(err)});
+			main.gui.windowlist.notification.raiseNotification("Encountered error while opening world: {s}", .{@errorName(err)});
+			main.game.world = null;
+			_connection.world = null;
+			return;
+		};
+		main.globalAllocator.free(settings.lastUsedIPAddress);
+		settings.lastUsedIPAddress = main.globalAllocator.dupe(u8, ipAddressEntry.currentString.items);
+		settings.save();
+		connection = null;
+	} else {
+		std.log.err("No connection found. Cannot connect.", .{});
+		main.gui.windowlist.notification.raiseNotification("No connection found. Cannot connect.", .{});
+	}
+	for (gui.openWindows.items) |openWindow| {
+		gui.closeWindowFromRef(openWindow);
+	}
+	gui.openHud();
+}
+
+fn copyIp() void {
+	main.Window.setClipboardString(ipAddress);
+}
+
+pub fn onOpen() void {
+	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
+	list.add(Label.init(.{0, 0}, width, "Please send your IP to the host of the game and enter the host's IP below.", .center));
+	//                                               255.255.255.255:?65536 (longest possible ip address)
+	ipAddressLabel = Label.init(.{0, 0}, width, "                      ", .center);
+	list.add(ipAddressLabel);
+	list.add(Button.initText(.{0, 0}, 100, "Copy IP", .{.onAction = .init(copyIp)}));
+	ipAddressEntry = TextInput.init(.{0, 0}, width, 32, settings.lastUsedIPAddress, .{.onNewline = .init(join)});
+	ipAddressEntry.obfuscated = main.settings.streamerMode;
+	list.add(ipAddressEntry);
+	list.add(Button.initText(.{0, 0}, 100, "Join", .{.onAction = .init(join)}));
+	list.finish(.center);
+	window.rootComponent = list.toComponent();
+	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));
+	gui.updateWindowPositions();
+
+	thread = std.Thread.spawn(.{}, discoverIpAddressFromNewThread, .{}) catch |err| blk: {
+		std.log.err("Error spawning thread: {s}. Doing it in the current thread instead.", .{@errorName(err)});
+		discoverIpAddress();
+		break :blk null;
+	};
+}
+
+pub fn onClose() void {
+	if (thread) |_thread| {
+		_thread.join();
+		thread = null;
+	}
+	if (connection) |_connection| {
+		_connection.deinit();
+		connection = null;
+	}
+	if (ipAddress.len != 0) {
+		main.globalAllocator.free(ipAddress);
+		ipAddress = "";
+	}
+
+	if (window.rootComponent) |*comp| {
+		comp.deinit();
+	}
+}
+
+pub fn update() void {
+	if (gotIpAddress.load(.acquire)) {
+		gotIpAddress.store(false, .monotonic);
+
+		if (main.settings.streamerMode) {
+			const obfuscatedIp = main.utils.obfuscateString(main.stackAllocator, ipAddress);
+			defer main.stackAllocator.free(obfuscatedIp);
+			ipAddressLabel.updateText(obfuscatedIp);
+		} else {
+			ipAddressLabel.updateText(ipAddress);
+		}
+	}
+}

--- a/src/gui/windows/pause.zig
+++ b/src/gui/windows/pause.zig
@@ -21,9 +21,10 @@ fn reorderHudCallbackFunction() void {
 }
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
-	list.add(Button.initText(.{0, 0}, 128, "Players", .{.onAction = gui.openWindowCallback("players")}));
+	const isSingleplayer = if (main.server.world) |w| w.mode == .singleplayer else false;
+	list.add(Button.initText(.{0, 0}, 128, "Players", .{.onAction = gui.openWindowCallback("players"), .disabled = isSingleplayer}));
 	if (main.server.world != null) {
-		list.add(Button.initText(.{0, 0}, 128, "Invite Player", .{.onAction = gui.openWindowCallback("invite")}));
+		list.add(Button.initText(.{0, 0}, 128, "Invite Player", .{.onAction = gui.openWindowCallback("invite"), .disabled = isSingleplayer}));
 	}
 	list.add(Button.initText(.{0, 0}, 128, "Settings", .{.onAction = gui.openWindowCallback("settings")}));
 	list.add(Button.initText(.{0, 0}, 128, "Reorder HUD", .{.onAction = .init(reorderHudCallbackFunction)}));

--- a/src/gui/windows/save_selection.zig
+++ b/src/gui/windows/save_selection.zig
@@ -21,7 +21,7 @@ pub var window = GuiWindow{
 };
 
 const padding: f32 = 8;
-const width: f32 = 128;
+const width: f32 = 160;
 var buttonNameArena: main.heap.NeverFailingArenaAllocator = undefined;
 
 pub var needsUpdate: bool = false;
@@ -108,7 +108,7 @@ pub fn update() void {
 pub fn onOpen() void {
 	buttonNameArena = main.heap.NeverFailingArenaAllocator.init(main.globalAllocator);
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 8);
-	list.add(Label.init(.{0, 0}, width, "**Select World**", .center));
+	list.add(Label.init(.{0, 0}, width, if (mode == .singleplayer) "**Select World**" else "**Select World to Host**", .center));
 	list.add(Button.initText(.{0, 0}, 128, "Create New World", .{.onAction = gui.openWindowCallback("save_creation")}));
 	readingSaves: {
 		var dir = main.files.cubyzDir().openIterableDir("saves") catch |err| {

--- a/src/gui/windows/save_selection.zig
+++ b/src/gui/windows/save_selection.zig
@@ -26,6 +26,8 @@ var buttonNameArena: main.heap.NeverFailingArenaAllocator = undefined;
 
 pub var needsUpdate: bool = false;
 
+pub var mode: main.server.ServerWorld.Mode = undefined;
+
 var deleteIcon: Texture = undefined;
 var fileExplorerIcon: Texture = undefined;
 
@@ -53,7 +55,7 @@ pub fn openWorld(name: []const u8) void {
 	};
 
 	std.log.info("Opening world {s}", .{name});
-	main.server.thread = std.Thread.spawn(.{}, main.server.startFromNewThread, .{name, clientConnection.localPort}) catch |err| {
+	main.server.thread = std.Thread.spawn(.{}, main.server.startFromNewThread, .{name, clientConnection.localPort, mode}) catch |err| {
 		std.log.err("Encountered error while starting server thread: {s}", .{@errorName(err)});
 		return;
 	};

--- a/src/main.zig
+++ b/src/main.zig
@@ -525,7 +525,7 @@ pub fn main(args: std.process.Init.Minimal) void { // MARK: main()
 	server.terrain.globalInit();
 
 	if (headless) {
-		server.startFromExistingThread(settings.launchConfig.autoEnterWorld, null);
+		server.startFromExistingThread(settings.launchConfig.autoEnterWorld, null, .multiplayer);
 	} else {
 		clientMain();
 	}

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -542,7 +542,7 @@ var lastTime: std.Io.Timestamp = undefined;
 
 pub var thread: ?std.Thread = null;
 
-fn init(name: []const u8, singlePlayerPort: ?u16) void { // MARK: init()
+fn init(name: []const u8, singlePlayerPort: ?u16, mode: ServerWorld.Mode) void { // MARK: init()
 	main.heap.allocators.createWorldArena();
 	std.debug.assert(world == null); // There can only be one world.
 	command.init();
@@ -559,7 +559,7 @@ fn init(name: []const u8, singlePlayerPort: ?u16) void { // MARK: init()
 	main.items.Inventory.server.init();
 	main.sync.server.init();
 
-	world = ServerWorld.init(name) catch |err| {
+	world = ServerWorld.init(name, mode) catch |err| {
 		std.log.err("Failed to create world: {s}", .{@errorName(err)});
 		@panic("Can't create world.");
 	};
@@ -694,15 +694,15 @@ fn update() void { // MARK: update()
 	}
 }
 
-pub fn startFromNewThread(name: []const u8, port: ?u16) void {
+pub fn startFromNewThread(name: []const u8, port: ?u16, mode: ServerWorld.Mode) void {
 	main.initThreadLocals();
 	defer main.deinitThreadLocals();
-	startFromExistingThread(name, port);
+	startFromExistingThread(name, port, mode);
 }
 
-pub fn startFromExistingThread(name: []const u8, port: ?u16) void {
+pub fn startFromExistingThread(name: []const u8, port: ?u16, mode: ServerWorld.Mode) void {
 	std.debug.assert(!running.load(.monotonic)); // There can only be one server.
-	init(name, port);
+	init(name, port, mode);
 	defer deinit();
 	running.store(true, .release);
 	while (running.load(.monotonic)) {

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -442,6 +442,8 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 
 	settings: Settings = undefined,
 
+	mode: Mode,
+
 	path: []const u8,
 	name: []const u8 = &.{},
 	spawn: Vec3i = undefined,
@@ -466,7 +468,9 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		milliTimeStamp: i64,
 	};
 
-	pub fn init(path: []const u8) !*ServerWorld { // MARK: init()
+	pub const Mode = enum { singleplayer, multiplayer };
+
+	pub fn init(path: []const u8, mode: Mode) !*ServerWorld { // MARK: init()
 		const self = main.globalAllocator.create(ServerWorld);
 		errdefer main.globalAllocator.destroy(self);
 		self.* = ServerWorld{
@@ -476,6 +480,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 			.path = main.globalAllocator.dupe(u8, path),
 			.chunkUpdateQueue = .init(main.globalAllocator, 256),
 			.regionUpdateQueue = .init(main.globalAllocator, 256),
+			.mode = mode,
 		};
 		self.itemDropManager.init(main.globalAllocator, self);
 		errdefer self.itemDropManager.deinit();


### PR DESCRIPTION
This now distinguishes between joining a world in singleplayer and hosting a world for multiplayer.
There is now a new Window when you click multiplayer that allows you to host the game:
<img width="1280" height="745" alt="Screenshot at 2026-06-15 16-26-50" src="https://github.com/user-attachments/assets/07fec42d-9d9c-4a7c-b3f9-70780958e3c2" />
If you open a world through the singleplayer options instead, it will not allow you to invite any players:
<img width="1280" height="745" alt="Screenshot at 2026-06-15 16-26-32" src="https://github.com/user-attachments/assets/daf82d32-e9f7-4561-92eb-7f016c95d5c4" />
This distinction is required for local accounts for #3192, and I think this will also make hosting more logical, as you no longer go through singleplayer to do so.