### PR TITLE
Make Surface Caves not Lead to dead ends anymore

### DIFF
--- a/assets/cubyz/cave_layers/surface_caves.zig.zon
+++ b/assets/cubyz/cave_layers/surface_caves.zig.zon
@@ -3,5 +3,5 @@
 	.layerHeight = 250,
 	.depthHint = -1,
 
-	.caveDensity = 0.02,
+	.caveDensity = 0.05,
 }

--- a/assets/cubyz/cave_layers/surface_caves.zig.zon
+++ b/assets/cubyz/cave_layers/surface_caves.zig.zon
@@ -3,5 +3,5 @@
 	.layerHeight = 250,
 	.depthHint = -1,
 
-	.caveDensity = 0.005,
+	.caveDensity = 0.02,
 }


### PR DESCRIPTION
This increases the chance of caves on the surface so that most large caves on the surface actually lead underground instead of stopping halfway