### PR TITLE
Use clusters in sky/base caves to reduce single caves and increase connectivity

### DIFF
--- a/assets/cubyz/biomes/cave/sky.zig.zon
+++ b/assets/cubyz/biomes/cave/sky.zig.zon
@@ -7,11 +7,19 @@
 	.ground_structure = .{},
 	.caveModels = .{
 		.{
-			.id = "cubyz:partial_sphere",
-			.minAmount = 10,
-			.maxAmount = 16,
-			.minRadius = 6,
-			.maxRadius = 14,
+			.id = "cubyz:cluster",
+			.minAmount = 1,
+			.maxAmount = 1.5,
+			.children = .{
+				.{
+					.id = "cubyz:partial_sphere",
+					.minAmount = 4,
+					.maxAmount = 6,
+					.minRadius = 6,
+					.maxRadius = 14,
+					.randomOffset = .{20, 20, 15},
+				},
+			},
 		},
 	},
 }

--- a/assets/cubyz/biomes/cave/slate/base.zig.zon
+++ b/assets/cubyz/biomes/cave/slate/base.zig.zon
@@ -19,11 +19,19 @@
 	},
 	.caveModels = .{
 		.{
-			.id = "cubyz:partial_sphere",
-			.minAmount = 10,
-			.maxAmount = 20,
-			.minRadius = 8,
-			.maxRadius = 16,
+			.id = "cubyz:cluster",
+			.minAmount = 1,
+			.maxAmount = 2,
+			.children = .{
+				.{
+					.id = "cubyz:partial_sphere",
+					.minAmount = 4,
+					.maxAmount = 6,
+					.minRadius = 8,
+					.maxRadius = 16,
+					.randomOffset = .{25, 25, 20},
+				},
+			},
 		},
 	},
 }

--- a/assets/cubyz/cave_layers/surface_caves.zig.zon
+++ b/assets/cubyz/cave_layers/surface_caves.zig.zon
@@ -3,5 +3,5 @@
 	.layerHeight = 250,
 	.depthHint = -1,
 
-	.caveDensity = 0.005,
+	.caveDensity = 0.008,
 }

--- a/src/server/terrain/sdf_models/cluster.zig
+++ b/src/server/terrain/sdf_models/cluster.zig
@@ -59,21 +59,27 @@ pub fn initAndGetExtend(zon: ZonElement) sdf.SdfModel.InitResult {
 }
 
 pub fn instantiate(self: *@This(), arena: NeverFailingAllocator, seed: *u64) SdfInstance {
-	const instance = arena.create(Instance);
-	instance.* = .{
-		.children = arena.alloc(SdfInstance, self.children.len),
-		.smoothness = self.smoothness,
-	};
 	var minPos: Vec3i = @splat(1e9);
 	var maxPos: Vec3i = @splat(-1e9);
-	for (self.children, instance.children) |entry, *result| {
-		result.* = entry.model.instantiate(arena, seed);
-		const offset = entry.positionOffset + entry.randomOffset*main.random.nextFloatVectorSigned(3, seed);
-		result.minBounds +%= @trunc(offset);
-		result.maxBounds +%= @trunc(offset);
-		minPos = @min(minPos, result.minBounds);
-		maxPos = @max(maxPos, result.maxBounds);
+	var children: main.List(SdfInstance) = .empty;
+	defer children.deinit(main.stackAllocator);
+	for (self.children) |entry| {
+		const amount: usize = @floor(entry.model.minAmount + main.random.nextFloat(seed)*(entry.model.maxAmount - entry.model.minAmount) + main.random.nextFloat(seed));
+		for (0..amount) |_| {
+			var result = entry.model.instantiate(arena, seed);
+			const offset = entry.positionOffset + entry.randomOffset*main.random.nextFloatVectorSigned(3, seed);
+			result.minBounds +%= @trunc(offset);
+			result.maxBounds +%= @trunc(offset);
+			minPos = @min(minPos, result.minBounds);
+			maxPos = @max(maxPos, result.maxBounds);
+			children.append(main.stackAllocator, result);
+		}
 	}
+	const instance = arena.create(Instance);
+	instance.* = .{
+		.children = arena.dupe(SdfInstance, children.items),
+		.smoothness = self.smoothness,
+	};
 	return .{
 		.data = instance,
 		.generateFn = main.meta.castFunctionSelfToAnyopaque(generate),


### PR DESCRIPTION
Clusters also now recognize child amounts.
Also adjusted the fractal cave spawn rate in surface layer.

This should make it easier to find a decent cave from the surface.

Before:
<img width="2560" height="1413" alt="Screenshot at 2026-06-19 20-57-33" src="https://github.com/user-attachments/assets/de2ea98e-0fc3-41f8-b352-c68ca7ae8c1f" />
After:
<img width="2560" height="1413" alt="Screenshot at 2026-06-19 21-18-28" src="https://github.com/user-attachments/assets/215ab3e8-8733-4f00-bf44-e14f5532c0cc" />

related to #3244

This does not fully fix the issue, but I hope that it makes it rarer without compromising on the underground structure too much, and without spamming caves all around the surface.