### PR TITLE
Remove the annoying checkbox when hosting a world with port forwarding, it now always allows for external connections

### DIFF
--- a/src/gui/windows/invite.zig
+++ b/src/gui/windows/invite.zig
@@ -59,10 +59,6 @@ fn copyIp() void {
 	main.Window.setClipboardString(ipAddress);
 }
 
-fn makePublic(public: bool) void {
-	main.server.connectionManager.allowNewConnections.store(public, .monotonic);
-}
-
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 260, 16);
 	list.add(Label.init(.{0, 0}, width, "Please send your IP to the player who wants to join and enter their IP below.", .center));
@@ -74,7 +70,6 @@ pub fn onOpen() void {
 	ipAddressEntry.obfuscated = main.settings.streamerMode;
 	list.add(ipAddressEntry);
 	list.add(Button.initText(.{0, 0}, 100, "Invite", .{.onAction = .init(invite)}));
-	list.add(CheckBox.init(.{0, 0}, width, "Allow anyone to join (requires a publicly visible IP address+port which may need some configuration in your router)", main.server.connectionManager.allowNewConnections.load(.monotonic), &makePublic));
 	list.finish(.center);
 	window.rootComponent = list.toComponent();
 	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));

--- a/src/gui/windows/multiplayer_join.zig
+++ b/src/gui/windows/multiplayer_join.zig
@@ -29,11 +29,12 @@ var thread: ?std.Thread = null;
 const width: f32 = 420;
 
 fn discoverIpAddress() void {
-	connection = ConnectionManager.init(main.settings.defaultPort, true) catch |err| {
+	connection = ConnectionManager.init(main.settings.defaultPort, .{}) catch |err| {
 		std.log.err("Could not open Connection: {s}", .{@errorName(err)});
 		ipAddress = main.globalAllocator.dupe(u8, @errorName(err));
 		return;
 	};
+	connection.?.makeOnline();
 	ipAddress = std.fmt.allocPrint(main.globalAllocator.allocator, "{f}", .{connection.?.externalAddress}) catch unreachable;
 	gotIpAddress.store(true, .release);
 }

--- a/src/gui/windows/save_selection.zig
+++ b/src/gui/windows/save_selection.zig
@@ -49,7 +49,7 @@ pub fn deinit() void {
 }
 
 pub fn openWorld(name: []const u8) void {
-	const clientConnection = ConnectionManager.init(0, false) catch |err| {
+	const clientConnection = ConnectionManager.init(0, .{}) catch |err| {
 		std.log.err("Encountered error while opening connection: {s}", .{@errorName(err)});
 		return;
 	};

--- a/src/network.zig
+++ b/src/network.zig
@@ -481,7 +481,7 @@ pub const ConnectionManager = struct { // MARK: ConnectionManager
 
 	mutex: main.utils.Mutex = .{},
 	waitingToFinishReceive: main.utils.Condition = .{},
-	allowNewConnections: Atomic(bool) = .init(false),
+	allowNewConnections: bool,
 
 	receiveBuffer: [Connection.maxMtu]u8 = undefined,
 
@@ -501,10 +501,12 @@ pub const ConnectionManager = struct { // MARK: ConnectionManager
 		}
 	};
 
-	pub fn init(localPort: u16, online: bool) !*ConnectionManager {
+	pub fn init(localPort: u16, options: struct { allowNewConnections: bool = false }) !*ConnectionManager {
 		const result: *ConnectionManager = main.globalAllocator.create(ConnectionManager);
 		errdefer main.globalAllocator.destroy(result);
-		result.* = .{};
+		result.* = .{
+			.allowNewConnections = options.allowNewConnections,
+		};
 
 		result.localPort = localPort;
 		result.socket = Socket.init(localPort) catch |err| blk: {
@@ -519,12 +521,6 @@ pub const ConnectionManager = struct { // MARK: ConnectionManager
 
 		try result.@"continue"();
 
-		if (online) {
-			result.makeOnline();
-		}
-		if (main.settings.launchConfig.headlessServer) {
-			result.allowNewConnections.store(true, .monotonic);
-		}
 		return result;
 	}
 	pub fn @"continue"(result: *ConnectionManager) !void {
@@ -669,7 +665,7 @@ pub const ConnectionManager = struct { // MARK: ConnectionManager
 			}
 			if (self.online.load(.acquire) and source.ip == self.externalAddress.ip and source.port == self.externalAddress.port) return;
 		}
-		if (self.allowNewConnections.load(.monotonic) or source.ip == Address.localHost) {
+		if (self.allowNewConnections or source.ip == Address.localHost) {
 			if (data.len != 0 and data[0] == @intFromEnum(Connection.ChannelId.init)) {
 				const ip = std.fmt.allocPrint(main.stackAllocator.allocator, "{f}", .{source}) catch unreachable;
 				defer main.stackAllocator.free(ip);

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -726,7 +726,7 @@ pub fn startFromExistingThread(name: []const u8, port: ?u16, mode: ServerWorld.M
 
 	restart = true;
 
-	connectionManager = ConnectionManager.init(main.settings.defaultPort, false) catch |err| {
+	connectionManager = ConnectionManager.init(main.settings.defaultPort, .{.allowNewConnections = mode == .multiplayer}) catch |err| {
 		std.log.err("Couldn't create socket: {s}", .{@errorName(err)});
 		@panic("Could not open Server.");
 	}; // TODO Configure the second argument in the server settings.


### PR DESCRIPTION
I also decided to remove the `online` parameter from the init function, it makes no sense for the fact that it's only used once.

fixes #3239