### PR TITLE
Disable autohints in freetype

### DIFF
--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -1211,7 +1211,7 @@ const TextRendering = struct { // MARK: TextRendering
 			glyphMapping.appendNTimes(0, index - glyphMapping.items.len + 1);
 		}
 		if (glyphMapping.items[index] == 0) { // glyph was not initialized yet.
-			try ftError(c.FT_Load_Glyph(freetypeFace, index, c.FT_LOAD_RENDER));
+			try ftError(c.FT_Load_Glyph(freetypeFace, index, c.FT_LOAD_RENDER | c.FT_LOAD_NO_AUTOHINT));
 			const glyph = freetypeFace.*.glyph;
 			const bitmap = glyph.*.bitmap;
 			const width = bitmap.width;


### PR DESCRIPTION
Updating freetype to 2.14.3 (https://github.com/PixelGuys/Cubyz-libs/pull/16) causes some glyphs to be fuzzy. Disabling autohints in glyph loading fixes this. Since the font is size 16 and textureHeight is 16, it seems to me hints are not needed.

Disclosure: I had an AI help me with this.

Freetype 2.14.3:
<img width="1410" height="878" alt="Screenshot_20260620_114528" src="https://github.com/user-attachments/assets/849cb6a4-6302-4bd4-b84e-485d6ab79e75" />

Freetype 2.14.3, autohints disabled:
<img width="1410" height="878" alt="Screenshot_20260620_114842" src="https://github.com/user-attachments/assets/784ef1a3-8741-4770-b2f7-14c3695ea8d9" />
