### PR TITLE
Add a small epsilon to the collision response

### DIFF
--- a/src/particles.zig
+++ b/src/particles.zig
@@ -164,7 +164,7 @@ pub const ParticleSystem = struct {
 	var particleCount: u32 = 0;
 	var particles: [maxCapacity]Particle = undefined;
 	var particlesLocal: [maxCapacity]ParticleLocal = undefined;
-	var previousPlayerPos: Vec3d = undefined;
+	var previousPlayerPos: Vec3i = undefined;
 
 	var mutex: main.utils.Mutex = .{};
 	var networkCreationQueue: main.List(struct { emitter: Emitter, pos: Vec3d, count: u32 }) = .empty;
@@ -217,8 +217,9 @@ pub const ParticleSystem = struct {
 		mutex.unlock();
 
 		const vecDeltaTime: Vec4f = @as(Vec4f, @splat(deltaTime));
-		const playerPos = game.Player.getEyePosBlocking();
-		const prevPlayerPosDifference: Vec3f = @floatCast(previousPlayerPos - playerPos);
+		const playerPosInt: Vec3i = @intFromFloat(game.Player.getEyePosBlocking());
+		const playerPos: Vec3d = @floatFromInt(playerPosInt);
+		const prevPlayerPosDifference: Vec3f = @floatFromInt(previousPlayerPos -% playerPosInt);
 
 		var i: u32 = 0;
 		while (i < particleCount) {
@@ -245,7 +246,7 @@ pub const ParticleSystem = struct {
 			particleLocal.velAndRotationVel *= @splat(@exp(-frictionCoefficient*deltaTime));
 
 			if (particleLocal.collides) {
-				var v3Pos = playerPos + @as(Vec3d, @floatCast(pos + prevPlayerPosDifference));
+				var v3Pos = playerPos + (pos + prevPlayerPosDifference);
 				const size = ParticleManager.types.items[particle.typ].size;
 				const hitBox: physics.collision.Box = .{.min = @splat(size*-0.5), .max = @splat(size*0.5)};
 
@@ -254,25 +255,25 @@ pub const ParticleSystem = struct {
 				v3Pos[0] += posDelta[0];
 				if (physics.collision.collides(.client, .x, -posDelta[0], v3Pos, hitBox)) |box| {
 					if (posDelta[0] < 0) {
-						v3Pos[0] = box.max[0] - hitBox.min[0];
+						v3Pos[0] = box.max[0] - hitBox.min[0] + physics.epsilon;
 					} else {
-						v3Pos[0] = box.min[0] - hitBox.max[0];
+						v3Pos[0] = box.min[0] - hitBox.max[0] - physics.epsilon;
 					}
 				}
 				v3Pos[1] += posDelta[1];
 				if (physics.collision.collides(.client, .y, -posDelta[1], v3Pos, hitBox)) |box| {
 					if (posDelta[1] < 0) {
-						v3Pos[1] = box.max[1] - hitBox.min[1];
+						v3Pos[1] = box.max[1] - hitBox.min[1] + physics.epsilon;
 					} else {
-						v3Pos[1] = box.min[1] - hitBox.max[1];
+						v3Pos[1] = box.min[1] - hitBox.max[1] - physics.epsilon;
 					}
 				}
 				v3Pos[2] += posDelta[2];
 				if (physics.collision.collides(.client, .z, -posDelta[2], v3Pos, hitBox)) |box| {
 					if (posDelta[2] < 0) {
-						v3Pos[2] = box.max[2] - hitBox.min[2];
+						v3Pos[2] = box.max[2] - hitBox.min[2] + physics.epsilon;
 					} else {
-						v3Pos[2] = box.min[2] - hitBox.max[2];
+						v3Pos[2] = box.min[2] - hitBox.max[2] - physics.epsilon;
 					}
 				}
 				pos = @as(Vec3f, @floatCast(v3Pos - playerPos));
@@ -300,7 +301,7 @@ pub const ParticleSystem = struct {
 
 			i += 1;
 		}
-		previousPlayerPos = playerPos;
+		previousPlayerPos = playerPosInt;
 	}
 
 	fn addParticle(typ: u32, particleType: ParticleTypeLocal, pos: Vec3d, vel: Vec3f, collides: bool, properties: EmitterProperties) void {
@@ -311,7 +312,7 @@ pub const ParticleSystem = struct {
 		const dragCoeff = particleType.dragCoefficient.get(&main.seed);
 
 		particles[particleCount] = Particle{
-			.pos = @as(Vec3f, @floatCast(pos - previousPlayerPos)),
+			.pos = @as(Vec3f, @floatCast(pos - @as(Vec3d, @floatFromInt(previousPlayerPos)))),
 			.rot = rot,
 			.typ = typ,
 		};
@@ -330,7 +331,7 @@ pub const ParticleSystem = struct {
 
 		pipeline.bind(null);
 
-		const projectionAndViewMatrix = Mat4f.mul(projectionMatrix, viewMatrix);
+		const projectionAndViewMatrix = Mat4f.mul(projectionMatrix, viewMatrix.mul(.translation(@floatCast(-game.Player.getEyePosBlocking() + @as(Vec3d, @floatFromInt(previousPlayerPos))))));
 		c.glUniformMatrix4fv(uniforms.projectionAndViewMatrix, 1, c.GL_TRUE, @ptrCast(&projectionAndViewMatrix));
 		c.glUniform3fv(uniforms.ambientLight, 1, @ptrCast(&ambientLight));
 

--- a/src/physics.zig
+++ b/src/physics.zig
@@ -16,6 +16,8 @@ pub const playerAirTerminalVelocity = 90.0;
 pub const airDensity = 0.001;
 pub const playerDensity = 1.2;
 
+const epsilon: f64 = 1.0/@as(comptime_float, 1 << (std.math.floatMantissaBits(f64) - 31)); // Should be the last bit when at the integer limit
+
 pub const collision = struct {
 	pub const Box = struct {
 		min: Vec3d,
@@ -274,7 +276,7 @@ pub const collision = struct {
 		checkPos[index] += amount;
 
 		if (collision.collides(side, dir, -amount, checkPos, hitBox)) |box| {
-			const newFloor = box.max[2] + hitBox.max[2];
+			const newFloor = box.max[2] + hitBox.max[2] + epsilon;
 			const heightDifference = newFloor - checkPos[2];
 			if (heightDifference <= steppingHeight) {
 				// If we collide but might be able to step up
@@ -288,9 +290,9 @@ pub const collision = struct {
 
 			// Otherwise move as close to the container as possible
 			if (amount < 0) {
-				resultingMovement[index] = box.max[index] - hitBox.min[index] - pos[index];
+				resultingMovement[index] = box.max[index] - hitBox.min[index] - pos[index] + epsilon;
 			} else {
-				resultingMovement[index] = box.min[index] - hitBox.max[index] - pos[index];
+				resultingMovement[index] = box.min[index] - hitBox.max[index] - pos[index] - epsilon;
 			}
 		}
 
@@ -560,9 +562,9 @@ pub fn calculateVerticalCollision(comptime side: main.sync.Side, deltaTime: f64,
 	if (collision.collides(side, .z, -motion[2], pos.*, hitBox)) |box| {
 		if (motion[2] < 0) {
 			onGround.* = true;
-			pos[2] = box.max[2] - hitBox.min[2];
+			pos[2] = box.max[2] - hitBox.min[2] + epsilon;
 		} else {
-			pos[2] = box.min[2] - hitBox.max[2];
+			pos[2] = box.min[2] - hitBox.max[2] - epsilon;
 		}
 		const bounciness = if (bouncinessMultiplier == 0) 0 else collision.calculateSurfaceProperties(side, pos.*, hitBox, 0.0).bounciness*bouncinessMultiplier;
 

--- a/src/physics.zig
+++ b/src/physics.zig
@@ -16,7 +16,7 @@ pub const playerAirTerminalVelocity = 90.0;
 pub const airDensity = 0.001;
 pub const playerDensity = 1.2;
 
-const epsilon: f64 = 1.0/@as(comptime_float, 1 << (std.math.floatMantissaBits(f64) - 31)); // Should be the last bit when at the integer limit
+pub const epsilon: f64 = 1.0/@as(comptime_float, 1 << (std.math.floatMantissaBits(f64) - 31)); // Should be the last bit when at the integer limit
 
 pub const collision = struct {
 	pub const Box = struct {


### PR DESCRIPTION
Note that originally I removed this in 4890045de06e6ac8d5e3e1ef8d0b965c009ae0a6, but I didn't account for floating point errors when at exact powers of two.
I re-added the offset to the collision response calculation, and I reduced it to the minimum we can afford within the world's size.
With the previous epsilon of `0.0001` a jitter was observed at high fps, with the new one which is about `0.000005` no jitter is visible.

fixes #1831
closes #2937