### PR TITLE
Collapse transitive migrations

### DIFF
--- a/src/migrations.zig
+++ b/src/migrations.zig
@@ -32,6 +32,27 @@ pub fn registerAll(comptime typ: MigrationType, migrations: *Assets.AddonNameToZ
 	while (migrationIterator.next()) |migration| {
 		register(typ, collection, migration.key_ptr.*, migration.value_ptr.*);
 	}
+
+	// apply transitive migrations
+	var iterator = collection.iterator();
+	var entries: main.List([]const u8) = .empty;
+	defer entries.deinit(main.stackAllocator);
+	while (iterator.next()) |migrationEntry| {
+		defer entries.clearRetainingCapacity();
+		entries.append(main.stackAllocator, migrationEntry.key_ptr.*);
+		entries.append(main.stackAllocator, migrationEntry.value_ptr.*);
+		transitiveChain: while (collection.get(migrationEntry.value_ptr.*)) |transitive| {
+			std.log.info("Collapsing transitive {s} migration: '{s}' -> {s} -> '{s}'", .{@tagName(typ), migrationEntry.key_ptr.*, migrationEntry.value_ptr.*, transitive});
+			for (entries.items) |entry| {
+				if (std.mem.eql(u8, transitive, entry)) {
+					std.log.err("Found circular migration for {s}. Circular migrations are not allowed", .{transitive});
+					break :transitiveChain;
+				}
+			}
+			migrationEntry.value_ptr.* = transitive;
+			entries.append(main.stackAllocator, transitive);
+		}
+	}
 }
 
 fn register(


### PR DESCRIPTION
should fix the problem described in https://github.com/PixelGuys/Cubyz/pull/3254#issuecomment-4762715964

I also decided to add an error for circular migrations:

<img width="840" height="118" alt="Screenshot at 2026-06-21 21-56-31" src="https://github.com/user-attachments/assets/d2fe713a-366f-4da3-99fc-85f4c7063b64" />
