### PR TITLE
Refactor item drop logic to check allowed tool tags (#3008)

### DIFF
--- a/src/callbacks/block/server/check_support_blocks.zig
+++ b/src/callbacks/block/server/check_support_blocks.zig
@@ -47,18 +47,20 @@ pub fn run(_: *@This(), params: main.callbacks.ServerBlockCallback.Params) main.
 		const drops = params.block.blockDrops();
 		for (0..dropAmount) |_| {
 			for (drops) |drop| {
-				if (drop.chance == 1 or main.random.nextFloat(&main.seed) < drop.chance) {
-					for (drop.items) |stack| {
-						var dir = main.vec.normalize(main.random.nextFloatVectorSigned(3, &main.seed));
-						// Bias upwards
-						dir[2] += main.random.nextFloat(&main.seed)*4.0;
-						const model = params.block.mode().model(params.block).model();
-						const pos = Vec3f{
-							@as(f32, @floatFromInt(wx)) + model.min[0] + main.random.nextFloat(&main.seed)*(model.max[0] - model.min[0]),
-							@as(f32, @floatFromInt(wy)) + model.min[1] + main.random.nextFloat(&main.seed)*(model.max[1] - model.min[1]),
-							@as(f32, @floatFromInt(wz)) + model.min[2] + main.random.nextFloat(&main.seed)*(model.max[2] - model.min[2]),
-						};
-						main.server.world.?.drop(stack.clone(), pos, dir, 1);
+				if (drop.allowedToolTags == null) {
+					if (drop.chance == 1 or main.random.nextFloat(&main.seed) < drop.chance) {
+						for (drop.items) |stack| {
+							var dir = main.vec.normalize(main.random.nextFloatVectorSigned(3, &main.seed));
+							// Bias upwards
+							dir[2] += main.random.nextFloat(&main.seed)*4.0;
+							const model = params.block.mode().model(params.block).model();
+							const pos = Vec3f{
+								@as(f32, @floatFromInt(wx)) + model.min[0] + main.random.nextFloat(&main.seed)*(model.max[0] - model.min[0]),
+								@as(f32, @floatFromInt(wy)) + model.min[1] + main.random.nextFloat(&main.seed)*(model.max[1] - model.min[1]),
+								@as(f32, @floatFromInt(wz)) + model.min[2] + main.random.nextFloat(&main.seed)*(model.max[2] - model.min[2]),
+							};
+							main.server.world.?.drop(stack.clone(), pos, dir, 1);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes: #3008
If the drop requires a tool, don't drop it when the block loses its support.