### PR TITLE
Remove threadPool.clear and instead provide means of pausing the threadPool

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -306,7 +306,16 @@ pub const World = struct { // MARK: World
 	}
 
 	pub fn deinit(self: *World) void {
+		main.server.stop(.stop);
+
+		if (main.server.thread) |serverThread| {
+			serverThread.join();
+			main.server.thread = null;
+		}
+
 		self.conn.deinit();
+		main.threadPool.pause();
+		defer main.threadPool.@"continue"();
 
 		self.connected = false;
 
@@ -317,7 +326,6 @@ pub const World = struct { // MARK: World
 		Player.inventory.deinit(main.globalAllocator);
 		main.sync.client.reset();
 
-		main.threadPool.clear();
 		Player.super.deinit(.client);
 		main.entity.client.clear();
 		self.itemDrops.deinit();
@@ -328,13 +336,6 @@ pub const World = struct { // MARK: World
 		self.entityComponentPalette.deinit();
 		self.entityModelPalette.deinit();
 		self.manager.deinit();
-		main.server.stop(.stop);
-
-		if (main.server.thread) |serverThread| {
-			serverThread.join();
-			main.server.thread = null;
-		}
-		main.threadPool.clear();
 		renderer.mesh_storage.deinit();
 		renderer.mesh_storage.init();
 		assets.unloadAssets();

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -597,7 +597,10 @@ fn init(name: []const u8, singlePlayerPort: ?u16, mode: ServerWorld.Mode) void {
 
 fn deinit() void {
 	connectionManager.pause();
-	main.threadPool.clear();
+	main.threadPool.pause();
+	defer main.threadPool.@"continue"();
+
+	main.threadPool.unschedulePlayers();
 
 	users.clearAndFree();
 	while (userDeinitList.popFront()) |user| {

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -320,6 +320,7 @@ pub const ChunkManager = struct { // MARK: ChunkManager
 	}
 
 	pub fn deinit(_: ChunkManager) void {
+		main.threadPool.updateTaskPriority();
 		for (0..main.settings.highestSupportedLod) |_| {
 			chunkCache.clear();
 		}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -815,9 +815,12 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 	currentTasks: []Atomic(?*const VTable),
 	loadList: ConcurrentMaxHeap(Task),
 	playerJobQueue: ConcurrentQueue(*main.server.User),
-	semaphore: main.utils.Semaphore = .{},
+	taskCountSemaphore: main.utils.Semaphore = .{},
+	stopSemaphore: main.utils.Semaphore = .{},
+	startSemaphore: main.utils.Semaphore = .{},
 	allocator: NeverFailingAllocator,
 	running: Atomic(bool) = .init(true),
+	paused: Atomic(bool) = .init(false),
 
 	performance: Performance,
 
@@ -869,6 +872,20 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 		self.allocator.destroy(self);
 	}
 
+	pub fn @"continue"(self: *ThreadPool) void {
+		std.debug.assert(self.paused.swap(false, .monotonic));
+		for (0..self.threads.len) |_| {
+			self.startSemaphore.post();
+		}
+	}
+
+	pub fn pause(self: *ThreadPool) void {
+		std.debug.assert(!self.paused.swap(true, .monotonic));
+		for (0..self.threads.len) |_| {
+			self.stopSemaphore.wait();
+		}
+	}
+
 	pub fn closeAllTasksOfType(self: *ThreadPool, vtable: *const VTable) void {
 		std.debug.assert(vtable.taskType != .chunkgen);
 		self.loadList.mutex.lock();
@@ -879,7 +896,7 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 			if (task.vtable == vtable) {
 				task.vtable.clean(task.self);
 				self.loadList.removeIndex(i);
-				self.semaphore.timedWait(.zero) catch {};
+				self.taskCountSemaphore.timedWait(.zero) catch {};
 			} else {
 				i += 1;
 			}
@@ -889,6 +906,14 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 			while (task.load(.monotonic) == vtable) {
 				main.io.sleep(.fromMilliseconds(1), .awake) catch {};
 			}
+		}
+	}
+
+	pub fn unschedulePlayers(self: *ThreadPool) void {
+		while (self.playerJobQueue.popFront()) |player| {
+			self.taskCountSemaphore.timedWait(.zero) catch {};
+			_ = self.trueQueueSize.fetchSub(1, .monotonic);
+			player.decreaseRefCount();
 		}
 	}
 
@@ -909,7 +934,7 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 				},
 				.hasMoreTasks => {
 					self.playerJobQueue.pushBack(player);
-					self.semaphore.post();
+					self.taskCountSemaphore.post();
 					_ = self.trueQueueSize.fetchAdd(1, .monotonic);
 				},
 			}
@@ -926,43 +951,56 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 		outer: while (self.running.load(.monotonic)) {
 			main.heap.GarbageCollection.syncPoint();
 
-			self.semaphore.timedWait(.fromMilliseconds(10)) catch continue :outer;
+			if (self.paused.load(.monotonic)) {
+				self.stopSemaphore.post();
+				while (true) {
+					main.heap.GarbageCollection.syncPoint();
+					self.startSemaphore.timedWait(.fromMilliseconds(10)) catch continue;
+					break;
+				}
+			}
+
+			self.taskCountSemaphore.timedWait(.fromMilliseconds(10)) catch continue :outer;
 
 			{
 				const task = self.getNextTask() orelse continue :outer;
 				self.currentTasks[id].store(task.vtable, .monotonic);
-				const start = main.timestamp();
+				const startTime = main.timestamp();
 				task.vtable.run(task.self);
-				const end = main.timestamp();
-				self.performance.add(task.vtable.taskType, @intCast(@divTrunc(start.durationTo(end).toNanoseconds(), 1000)));
+				const endTime = main.timestamp();
+				self.performance.add(task.vtable.taskType, @intCast(@divTrunc(startTime.durationTo(endTime).toNanoseconds(), 1000)));
 				self.currentTasks[id].store(null, .monotonic);
 				_ = self.trueQueueSize.fetchSub(1, .monotonic);
 			}
 
 			if (id == 0 and lastUpdate.durationTo(main.timestamp()).nanoseconds > refreshTime.nanoseconds) {
-				const start = main.timestamp();
-				var temporaryTaskList: main.List(Task) = .empty;
-				defer temporaryTaskList.deinit(main.stackAllocator);
-				while (self.loadList.extractAny()) |task| {
-					self.semaphore.timedWait(.zero) catch {};
-					if (!task.vtable.isStillNeeded(task.self)) {
-						task.vtable.clean(task.self);
-						_ = self.trueQueueSize.fetchSub(1, .monotonic);
-					} else {
-						const taskPtr = temporaryTaskList.addOne(main.stackAllocator);
-						taskPtr.* = task;
-						taskPtr.cachedPriority = task.vtable.getPriority(task.self);
-					}
-				}
-				self.loadList.addMany(temporaryTaskList.items);
-				for (0..temporaryTaskList.items.len) |_| {
-					self.semaphore.post();
-				}
-				const end = main.timestamp();
-				lastUpdate = end;
-				self.performance.add(.taskPriorityUpdate, @intCast(@divTrunc(start.durationTo(end).toNanoseconds(), 1000)));
+				self.updateTaskPriority();
+				lastUpdate = main.timestamp();
 			}
 		}
+	}
+
+	pub fn updateTaskPriority(self: *ThreadPool) void {
+		const startTime = main.timestamp();
+		var temporaryTaskList: main.List(Task) = .empty;
+		defer temporaryTaskList.deinit(main.stackAllocator);
+		while (self.loadList.extractAny()) |task| {
+			self.taskCountSemaphore.timedWait(.zero) catch {};
+			if (!task.vtable.isStillNeeded(task.self)) {
+				task.vtable.clean(task.self);
+				_ = self.trueQueueSize.fetchSub(1, .monotonic);
+			} else {
+				const taskPtr = temporaryTaskList.addOne(main.stackAllocator);
+				taskPtr.* = task;
+				taskPtr.cachedPriority = task.vtable.getPriority(task.self);
+			}
+		}
+		self.loadList.addMany(temporaryTaskList.items);
+		for (0..temporaryTaskList.items.len) |_| {
+			self.taskCountSemaphore.post();
+		}
+		const endTime = main.timestamp();
+		self.performance.add(.taskPriorityUpdate, @intCast(@divTrunc(startTime.durationTo(endTime).toNanoseconds(), 1000)));
 	}
 
 	pub fn addTask(self: *ThreadPool, task: *anyopaque, vtable: *const VTable) void {
@@ -971,36 +1009,15 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 			.vtable = vtable,
 			.self = task,
 		});
-		self.semaphore.post();
+		self.taskCountSemaphore.post();
 		_ = self.trueQueueSize.fetchAdd(1, .monotonic);
 	}
 
 	pub fn addPlayer(self: *ThreadPool, player: *main.server.User) void {
 		player.increaseRefCount();
 		self.playerJobQueue.pushBack(player);
-		self.semaphore.post();
+		self.taskCountSemaphore.post();
 		_ = self.trueQueueSize.fetchAdd(1, .monotonic);
-	}
-
-	pub fn clear(self: *ThreadPool) void {
-		// Clear the remaining tasks:
-		while (self.loadList.extractAny()) |task| {
-			self.semaphore.timedWait(.zero) catch {};
-			task.vtable.clean(task.self);
-			_ = self.trueQueueSize.fetchSub(1, .monotonic);
-		}
-		while (self.playerJobQueue.popFront()) |player| {
-			while (player.getTaskFromJobQueue()) |task| {
-				task[0].vtable.clean(task[0].self);
-			}
-			self.semaphore.timedWait(.zero) catch {};
-			player.decreaseRefCount();
-			_ = self.trueQueueSize.fetchSub(1, .monotonic);
-		}
-		// Wait for the in-progress tasks to finish:
-		while (self.trueQueueSize.load(.monotonic) != 0) {
-			main.io.sleep(.fromMilliseconds(1), .awake) catch {};
-		}
 	}
 
 	pub fn queueSize(self: *const ThreadPool) usize {


### PR DESCRIPTION
`clear()` is a brute-force solution, and it doesn't behave predictably when multiple threads are involved, as discovered in https://github.com/PixelGuys/Cubyz/pull/3278#discussion_r3494360536

This is solved here by providing the ability to pause the threadpool momentarily (e.g. during cleanup). This means we do not have to worry about other tasks interfering with our cleanup logic
Then the cleanup phase can manually unschedule the tasks it doesn't need anymore (relying on the `isStillNeeded` function, which can be triggered by task reprioritization).

fixes #3237
helps with #3278