### PR TITLE
Print help and refer to launchConfig.zon on any command line argument

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -335,22 +335,17 @@ pub fn main(args: std.process.Init.Minimal) void { // MARK: main()
 		std.log.warn("Cubyz detected it's running on Windows. For optimal performance and reduced power usage please install Linux.", .{});
 	}
 
-	{
+	argCheck: {
 		var argIterator = args.args.iterateAllocator(stackAllocator.allocator) catch |err| {
 			std.log.err("Failed to read command line arguments: {s}", .{@errorName(err)});
-			@panic("Failed to read command line arguments");
+			break :argCheck;
 		};
 		defer argIterator.deinit();
 		_ = argIterator.skip();
 		if (argIterator.next() != null) {
 			std.debug.print(
 				\\Cubyz does not accept any command line arguments.
-				\\All launch-time configuration is done through the "launchConfig.zon" file in the game's working directory. Supported fields:
-				\\  cubyzDir - Directory used to store game data and world saves.
-				\\  autoEnterWorld - Name of a world to automatically enter on startup.
-				\\  headlessServer - Set to true to run as a headless server.
-				\\  preferredAuthenticationAlgorithm - Key algorithm used for server authentication (e.g. ed25519).
-				\\  vulkanTestingMode - Set to true to enable experimental Vulkan testing mode.
+				\\All launch-time configuration is done through the "launchConfig.zon" file in the game's working directory. See that file for the available options.
 				\\
 			, .{});
 			return;

--- a/src/main.zig
+++ b/src/main.zig
@@ -340,9 +340,8 @@ pub fn main(args: std.process.Init.Minimal) void { // MARK: main()
 			std.log.info(
 				\\Cubyz does not accept any command line arguments.
 				\\All launch-time configuration is done through the "launchConfig.zon" file in the game's working directory. See that file for the available options.
-				\\
 			, .{});
-			return;
+			std.process.exit(0);
 		}
 	}
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -329,12 +329,6 @@ pub fn main(args: std.process.Init.Minimal) void { // MARK: main()
 	log.init();
 	defer log.deinit();
 
-	std.log.info("Starting game with version {s}", .{settings.version.version});
-
-	if (builtin.os.tag == .windows) {
-		std.log.warn("Cubyz detected it's running on Windows. For optimal performance and reduced power usage please install Linux.", .{});
-	}
-
 	argCheck: {
 		var argIterator = args.args.iterateAllocator(stackAllocator.allocator) catch |err| {
 			std.log.err("Failed to read command line arguments: {s}", .{@errorName(err)});
@@ -343,13 +337,19 @@ pub fn main(args: std.process.Init.Minimal) void { // MARK: main()
 		defer argIterator.deinit();
 		_ = argIterator.skip();
 		if (argIterator.next() != null) {
-			std.debug.print(
+			std.log.info(
 				\\Cubyz does not accept any command line arguments.
 				\\All launch-time configuration is done through the "launchConfig.zon" file in the game's working directory. See that file for the available options.
 				\\
 			, .{});
 			return;
 		}
+	}
+
+	std.log.info("Starting game with version {s}", .{settings.version.version});
+
+	if (builtin.os.tag == .windows) {
+		std.log.warn("Cubyz detected it's running on Windows. For optimal performance and reduced power usage please install Linux.", .{});
 	}
 
 	settings.environment.init(args.environ);

--- a/src/main.zig
+++ b/src/main.zig
@@ -335,6 +335,28 @@ pub fn main(args: std.process.Init.Minimal) void { // MARK: main()
 		std.log.warn("Cubyz detected it's running on Windows. For optimal performance and reduced power usage please install Linux.", .{});
 	}
 
+	{
+		var argIterator = args.args.iterateAllocator(stackAllocator.allocator) catch |err| {
+			std.log.err("Failed to read command line arguments: {s}", .{@errorName(err)});
+			@panic("Failed to read command line arguments");
+		};
+		defer argIterator.deinit();
+		_ = argIterator.skip();
+		if (argIterator.next() != null) {
+			std.debug.print(
+				\\Cubyz does not accept any command line arguments.
+				\\All launch-time configuration is done through the "launchConfig.zon" file in the game's working directory. Supported fields:
+				\\  cubyzDir - Directory used to store game data and world saves.
+				\\  autoEnterWorld - Name of a world to automatically enter on startup.
+				\\  headlessServer - Set to true to run as a headless server.
+				\\  preferredAuthenticationAlgorithm - Key algorithm used for server authentication (e.g. ed25519).
+				\\  vulkanTestingMode - Set to true to enable experimental Vulkan testing mode.
+				\\
+			, .{});
+			return;
+		}
+	}
+
 	settings.environment.init(args.environ);
 	settings.launchConfig.init();
 


### PR DESCRIPTION
This adds a check in `main()` where if any argument beyond the executable path is present, it prints a short message explaining that it takes no CLI arguments, lists the fields supported by `launchConfig.zon`, and exits before any further initialization instead of proceeding to launch.

Closes #3284