### PR TITLE
Add name field to Multiplayer menu

### DIFF
--- a/src/gui/windows/multiplayer.zig
+++ b/src/gui/windows/multiplayer.zig
@@ -1,10 +1,13 @@
 const std = @import("std");
 
 const main = @import("main");
+const settings = main.settings;
 const gui = main.gui;
 const GuiComponent = gui.GuiComponent;
 const GuiWindow = gui.GuiWindow;
 const Button = GuiComponent.Button;
+const Label = GuiComponent.Label;
+const TextInput = GuiComponent.TextInput;
 const VerticalList = GuiComponent.VerticalList;
 const Vec2f = main.vec.Vec2f;
 
@@ -12,17 +15,40 @@ pub var window = GuiWindow{
 	.contentSize = Vec2f{128, 256},
 };
 
+var nameEntry: *TextInput = undefined;
+
 const padding: f32 = 8;
 
-fn multiplayerSelection() void {
+fn applyName() void {
+	if (nameEntry.currentString.items.len > 500 or main.graphics.TextBuffer.Parser.countVisibleCharacters(nameEntry.currentString.items) > 50) {
+		std.log.err("Name is too long with {}/{} characters. Limits are 50/500", .{main.graphics.TextBuffer.Parser.countVisibleCharacters(nameEntry.currentString.items), nameEntry.currentString.items.len});
+		return;
+	}
+	if (std.mem.eql(u8, nameEntry.currentString.items, settings.playerName)) return;
+	main.globalAllocator.free(settings.playerName);
+	settings.playerName = main.globalAllocator.dupe(u8, nameEntry.currentString.items);
+	settings.save();
+}
+
+fn hostWorld() void {
+	applyName();
 	gui.windowlist.save_selection.mode = .multiplayer;
 	gui.closeWindow("save_selection");
 	gui.openWindow("save_selection");
 }
+
+fn joinServer() void {
+	applyName();
+	gui.openWindow("multiplayer_join");
+}
+
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
-	list.add(Button.initText(.{0, 0}, 128, "Host World", .{.onAction = .init(multiplayerSelection)}));
-	list.add(Button.initText(.{0, 0}, 128, "Join Server", .{.onAction = gui.openWindowCallback("multiplayer_join")}));
+	list.add(Label.init(.{0, 0}, 200, "Name:", .center));
+	nameEntry = TextInput.init(.{0, 0}, 200, 32, settings.playerName, .{.onNewline = .init(applyName)});
+	list.add(nameEntry);
+	list.add(Button.initText(.{0, 0}, 128, "Host World", .{.onAction = .init(hostWorld)}));
+	list.add(Button.initText(.{0, 0}, 128, "Join Server", .{.onAction = .init(joinServer)}));
 	list.finish(.center);
 	window.rootComponent = list.toComponent();
 	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));
@@ -30,6 +56,7 @@ pub fn onOpen() void {
 }
 
 pub fn onClose() void {
+	applyName();
 	if (window.rootComponent) |*comp| {
 		comp.deinit();
 	}

--- a/src/gui/windows/multiplayer.zig
+++ b/src/gui/windows/multiplayer.zig
@@ -56,7 +56,6 @@ pub fn onOpen() void {
 }
 
 pub fn onClose() void {
-	applyName();
 	if (window.rootComponent) |*comp| {
 		comp.deinit();
 	}

--- a/src/gui/windows/multiplayer.zig
+++ b/src/gui/windows/multiplayer.zig
@@ -1,13 +1,10 @@
 const std = @import("std");
 
 const main = @import("main");
-const settings = main.settings;
 const gui = main.gui;
 const GuiComponent = gui.GuiComponent;
 const GuiWindow = gui.GuiWindow;
 const Button = GuiComponent.Button;
-const Label = GuiComponent.Label;
-const TextInput = GuiComponent.TextInput;
 const VerticalList = GuiComponent.VerticalList;
 const Vec2f = main.vec.Vec2f;
 
@@ -15,40 +12,17 @@ pub var window = GuiWindow{
 	.contentSize = Vec2f{128, 256},
 };
 
-var nameEntry: *TextInput = undefined;
-
 const padding: f32 = 8;
 
-fn applyName() void {
-	if (nameEntry.currentString.items.len > 500 or main.graphics.TextBuffer.Parser.countVisibleCharacters(nameEntry.currentString.items) > 50) {
-		std.log.err("Name is too long with {}/{} characters. Limits are 50/500", .{main.graphics.TextBuffer.Parser.countVisibleCharacters(nameEntry.currentString.items), nameEntry.currentString.items.len});
-		return;
-	}
-	if (std.mem.eql(u8, nameEntry.currentString.items, settings.playerName)) return;
-	main.globalAllocator.free(settings.playerName);
-	settings.playerName = main.globalAllocator.dupe(u8, nameEntry.currentString.items);
-	settings.save();
-}
-
-fn hostWorld() void {
-	applyName();
+fn multiplayerSelection() void {
 	gui.windowlist.save_selection.mode = .multiplayer;
 	gui.closeWindow("save_selection");
 	gui.openWindow("save_selection");
 }
-
-fn joinServer() void {
-	applyName();
-	gui.openWindow("multiplayer_join");
-}
-
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
-	list.add(Label.init(.{0, 0}, 200, "Name:", .center));
-	nameEntry = TextInput.init(.{0, 0}, 200, 32, settings.playerName, .{.onNewline = .init(applyName)});
-	list.add(nameEntry);
-	list.add(Button.initText(.{0, 0}, 128, "Host World", .{.onAction = .init(hostWorld)}));
-	list.add(Button.initText(.{0, 0}, 128, "Join Server", .{.onAction = .init(joinServer)}));
+	list.add(Button.initText(.{0, 0}, 128, "Host World", .{.onAction = .init(multiplayerSelection)}));
+	list.add(Button.initText(.{0, 0}, 128, "Join Server", .{.onAction = gui.openWindowCallback("multiplayer_join")}));
 	list.finish(.center);
 	window.rootComponent = list.toComponent();
 	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));

--- a/src/gui/windows/multiplayer_join.zig
+++ b/src/gui/windows/multiplayer_join.zig
@@ -9,6 +9,7 @@ const gui = @import("../gui.zig");
 const GuiComponent = gui.GuiComponent;
 const GuiWindow = gui.GuiWindow;
 const Button = @import("../components/Button.zig");
+const HorizontalList = @import("../components/HorizontalList.zig");
 const Label = @import("../components/Label.zig");
 const TextInput = @import("../components/TextInput.zig");
 const VerticalList = @import("../components/VerticalList.zig");
@@ -88,9 +89,6 @@ fn copyIp() void {
 
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
-	list.add(Label.init(.{0, 0}, width, "Name:", .center));
-	nameEntry = TextInput.init(.{0, 0}, width, 32, settings.playerName, .{.onNewline = .init(applyName)});
-	list.add(nameEntry);
 	list.add(Label.init(.{0, 0}, width, "Please send your IP to the host of the game and enter the host's IP below.", .center));
 	//                                               255.255.255.255:?65536 (longest possible ip address)
 	ipAddressLabel = Label.init(.{0, 0}, width, "                      ", .center);
@@ -99,6 +97,13 @@ pub fn onOpen() void {
 	ipAddressEntry = TextInput.init(.{0, 0}, width, 32, settings.lastUsedIPAddress, .{.onNewline = .init(join)});
 	ipAddressEntry.obfuscated = main.settings.streamerMode;
 	list.add(ipAddressEntry);
+	const nameLabel = Label.init(.{0, 0}, 48, "Name:", .left);
+	nameEntry = TextInput.init(.{0, 0}, width - 48, 32, settings.playerName, .{.onNewline = .init(applyName)});
+	const nameRow = HorizontalList.init();
+	nameRow.add(nameLabel);
+	nameRow.add(nameEntry);
+	nameRow.finish(.{0, 0}, .center);
+	list.add(nameRow);
 	list.add(Button.initText(.{0, 0}, 100, "Join", .{.onAction = .init(join)}));
 	list.finish(.center);
 	window.rootComponent = list.toComponent();

--- a/src/gui/windows/multiplayer_join.zig
+++ b/src/gui/windows/multiplayer_join.zig
@@ -17,6 +17,7 @@ pub var window = GuiWindow{
 	.contentSize = Vec2f{128, 256},
 };
 
+var nameEntry: *TextInput = undefined;
 var ipAddressLabel: *Label = undefined;
 var ipAddressEntry: *TextInput = undefined;
 
@@ -46,7 +47,19 @@ fn discoverIpAddressFromNewThread() void {
 	discoverIpAddress();
 }
 
+fn applyName() void {
+	if (nameEntry.currentString.items.len > 500 or main.graphics.TextBuffer.Parser.countVisibleCharacters(nameEntry.currentString.items) > 50) {
+		std.log.err("Name is too long with {}/{} characters. Limits are 50/500", .{main.graphics.TextBuffer.Parser.countVisibleCharacters(nameEntry.currentString.items), nameEntry.currentString.items.len});
+		return;
+	}
+	if (std.mem.eql(u8, nameEntry.currentString.items, settings.playerName)) return;
+	main.globalAllocator.free(settings.playerName);
+	settings.playerName = main.globalAllocator.dupe(u8, nameEntry.currentString.items);
+	settings.save();
+}
+
 fn join() void {
+	applyName();
 	if (thread) |_thread| {
 		_thread.join();
 		thread = null;
@@ -75,6 +88,9 @@ fn copyIp() void {
 
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
+	list.add(Label.init(.{0, 0}, width, "Name:", .center));
+	nameEntry = TextInput.init(.{0, 0}, width, 32, settings.playerName, .{.onNewline = .init(applyName)});
+	list.add(nameEntry);
 	list.add(Label.init(.{0, 0}, width, "Please send your IP to the host of the game and enter the host's IP below.", .center));
 	//                                               255.255.255.255:?65536 (longest possible ip address)
 	ipAddressLabel = Label.init(.{0, 0}, width, "                      ", .center);


### PR DESCRIPTION
Adds a text field to the Multiplayer menu so players can change their display name right before hosting or joining a server, instead of having to back out to the Social panel first.

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/1654befe-3bed-463a-b403-fe423509cd0e" />

Reuses the same length validation and persistence logic as the existing Change Name window. The name is applied on Enter, when clicking "Host World" or "Join Server", and when the window is closed so no edit is lost.

Closes #3233