### PR TITLE
Move multiplayer connect off main thread

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -285,7 +285,7 @@ pub const World = struct { // MARK: World
 	shouldRestart: std.atomic.Value(bool) = .init(false),
 	shouldReload: bool = false,
 
-	pub fn connect(self: *World) !ZonElement {
+	fn connect(self: *World) !ZonElement {
 		main.heap.allocators.createWorldArena();
 		errdefer main.heap.allocators.destroyWorldArena();
 
@@ -360,6 +360,8 @@ pub const World = struct { // MARK: World
 	}
 
 	pub fn finishHandshake(self: *World, zon: ZonElement) !void {
+		self.conn.manager.world = self;
+		main.game.world = self;
 		errdefer main.heap.allocators.destroyWorldArena();
 		errdefer self.conn.deinit();
 		errdefer self.itemDrops.deinit();

--- a/src/game.zig
+++ b/src/game.zig
@@ -285,12 +285,7 @@ pub const World = struct { // MARK: World
 	shouldRestart: std.atomic.Value(bool) = .init(false),
 	shouldReload: bool = false,
 
-	pub fn init(self: *World, ip: []const u8, manager: *ConnectionManager) !void {
-		self.conn = try Connection.init(manager, ip, null);
-		self.manager = manager;
-		try self.@"continue"();
-	}
-	pub fn @"continue"(self: *World) !void {
+	pub fn connect(self: *World) !ZonElement {
 		main.heap.allocators.createWorldArena();
 		errdefer main.heap.allocators.destroyWorldArena();
 
@@ -308,12 +303,17 @@ pub const World = struct { // MARK: World
 		self.itemDrops.init(main.globalAllocator);
 		errdefer self.itemDrops.deinit();
 
-		const handshakeZon = try network.protocols.handShake.clientSide(self.conn, settings.playerName);
+		return try network.protocols.handShake.clientSide(self.conn, settings.playerName);
+	}
 
-		try self.finishHandshake(handshakeZon);
-		main.network.protocols.handShake.signalLoadedAssets();
+	pub fn init(self: *World, ip: []const u8, manager: *ConnectionManager) !ZonElement {
+		self.conn = try Connection.init(manager, ip, null);
+		self.manager = manager;
+		return try self.connect();
+	}
 
-		self.paused = false;
+	pub fn @"continue"(self: *World) !void {
+		try self.finishHandshake(try self.connect());
 	}
 
 	pub fn deinit(self: *World) void {
@@ -359,7 +359,11 @@ pub const World = struct { // MARK: World
 		main.heap.allocators.destroyWorldArena();
 	}
 
-	fn finishHandshake(self: *World, zon: ZonElement) !void {
+	pub fn finishHandshake(self: *World, zon: ZonElement) !void {
+		errdefer main.heap.allocators.destroyWorldArena();
+		errdefer self.conn.deinit();
+		errdefer self.itemDrops.deinit();
+
 		// TODO: Consider using a per-world allocator.
 		self.blockPalette = try assets.Palette.init(main.globalAllocator, zon.getChild("blockPalette"), "cubyz:air");
 		errdefer self.blockPalette.deinit();
@@ -390,6 +394,9 @@ pub const World = struct { // MARK: World
 		main.entityModel.loadModelsAndTexture();
 
 		try Player.loadFrom(zon.getChild("player"));
+		main.network.protocols.handShake.signalLoadedAssets();
+
+		self.paused = false;
 	}
 
 	pub fn update(self: *World, deltaTime: f64) void {

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -31,6 +31,7 @@ var windowList: ListManaged(*GuiWindow) = undefined;
 var hudWindows: ListManaged(*GuiWindow) = undefined;
 pub var openWindows: ListManaged(*GuiWindow) = undefined;
 var selectedWindow: ?*GuiWindow = null;
+var modalWindow: ?*GuiWindow = null;
 pub var selectedTextInput: ?*TextInput = null;
 var hoveredAWindow: bool = false;
 pub var reorderWindows: bool = false;
@@ -43,6 +44,7 @@ pub var hoveredItemSlot: ?*ItemSlot = null;
 const GuiCommandQueue = struct { // MARK: GuiCommandQueue
 	const Action = enum {
 		open,
+		openModal,
 		close,
 	};
 	const Command = struct {
@@ -70,6 +72,9 @@ const GuiCommandQueue = struct { // MARK: GuiCommandQueue
 				.open => {
 					executeOpenWindowCommand(command.window);
 				},
+				.openModal => {
+					executeOpenModalWindowCommand(command.window);
+				},
 				.close => {
 					executeCloseWindowCommand(command.window);
 				},
@@ -92,10 +97,20 @@ const GuiCommandQueue = struct { // MARK: GuiCommandQueue
 		selectedWindow = null;
 	}
 
+	fn executeOpenModalWindowCommand(window: *GuiWindow) void {
+		const alreadyOpen = std.mem.containsAtLeastScalar(*GuiWindow, openWindows.items, 1, window);
+		if (!alreadyOpen) setSelectedTextInput(null);
+		modalWindow = window;
+		executeOpenWindowCommand(window);
+	}
+
 	fn executeCloseWindowCommand(window: *GuiWindow) void {
 		defer updateWindowPositions();
 		if (selectedWindow == window) {
 			selectedWindow = null;
+		}
+		if (modalWindow == window) {
+			modalWindow = null;
 		}
 		for (openWindows.items, 0..) |_openWindow, i| {
 			if (_openWindow == window) {
@@ -327,6 +342,20 @@ pub fn openWindowFromRef(window: *GuiWindow) void {
 	GuiCommandQueue.scheduleCommand(.{.action = .open, .window = window});
 }
 
+pub fn openModalWindow(id: []const u8) void {
+	for (windowList.items) |window| {
+		if (std.mem.eql(u8, window.id, id)) {
+			openModalWindowFromRef(window);
+			return;
+		}
+	}
+	std.log.err("Could not find window with id {s}.", .{id});
+}
+
+pub fn openModalWindowFromRef(window: *GuiWindow) void {
+	GuiCommandQueue.scheduleCommand(.{.action = .openModal, .window = window});
+}
+
 pub fn toggleWindow(id: []const u8) void {
 	defer updateWindowPositions();
 	for (windowList.items) |window| {
@@ -471,6 +500,15 @@ pub fn mainButtonPressed(_: main.Window.Key.Modifiers) void {
 	setSelectedTextInput(null);
 	const mousePosition = main.Window.getMousePosition()/@as(Vec2f, @splat(scale));
 
+	if (modalWindow) |modal| {
+		if (@reduce(.And, mousePosition >= modal.pos) and @reduce(.And, mousePosition < modal.pos + modal.size)) {
+			if (modal.mainButtonPressed(mousePosition) == .handled) {
+				selectedWindow = modal;
+			}
+		}
+		return;
+	}
+
 	// reverse order of rendering, the last-rendered element is the first one that we should try to interact with
 	var i: usize = openWindows.items.len;
 	while (i > 0) {
@@ -495,6 +533,9 @@ pub fn mainButtonReleased(_: main.Window.Key.Modifiers) void {
 	const oldWindow = selectedWindow;
 	selectedWindow = null;
 	for (openWindows.items) |window| {
+		if (modalWindow) |modal| {
+			if (window != modal) continue;
+		}
 		var mousePosition = main.Window.getMousePosition()/@as(Vec2f, @splat(scale));
 		mousePosition -= window.pos;
 		if (@reduce(.And, mousePosition >= Vec2f{0, 0}) and @reduce(.And, mousePosition < window.size)) {
@@ -547,6 +588,9 @@ pub fn updateAndRenderGui() void {
 		while (i != 0) {
 			i -= 1;
 			const window: *GuiWindow = openWindows.items[i];
+			if (modalWindow) |modal| {
+				if (window != modal) continue;
+			}
 			if (GuiComponent.contains(window.pos, window.size, mousePos)) {
 				if (window.updateHovered(mousePos) == .handled) {
 					hoveredAWindow = true;
@@ -570,6 +614,11 @@ pub fn updateAndRenderGui() void {
 		const oldScale = draw.setScale(scale);
 		defer draw.restoreScale(oldScale);
 		for (openWindows.items) |window| {
+			if (modalWindow == window) {
+				const modalOldColor = draw.setColor(0x80000000);
+				draw.rect(.{0, 0}, main.Window.getWindowSize());
+				draw.restoreColor(modalOldColor);
+			}
 			window.render(mousePos);
 		}
 		inventory.render(mousePos);

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -616,8 +616,8 @@ pub fn updateAndRenderGui() void {
 		for (openWindows.items) |window| {
 			if (modalWindow == window) {
 				const modalOldColor = draw.setColor(0x80000000);
+				defer draw.restoreColor(modalOldColor);
 				draw.rect(.{0, 0}, main.Window.getWindowSize());
-				draw.restoreColor(modalOldColor);
 			}
 			window.render(mousePos);
 		}

--- a/src/gui/windows/_list.zig
+++ b/src/gui/windows/_list.zig
@@ -3,6 +3,7 @@ pub const change_name = @import("change_name.zig");
 pub const chat = @import("chat.zig");
 pub const chest = @import("chest.zig");
 pub const clipboard_deleted = @import("clipboard_deleted.zig");
+pub const connecting = @import("connecting.zig");
 pub const controls = @import("controls.zig");
 pub const creative_inventory = @import("creative_inventory.zig");
 pub const crosshair = @import("crosshair.zig");

--- a/src/gui/windows/connecting.zig
+++ b/src/gui/windows/connecting.zig
@@ -1,0 +1,129 @@
+const std = @import("std");
+
+const main = @import("main");
+const ConnectionManager = main.network.ConnectionManager;
+const settings = main.settings;
+const Vec2f = main.vec.Vec2f;
+
+const gui = @import("../gui.zig");
+const GuiWindow = gui.GuiWindow;
+const Button = @import("../components/Button.zig");
+const Label = @import("../components/Label.zig");
+const VerticalList = @import("../components/VerticalList.zig");
+
+pub var window = GuiWindow{
+	.contentSize = Vec2f{128, 64},
+	.hasBackground = true,
+	.closeable = false,
+};
+
+const padding: f32 = 8;
+const width: f32 = 280;
+
+const State = enum(u8) { connecting, connected, failed, cancelled };
+
+var connectionManager: ?*ConnectionManager = null;
+var ip: []const u8 = "";
+var connectFuture: ?std.Io.Future(void) = null;
+var handshakeZon: main.ZonElement = undefined;
+var state: std.atomic.Value(State) = .init(.connecting);
+var errorMessage: []const u8 = "";
+var statusLabel: *Label = undefined;
+
+fn connectFromNewThread() void {
+	main.initThreadLocals();
+	defer main.deinitThreadLocals();
+
+	handshakeZon = main.game.testWorld.init(ip, connectionManager.?) catch |err| {
+		if (err == error.Canceled) {
+			state.store(.cancelled, .release);
+		} else {
+			errorMessage = @errorName(err);
+			state.store(.failed, .release);
+		}
+		return;
+	};
+	state.store(.connected, .release);
+}
+
+pub fn start(_ip: []const u8, manager: *ConnectionManager) void {
+	ip = main.globalAllocator.dupe(u8, _ip);
+	connectionManager = manager;
+	state = .init(.connecting);
+	gui.openModalWindow("connecting");
+	connectFuture = main.io.concurrent(connectFromNewThread, .{}) catch |err| blk: {
+		std.log.err("Error spawning connect task: {s}. Doing it in the current thread instead.", .{@errorName(err)});
+		connectFromNewThread();
+		break :blk null;
+	};
+}
+
+fn cancel() void {
+	if (connectFuture) |*future| {
+		_ = future.cancel(main.io);
+		connectFuture = null;
+	}
+}
+
+pub fn onOpen() void {
+	const list = VerticalList.init(.{padding, 16 + padding}, width, 16);
+	statusLabel = Label.init(.{0, 0}, width, "Connecting...", .center);
+	list.add(statusLabel);
+	list.add(Button.initText(.{0, 0}, 100, "Cancel", .{.onAction = .init(cancel)}));
+	list.finish(.center);
+	window.rootComponent = list.toComponent();
+	window.contentSize = window.rootComponent.?.pos() + window.rootComponent.?.size() + @as(Vec2f, @splat(padding));
+	gui.updateWindowPositions();
+}
+
+pub fn onClose() void {
+	std.debug.assert(connectFuture == null);
+	if (ip.len != 0) {
+		main.globalAllocator.free(ip);
+		ip = "";
+	}
+	if (window.rootComponent) |*comp| {
+		comp.deinit();
+	}
+}
+
+pub fn update() void {
+	stateSwitch: switch (state.load(.acquire)) {
+		.connecting => {},
+		.connected => {
+			if (connectFuture) |*future| {
+				_ = future.await(main.io);
+				connectFuture = null;
+			}
+			main.game.testWorld.finishHandshake(handshakeZon) catch |err| {
+				errorMessage = @errorName(err);
+				state.store(.failed, .release);
+				continue :stateSwitch .failed;
+			};
+			connectionManager.?.world = &main.game.testWorld;
+			gui.closeWindowFromRef(&window);
+			main.game.world = &main.game.testWorld;
+			main.globalAllocator.free(settings.lastUsedIPAddress);
+			settings.lastUsedIPAddress = main.globalAllocator.dupe(u8, ip);
+			settings.save();
+			for (gui.openWindows.items) |openWindow| {
+				gui.closeWindowFromRef(openWindow);
+			}
+			gui.openHud();
+		},
+		.failed => {
+			if (connectFuture) |*future| {
+				_ = future.await(main.io);
+				connectFuture = null;
+			}
+			gui.closeWindowFromRef(&window);
+			gui.windowlist.multiplayer_join.restoreConnection(connectionManager.?);
+			main.gui.windowlist.notification.raiseNotification("Encountered error while opening world: {s}", .{errorMessage});
+			errorMessage = "";
+		},
+		.cancelled => {
+			gui.closeWindowFromRef(&window);
+			gui.windowlist.multiplayer_join.restoreConnection(connectionManager.?);
+		},
+	}
+}

--- a/src/gui/windows/connecting.zig
+++ b/src/gui/windows/connecting.zig
@@ -28,7 +28,6 @@ var connectFuture: ?std.Io.Future(void) = null;
 var handshakeZon: main.ZonElement = undefined;
 var state: std.atomic.Value(State) = .init(.connecting);
 var errorMessage: []const u8 = "";
-var statusLabel: *Label = undefined;
 
 fn connectFromNewThread() void {
 	main.initThreadLocals();
@@ -50,7 +49,7 @@ pub fn start(_ip: []const u8, manager: *ConnectionManager) void {
 	ip = main.globalAllocator.dupe(u8, _ip);
 	connectionManager = manager;
 	state = .init(.connecting);
-	gui.openModalWindow("connecting");
+	gui.openModalWindowFromRef(&window);
 	connectFuture = main.io.concurrent(connectFromNewThread, .{}) catch |err| blk: {
 		std.log.err("Error spawning connect task: {s}. Doing it in the current thread instead.", .{@errorName(err)});
 		connectFromNewThread();
@@ -67,8 +66,7 @@ fn cancel() void {
 
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, width, 16);
-	statusLabel = Label.init(.{0, 0}, width, "Connecting...", .center);
-	list.add(statusLabel);
+	list.add(Label.init(.{0, 0}, width, "Connecting...", .center));
 	list.add(Button.initText(.{0, 0}, 100, "Cancel", .{.onAction = .init(cancel)}));
 	list.finish(.center);
 	window.rootComponent = list.toComponent();
@@ -100,9 +98,7 @@ pub fn update() void {
 				state.store(.failed, .release);
 				continue :stateSwitch .failed;
 			};
-			connectionManager.?.world = &main.game.testWorld;
 			gui.closeWindowFromRef(&window);
-			main.game.world = &main.game.testWorld;
 			main.globalAllocator.free(settings.lastUsedIPAddress);
 			settings.lastUsedIPAddress = main.globalAllocator.dupe(u8, ip);
 			settings.save();

--- a/src/gui/windows/multiplayer_join.zig
+++ b/src/gui/windows/multiplayer_join.zig
@@ -56,28 +56,17 @@ fn join() void {
 		ipAddress = "";
 	}
 	if (connection) |_connection| {
-		_connection.world = &main.game.testWorld;
-		main.game.world = &main.game.testWorld;
 		std.log.info("Connecting to server: {s}", .{ipAddressEntry.currentString.items});
-		main.game.testWorld.init(ipAddressEntry.currentString.items, _connection) catch |err| {
-			std.log.err("Encountered error while opening world: {s}", .{@errorName(err)});
-			main.gui.windowlist.notification.raiseNotification("Encountered error while opening world: {s}", .{@errorName(err)});
-			main.game.world = null;
-			_connection.world = null;
-			return;
-		};
-		main.globalAllocator.free(settings.lastUsedIPAddress);
-		settings.lastUsedIPAddress = main.globalAllocator.dupe(u8, ipAddressEntry.currentString.items);
-		settings.save();
+		gui.windowlist.connecting.start(ipAddressEntry.currentString.items, _connection);
 		connection = null;
 	} else {
 		std.log.err("No connection found. Cannot connect.", .{});
 		main.gui.windowlist.notification.raiseNotification("No connection found. Cannot connect.", .{});
 	}
-	for (gui.openWindows.items) |openWindow| {
-		gui.closeWindowFromRef(openWindow);
-	}
-	gui.openHud();
+}
+
+pub fn restoreConnection(manager: *ConnectionManager) void {
+	connection = manager;
 }
 
 fn copyIp() void {

--- a/src/gui/windows/save_selection.zig
+++ b/src/gui/windows/save_selection.zig
@@ -77,8 +77,6 @@ pub fn openWorld(name: []const u8) void {
 		std.log.err("Encountered error while opening world: {s}", .{@errorName(err)});
 		return;
 	};
-	clientConnection.world = &main.game.testWorld;
-	main.game.world = &main.game.testWorld;
 	for (gui.openWindows.items) |openWindow| {
 		gui.closeWindowFromRef(openWindow);
 	}

--- a/src/gui/windows/save_selection.zig
+++ b/src/gui/windows/save_selection.zig
@@ -67,13 +67,18 @@ pub fn openWorld(name: []const u8) void {
 		main.io.sleep(.fromMilliseconds(1), .awake) catch {};
 		main.heap.GarbageCollection.syncPoint();
 	}
-	clientConnection.world = &main.game.testWorld;
 	const ipPort = std.fmt.allocPrint(main.stackAllocator.allocator, "127.0.0.1:{}", .{main.server.connectionManager.localPort}) catch unreachable;
 	defer main.stackAllocator.free(ipPort);
-	main.game.world = &main.game.testWorld;
-	main.game.testWorld.init(ipPort, clientConnection) catch |err| {
+	const zon = main.game.testWorld.init(ipPort, clientConnection) catch |err| {
 		std.log.err("Encountered error while opening world: {s}", .{@errorName(err)});
+		return;
 	};
+	main.game.testWorld.finishHandshake(zon) catch |err| {
+		std.log.err("Encountered error while opening world: {s}", .{@errorName(err)});
+		return;
+	};
+	clientConnection.world = &main.game.testWorld;
+	main.game.world = &main.game.testWorld;
 	for (gui.openWindows.items) |openWindow| {
 		gui.closeWindowFromRef(openWindow);
 	}

--- a/src/network.zig
+++ b/src/network.zig
@@ -1322,7 +1322,8 @@ pub const Connection = struct { // MARK: Connection
 				const result = c.mbedtls_ssl_handshake(&self.sslContext);
 				self.mutex.unlock();
 				if (result == c.MBEDTLS_ERR_SSL_WANT_READ) {
-					main.io.sleep(.fromMilliseconds(10), .awake) catch {};
+					main.heap.GarbageCollection.syncPoint();
+					try main.io.sleep(.fromMilliseconds(10), .awake);
 					continue;
 				}
 				try checkResult(result, "mbedtls_ssl_handshake");
@@ -1927,7 +1928,9 @@ pub const Connection = struct { // MARK: Connection
 			main.server.disconnect(user);
 		} else {
 			self.handShakeWaiting.broadcast();
-			main.exitToMenu();
+			if (self.handShakeState.load(.monotonic) == .complete) {
+				main.exitToMenu();
+			}
 		}
 		std.log.info("Disconnected", .{});
 	}

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -270,16 +270,19 @@ pub const handShake = struct { // MARK: handShake
 			else => unreachable,
 		}
 
-		conn.mutex.lock();
-		while (true) {
-			conn.handShakeWaiting.timedWait(&conn.mutex, .fromMilliseconds(16)) catch {
-				main.heap.GarbageCollection.syncPoint();
-				continue;
-			};
-			break;
+		{
+			conn.mutex.lock();
+			defer conn.mutex.unlock();
+			while (true) {
+				try main.io.checkCancel();
+				conn.handShakeWaiting.timedWait(&conn.mutex, .fromMilliseconds(16)) catch {
+					main.heap.GarbageCollection.syncPoint();
+					continue;
+				};
+				break;
+			}
+			if (conn.connectionState.load(.monotonic) == .disconnected) return error.DisconnectedByServer;
 		}
-		if (conn.connectionState.load(.monotonic) == .disconnected) return error.DisconnectedByServer;
-		conn.mutex.unlock();
 
 		return handshakeZon;
 	}


### PR DESCRIPTION
Moves the connect attempt off the main thread and onto a background thread, with a new "Connecting..." window shown while it runs.

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/21135017-0ea7-4eae-a3b2-701502e697d8" />

Adds a Cancel button on that window that flags the background thread to bail out via a shared `cancelRequested` atomic, checked in both the TLS handshake retry loop and the handshake wait loop, where it could get blocked against an unresponsive server.

Cancelling or failing a join attempt stays on the Join screen instead of jumping to the main menu. `connecting.zig` restores the `ConnectionManager` via `multiplayer_join.restoreConnection()` on both the `.failed` and `.cancelled` paths. The background connect thread calls `GarbageCollection.syncPoint()` while spinning in the TLS retry loop.

Split the GPU-uploading `finishHandshake()` tail out into a new `World.finishGpuUpload()`, called on the main thread after a successful `init()`: from `connecting.zig`'s `.success` branch for multiplayer, and from `save_selection.zig`'s success path for singleplayer or hosting (which still is synchronous but would otherwise have lost its GPU upload).

Fixes #2726