### PR TITLE
Shader includes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       - run: zig build -Dtarget=aarch64-linux-gnu
       - run: zig build -Dtarget=aarch64-windows-gnu
       - run: zig build test
-      - run: find assets/cubyz/shaders -type f | xargs -L1 glslangValidator -G100
+      - run: find assets/cubyz/shaders -type f ! -name "*.glsl" | xargs -L1 glslangValidator -G100 -P"#extension GL_GOOGLE_include_directive : enable" -Iassets/cubyz/shaders/include

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       - run: zig build -Dtarget=aarch64-linux-gnu
       - run: zig build -Dtarget=aarch64-windows-gnu
       - run: zig build test
-      - run: find assets/cubyz/shaders -type f ! -name "*.glsl" | xargs -L1 glslangValidator -G100 -P"#extension GL_GOOGLE_include_directive : enable" -Iassets/cubyz/shaders/include
+      - run: 'find assets/cubyz/shaders -type f ! -name "*.glsl" | xargs -L1 glslangValidator -G100 -P"#extension GL_GOOGLE_include_directive : enable" -Iassets/cubyz/shaders/include'

--- a/assets/cubyz/shaders/chunks/chunk_vertex.vert
+++ b/assets/cubyz/shaders/chunks/chunk_vertex.vert
@@ -47,24 +47,7 @@ layout(std430, binding = 10) buffer _lightData
 	uint lightData[];
 };
 
-struct ChunkData {
-	ivec4 position;
-	vec4 minPos;
-	vec4 maxPos;
-	int voxelSize;
-	uint lightStart;
-	uint vertexStartOpaque;
-	uint faceCountsByNormalOpaque[14];
-	uint vertexStartTransparent;
-	uint vertexCountTransparent;
-	uint visibilityState;
-	uint oldVisibilityState;
-};
-
-layout(std430, binding = 6) buffer _chunks
-{
-	ChunkData chunks[];
-};
+#include "chunk_data.glsl"
 
 vec3 square(vec3 x) {
 	return x*x;

--- a/assets/cubyz/shaders/chunks/fillIndirectBuffer.comp
+++ b/assets/cubyz/shaders/chunks/fillIndirectBuffer.comp
@@ -7,23 +7,8 @@ struct AnimationData {
 	uint time;
 };
 
-struct ChunkData {
-	ivec4 position;
-	vec4 minPos;
-	vec4 maxPos;
-	int voxelSize;
-	uint lightStart;
-	uint vertexStartOpaque;
-	uint faceCountsByNormalOpaque[14];
-	uint vertexStartTransparent;
-	uint vertexCountTransparent;
-	uint visibilityState;
-	uint oldVisibilityState;
-};
-layout(std430, binding = 6) buffer _chunks
-{
-	ChunkData chunks[];
-};
+#include "chunk_data.glsl"
+
 struct DrawElementsIndirectCommand {
 	uint  count;
 	uint  instanceCount;

--- a/assets/cubyz/shaders/chunks/occlusionTestFragment.frag
+++ b/assets/cubyz/shaders/chunks/occlusionTestFragment.frag
@@ -4,24 +4,7 @@ layout(early_fragment_tests) in;
 
 layout(location = 0) flat in uint chunkID;
 
-struct ChunkData {
-	ivec4 position;
-	vec4 minPos;
-	vec4 maxPos;
-	int voxelSize;
-	uint lightStart;
-	uint vertexStartOpaque;
-	uint faceCountsByNormalOpaque[14];
-	uint vertexStartTransparent;
-	uint vertexCountTransparent;
-	uint visibilityState;
-	uint oldVisibilityState;
-};
-
-layout(std430, binding = 6) buffer _chunks
-{
-	ChunkData chunks[];
-};
+#include "chunk_data.glsl"
 
 void main() {
 	chunks[chunkID].visibilityState = 1;

--- a/assets/cubyz/shaders/chunks/occlusionTestVertex.vert
+++ b/assets/cubyz/shaders/chunks/occlusionTestVertex.vert
@@ -2,24 +2,8 @@
 
 layout(location = 0) flat out uint chunkID;
 
-struct ChunkData {
-	ivec4 position;
-	vec4 minPos;
-	vec4 maxPos;
-	int voxelSize;
-	uint lightStart;
-	uint vertexStartOpaque;
-	uint faceCountsByNormalOpaque[14];
-	uint vertexStartTransparent;
-	uint vertexCountTransparent;
-	uint visibilityState;
-	uint oldVisibilityState;
-};
+#include "chunk_data.glsl"
 
-layout(std430, binding = 6) buffer _chunks
-{
-	ChunkData chunks[];
-};
 layout(std430, binding = 9) buffer _chunkIDs
 {
 	uint chunkIDs[];

--- a/assets/cubyz/shaders/include/chunk_data.glsl
+++ b/assets/cubyz/shaders/include/chunk_data.glsl
@@ -1,0 +1,18 @@
+struct ChunkData {
+	ivec4 position;
+	vec4 minPos;
+	vec4 maxPos;
+	int voxelSize;
+	uint lightStart;
+	uint vertexStartOpaque;
+	uint faceCountsByNormalOpaque[14];
+	uint vertexStartTransparent;
+	uint vertexCountTransparent;
+	uint visibilityState;
+	uint oldVisibilityState;
+};
+
+layout(std430, binding = 6) buffer _chunks
+{
+	ChunkData chunks[];
+};

--- a/src/graphics/pipelines.zig
+++ b/src/graphics/pipelines.zig
@@ -72,11 +72,64 @@ const Shader = struct { // MARK: Shader
 		return result;
 	}
 
-	fn addShader(self: *const Shader, filename: []const u8, defines: []const u8, shaderStage: c_uint) !void {
-		const source = main.files.cwd().read(main.stackAllocator, filename) catch |err| {
+	fn loadShaderFile(allocator: main.heap.NeverFailingAllocator, filename: []const u8, defines: []const u8) ![]const u8 {
+		var result: main.ListManaged(u8) = .init(allocator);
+		errdefer result.deinit();
+
+		const arena = main.stackAllocator.createArena();
+		defer main.stackAllocator.destroyArena(arena);
+
+		const includePaths: [3]?[]const u8 = .{
+			blk: {
+				const end = std.mem.findScalarLast(u8, filename, '/') orelse break :blk null;
+				break :blk filename[0..end];
+			},
+			blk: {
+				const end = std.mem.find(u8, filename, "/shaders/") orelse break :blk null;
+				break :blk std.fmt.allocPrint(arena.allocator, "{s}/shaders/include", .{filename[0..end]}) catch unreachable;
+			},
+			"assets/cubyz/shaders/include",
+		};
+
+		var source = main.files.cwd().read(arena, filename) catch |err| {
 			std.log.err("Couldn't read shader file: {s}", .{filename});
 			return err;
 		};
+
+		const versionLineEnd = if (std.mem.indexOfScalar(u8, source, '\n')) |len| len + 1 else 0;
+		result.appendSlice(source[0..versionLineEnd]);
+		result.appendSlice(defines);
+
+		var includeIterator = std.mem.splitSequence(u8, source[versionLineEnd..], "#include");
+		result.appendSlice(includeIterator.first());
+		while (includeIterator.next()) |next_| {
+			var next = next_;
+			while (next[0] == ' ') next = next[1..];
+			if (next[0] != '"') return error.MalformedInclude;
+			next = next[1..];
+			const includeEnd = std.mem.findScalar(u8, next, '"') orelse return error.MalformedInclude;
+			const includeFilename = next[0..includeEnd];
+			next = next[includeEnd + 1 ..];
+
+			for (includePaths) |includePath| {
+				const fullPath = std.fmt.allocPrint(main.stackAllocator.allocator, "{s}/{s}", .{includePath orelse continue, includeFilename}) catch unreachable;
+				defer main.stackAllocator.free(fullPath);
+				if (main.files.cwd().hasFile(fullPath)) {
+					const code = try loadShaderFile(main.stackAllocator, fullPath, &.{});
+					defer main.stackAllocator.free(code);
+					result.appendSlice(code);
+					break;
+				}
+			}
+
+			result.appendSlice(next);
+		}
+
+		return result.toOwnedSlice();
+	}
+
+	fn addShader(self: *const Shader, filename: []const u8, defines: []const u8, shaderStage: c_uint) !void {
+		const source = try loadShaderFile(main.stackAllocator, filename, defines);
 		defer main.stackAllocator.free(source);
 
 		const shader = c.glCreateShader(shaderStage);
@@ -152,10 +205,7 @@ const Shader = struct { // MARK: Shader
 	}
 
 	fn createShaderModule(path: []const u8, defines: []const u8, stage: ShaderStage) !c.VkShaderModule {
-		const source = main.files.cwd().read(main.stackAllocator, path) catch |err| {
-			std.log.err("Couldn't read shader file: {s}", .{path});
-			return err;
-		};
+		const source = try loadShaderFile(main.stackAllocator, path, defines);
 		defer main.stackAllocator.free(source);
 
 		const spirv = try compileToSpirV(main.stackAllocator, source, path, defines, stage);


### PR DESCRIPTION
This is done in our code since OpenGL's driver support is rather lacking.
Also I found the required extension naming `#extension GL_ARB_shading_language_include : require` rather annoying which comes which comes with other parsers, so I omitted it here. Furthermore my VSCode extension for glsl does not properly support includes whether they have it or not.

Here I implemented includes for chunk data as an example.

fixes #105
required for #3335