### PR TITLE
Make map generation 12% faster.

### DIFF
--- a/sdasdas
+++ b/sdasdas
@@ -1,2 +1,0 @@
-* [32mlayer-split[m 3c6a567f [[34morigin/layer-split[m] Refactor take 3
-  master     [m c4cf9ec8 [[34mupstream/master[m] Change source for commands from User to Source (#3223)

--- a/sdasdas
+++ b/sdasdas
@@ -1,0 +1,2 @@
+* [32mlayer-split[m 3c6a567f [[34morigin/layer-split[m] Refactor take 3
+  master     [m c4cf9ec8 [[34mupstream/master[m] Change source for commands from User to Source (#3223)

--- a/src/server/terrain/cave_layers.zig
+++ b/src/server/terrain/cave_layers.zig
@@ -17,6 +17,7 @@ pub const CaveLayer = struct {
 
 	biomes: main.utils.AliasTable(*const Biome),
 	id: []const u8,
+	tags: []const Tag,
 
 	pub fn init(id: []const u8, zon: ZonElement) ?CaveLayer {
 		var result: CaveLayer = undefined;
@@ -31,8 +32,8 @@ pub const CaveLayer = struct {
 		result.caveDensity = zon.get(f32, "caveDensity") orelse 1.0/32.0;
 		result.id = main.worldArena.dupe(u8, id);
 
-		const tags = Tag.loadTagsFromZon(main.stackAllocator, zon.getChild("tags"));
-		defer main.stackAllocator.free(tags);
+		const tags = Tag.loadTagsFromZon(main.worldArena, zon.getChild("tags"));
+		result.tags = tags;
 		if (tags.len == 0) {
 			std.log.err("Cave layer with id {s} is missing tags. Skipping", .{id});
 			return null;
@@ -43,30 +44,6 @@ pub const CaveLayer = struct {
 				return null;
 			}
 		}
-		var biomes: main.List(*const Biome) = .empty;
-		defer biomes.deinit(main.stackAllocator);
-		outer: for (terrain.biomes.getCaveBiomes()) |*biome| {
-			for (tags) |tag| {
-				if (biome.hasTag(tag)) {
-					biomes.append(main.stackAllocator, biome);
-					continue :outer;
-				}
-			}
-		}
-
-		if (biomes.items.len == 0) {
-			std.log.err("Cave layer with id {s} has no biomes that match the provided tags. Skipping", .{id});
-			return null;
-		}
-		for (biomes.items) |biome| {
-			if (biome.minHeight == std.math.minInt(i32) and biome.maxHeight == std.math.maxInt(i32) and biome.chance != 0) break;
-		} else {
-			std.log.err("Cave layer with id {s} has no biomes with unbounded height. At least one biome with unbounded height must exist to ensure compatibility with other addons. Skipping", .{id});
-			return null;
-		}
-
-		result.biomes = .init(main.worldArena, main.worldArena.dupe(*const Biome, biomes.items));
-
 		return result;
 	}
 };
@@ -111,10 +88,11 @@ pub fn registerCaveLayers(caveLayerMap: *Assets.ZonHashMap) !void {
 	var newLayers: main.List(CaveLayer) = .empty;
 
 	for (caveLayers.items) |layer| {
-		const split = splitLayer(main.worldArena, layer);
-
-		for (split.items) |newLayer| {
-			newLayers.append(main.worldArena, newLayer);
+		const splitLayers = splitLayer(main.worldArena, layer);
+		if (splitLayers) |layers| {
+			for (layers.items) |newLayer| {
+				newLayers.append(main.worldArena, newLayer);
+			}
 		}
 	}
 
@@ -126,10 +104,32 @@ pub fn registerCaveLayers(caveLayerMap: *Assets.ZonHashMap) !void {
 	}
 }
 
-fn splitLayer(allocator: NeverFailingAllocator, layer: CaveLayer) main.List(CaveLayer) {
+fn splitLayer(allocator: NeverFailingAllocator, layer: CaveLayer) ?main.List(CaveLayer) {
+	var possibleBiomes: main.List(*const Biome) = .empty;
+	defer possibleBiomes.deinit(main.stackAllocator);
+	outer: for (terrain.biomes.getCaveBiomes()) |*biome| {
+		for (layer.tags) |tag| {
+			if (biome.hasTag(tag)) {
+				possibleBiomes.append(main.stackAllocator, biome);
+				continue :outer;
+			}
+		}
+	}
+
+	if (possibleBiomes.items.len == 0) {
+		std.log.err("Cave layer with id {s} has no biomes that match the provided tags. Skipping", .{layer.id});
+		return null;
+	}
+	for (possibleBiomes.items) |biome| {
+		if (biome.minHeight == std.math.minInt(i32) and biome.maxHeight == std.math.maxInt(i32) and biome.chance != 0) break;
+	} else {
+		std.log.err("Cave layer with id {s} has no biomes with unbounded height. At least one biome with unbounded height must exist to ensure compatibility with other addons. Skipping", .{layer.id});
+		return null;
+	}
+
 	var splitPoints: main.List(i32) = .empty;
 	defer splitPoints.deinit(main.stackAllocator);
-	for (layer.biomes.items) |biome| {
+	for (possibleBiomes.items) |biome| {
 		if (biome.maxHeight > layer.minHeight and biome.maxHeight < layer.maxHeight) {
 			splitPoints.append(main.stackAllocator, biome.maxHeight);
 		}
@@ -155,13 +155,14 @@ fn splitLayer(allocator: NeverFailingAllocator, layer: CaveLayer) main.List(Cave
 	while (i <= splitPoints.items.len) : (i += 1) {
 		const point = if (i < splitPoints.items.len) splitPoints.items[i] else layer.maxHeight;
 		var biomes: main.List(*const Biome) = .empty;
-		for (layer.biomes.items) |biome| {
+		for (possibleBiomes.items) |biome| {
 			if (biome.maxHeight >= point and biome.minHeight <= lastPoint) {
 				biomes.append(allocator, biome);
 			}
 		}
 
 		newLayers.append(allocator, CaveLayer{
+			.tags = layer.tags,
 			.biomes = main.utils.AliasTable(*const Biome).init(allocator, biomes.toOwnedSlice(allocator)),
 			.caveDensity = layer.caveDensity,
 			.id = layer.id,

--- a/src/server/terrain/cave_layers.zig
+++ b/src/server/terrain/cave_layers.zig
@@ -111,15 +111,14 @@ pub fn registerCaveLayers(caveLayerMap: *Assets.ZonHashMap) !void {
 	var newLayers: main.List(CaveLayer) = .empty;
 
 	for (caveLayers.items) |layer| {
-		var split = splitLayer(layer);
-		defer split.deinit(main.worldArena);
+		var split = splitLayer(main.stackAllocator, layer);
+		defer split.deinit(main.stackAllocator);
 
 		for (split.items) |newLayer| {
 			newLayers.append(main.worldArena, newLayer);
 		}
 	}
 
-	caveLayers.deinit(main.worldArena);
 	caveLayers = newLayers;
 
 	std.log.debug("Registered cave layers:", .{});
@@ -128,15 +127,15 @@ pub fn registerCaveLayers(caveLayerMap: *Assets.ZonHashMap) !void {
 	}
 }
 
-fn splitLayer(layer: CaveLayer) main.List(CaveLayer) {
+fn splitLayer(allocator: NeverFailingAllocator, layer: CaveLayer) main.List(CaveLayer) {
 	var splitPoints: main.List(i32) = .empty;
 	defer splitPoints.deinit(main.stackAllocator);
 	for (layer.biomes.items) |biome| {
-		if (biome.*.maxHeight > layer.minHeight and biome.*.maxHeight < layer.maxHeight) {
-			splitPoints.append(main.stackAllocator, biome.*.maxHeight);
+		if (biome.maxHeight > layer.minHeight and biome.maxHeight < layer.maxHeight) {
+			splitPoints.append(main.stackAllocator, biome.maxHeight);
 		}
-		if (biome.*.minHeight < layer.maxHeight and biome.*.minHeight > layer.minHeight) {
-			splitPoints.append(main.stackAllocator, biome.*.minHeight);
+		if (biome.minHeight < layer.maxHeight and biome.minHeight > layer.minHeight) {
+			splitPoints.append(main.stackAllocator, biome.minHeight);
 		}
 	}
 	std.mem.sort(i32, splitPoints.items, {}, comptime std.sort.asc(i32));
@@ -159,12 +158,12 @@ fn splitLayer(layer: CaveLayer) main.List(CaveLayer) {
 		var biomes: main.List(*const Biome) = .empty;
 		for (layer.biomes.items) |biome| {
 			if (biome.maxHeight >= point and biome.minHeight <= lastPoint) {
-				biomes.append(main.worldArena, biome);
+				biomes.append(main.stackAllocator, biome);
 			}
 		}
 
-		newLayers.append(main.worldArena, CaveLayer{
-			.biomes = main.utils.AliasTable(*const Biome).init(main.worldArena, biomes.items),
+		newLayers.append(allocator, CaveLayer{
+			.biomes = main.utils.AliasTable(*const Biome).init(allocator, biomes.items.toOwnedSlice(main.worldArena)),
 			.caveDensity = layer.caveDensity,
 			.id = layer.id,
 			.layerHeight = point - lastPoint,

--- a/src/server/terrain/cave_layers.zig
+++ b/src/server/terrain/cave_layers.zig
@@ -107,10 +107,77 @@ pub fn registerCaveLayers(caveLayerMap: *Assets.ZonHashMap) !void {
 		height -= caveLayers.items[i].layerHeight;
 		caveLayers.items[i].minHeight = height;
 	}
+
+	var newLayers: main.List(CaveLayer) = .empty;
+
+	for (caveLayers.items) |layer| {
+		var split = splitLayer(layer);
+		defer split.deinit(main.worldArena);
+
+		for (split.items) |newLayer| {
+			newLayers.append(main.worldArena, newLayer);
+		}
+	}
+
+	caveLayers.deinit(main.worldArena);
+	caveLayers = newLayers;
+
 	std.log.debug("Registered cave layers:", .{});
 	for (caveLayers.items) |caveLayer| {
 		std.log.debug("{s}: {} to {}", .{caveLayer.id, caveLayer.minHeight, caveLayer.maxHeight});
 	}
+}
+
+fn splitLayer(layer: CaveLayer) main.List(CaveLayer) {
+	var splitPoints: main.List(i32) = .empty;
+	defer splitPoints.deinit(main.stackAllocator);
+	for (layer.biomes.items) |biome| {
+		if (biome.*.maxHeight > layer.minHeight and biome.*.maxHeight < layer.maxHeight) {
+			splitPoints.append(main.stackAllocator, biome.*.maxHeight);
+		}
+		if (biome.*.minHeight < layer.maxHeight and biome.*.minHeight > layer.minHeight) {
+			splitPoints.append(main.stackAllocator, biome.*.minHeight);
+		}
+	}
+	std.mem.sort(i32, splitPoints.items, {}, comptime std.sort.asc(i32));
+	// Remove duplicates in place
+	var write: usize = 0;
+	for (splitPoints.items) |value| {
+		if (write == 0 or splitPoints.items[write - 1] != value) {
+			splitPoints.items[write] = value;
+			write += 1;
+		}
+	}
+	splitPoints.shrinkAndFree(main.stackAllocator, write);
+	splitPoints.items.len = write;
+
+	var newLayers: main.List(CaveLayer) = .empty;
+	var lastPoint: i32 = layer.minHeight;
+	var i: usize = 0;
+	while (i <= splitPoints.items.len) : (i += 1) {
+		const point = if (i < splitPoints.items.len) splitPoints.items[i] else layer.maxHeight;
+		var biomes: main.List(*const Biome) = .empty;
+		for (layer.biomes.items) |biome| {
+			if (biome.maxHeight > point and biome.minHeight < lastPoint) {
+				biomes.append(main.worldArena, biome);
+			}
+			if (biome.maxHeight == point and biome.minHeight == lastPoint) {
+				biomes.append(main.worldArena, biome);
+			}
+		}
+
+		newLayers.append(main.worldArena, CaveLayer{
+			.biomes = main.utils.AliasTable(*const Biome).init(main.worldArena, biomes.items),
+			.caveDensity = layer.caveDensity,
+			.id = layer.id,
+			.layerHeight = point - lastPoint,
+			.depthHint = layer.depthHint,
+			.minHeight = lastPoint,
+			.maxHeight = point,
+		});
+		lastPoint = point;
+	}
+	return newLayers;
 }
 
 fn lessThan(_: void, lhs: CaveLayer, rhs: CaveLayer) bool {

--- a/src/server/terrain/cave_layers.zig
+++ b/src/server/terrain/cave_layers.zig
@@ -125,9 +125,6 @@ pub fn registerCaveLayers(caveLayerMap: *Assets.ZonHashMap) !void {
 	std.log.debug("Registered cave layers:", .{});
 	for (caveLayers.items) |caveLayer| {
 		std.log.debug("{s}: {} to {}", .{caveLayer.id, caveLayer.minHeight, caveLayer.maxHeight});
-		for (caveLayer.biomes.items) |biome| {
-			std.log.debug("     {s}: {} to {}", .{biome.id, biome.minHeight, biome.maxHeight});
-		}
 	}
 }
 

--- a/src/server/terrain/cave_layers.zig
+++ b/src/server/terrain/cave_layers.zig
@@ -111,8 +111,7 @@ pub fn registerCaveLayers(caveLayerMap: *Assets.ZonHashMap) !void {
 	var newLayers: main.List(CaveLayer) = .empty;
 
 	for (caveLayers.items) |layer| {
-		var split = splitLayer(main.stackAllocator, layer);
-		defer split.deinit(main.stackAllocator);
+		const split = splitLayer(main.worldArena, layer);
 
 		for (split.items) |newLayer| {
 			newLayers.append(main.worldArena, newLayer);
@@ -158,12 +157,12 @@ fn splitLayer(allocator: NeverFailingAllocator, layer: CaveLayer) main.List(Cave
 		var biomes: main.List(*const Biome) = .empty;
 		for (layer.biomes.items) |biome| {
 			if (biome.maxHeight >= point and biome.minHeight <= lastPoint) {
-				biomes.append(main.stackAllocator, biome);
+				biomes.append(allocator, biome);
 			}
 		}
 
 		newLayers.append(allocator, CaveLayer{
-			.biomes = main.utils.AliasTable(*const Biome).init(allocator, biomes.items.toOwnedSlice(main.worldArena)),
+			.biomes = main.utils.AliasTable(*const Biome).init(allocator, biomes.toOwnedSlice(allocator)),
 			.caveDensity = layer.caveDensity,
 			.id = layer.id,
 			.layerHeight = point - lastPoint,

--- a/src/server/terrain/cave_layers.zig
+++ b/src/server/terrain/cave_layers.zig
@@ -125,6 +125,9 @@ pub fn registerCaveLayers(caveLayerMap: *Assets.ZonHashMap) !void {
 	std.log.debug("Registered cave layers:", .{});
 	for (caveLayers.items) |caveLayer| {
 		std.log.debug("{s}: {} to {}", .{caveLayer.id, caveLayer.minHeight, caveLayer.maxHeight});
+		for (caveLayer.biomes.items) |biome| {
+			std.log.debug("     {s}: {} to {}", .{biome.id, biome.minHeight, biome.maxHeight});
+		}
 	}
 }
 
@@ -158,10 +161,7 @@ fn splitLayer(layer: CaveLayer) main.List(CaveLayer) {
 		const point = if (i < splitPoints.items.len) splitPoints.items[i] else layer.maxHeight;
 		var biomes: main.List(*const Biome) = .empty;
 		for (layer.biomes.items) |biome| {
-			if (biome.maxHeight > point and biome.minHeight < lastPoint) {
-				biomes.append(main.worldArena, biome);
-			}
-			if (biome.maxHeight == point and biome.minHeight == lastPoint) {
+			if (biome.maxHeight >= point and biome.minHeight <= lastPoint) {
 				biomes.append(main.worldArena, biome);
 			}
 		}

--- a/src/server/terrain/cave_layers.zig
+++ b/src/server/terrain/cave_layers.zig
@@ -17,7 +17,6 @@ pub const CaveLayer = struct {
 
 	biomes: main.utils.AliasTable(*const Biome),
 	id: []const u8,
-	tags: []const Tag,
 
 	pub fn init(id: []const u8, zon: ZonElement) ?CaveLayer {
 		var result: CaveLayer = undefined;
@@ -32,8 +31,8 @@ pub const CaveLayer = struct {
 		result.caveDensity = zon.get(f32, "caveDensity") orelse 1.0/32.0;
 		result.id = main.worldArena.dupe(u8, id);
 
-		const tags = Tag.loadTagsFromZon(main.worldArena, zon.getChild("tags"));
-		result.tags = tags;
+		const tags = Tag.loadTagsFromZon(main.stackAllocator, zon.getChild("tags"));
+		defer main.stackAllocator.free(tags);
 		if (tags.len == 0) {
 			std.log.err("Cave layer with id {s} is missing tags. Skipping", .{id});
 			return null;
@@ -44,6 +43,28 @@ pub const CaveLayer = struct {
 				return null;
 			}
 		}
+		var biomes: main.List(*const Biome) = .empty;
+		defer biomes.deinit(main.stackAllocator);
+		outer: for (terrain.biomes.getCaveBiomes()) |*biome| {
+			for (tags) |tag| {
+				if (biome.hasTag(tag)) {
+					biomes.append(main.stackAllocator, biome);
+					continue :outer;
+				}
+			}
+		}
+
+		outer: for (terrain.biomes.getCaveBiomes()) |*biome| {
+			for (tags) |_| {
+				if (biome.minHeight == std.math.minInt(i32) and biome.maxHeight == std.math.maxInt(i32) and biome.chance != 0) break :outer;
+			}
+		} else {
+			std.log.err("Cave layer with id {s} has no biomes with unbounded height. At least one biome with unbounded height must exist to ensure compatibility with other addons. Skipping", .{id});
+			return null;
+		}
+
+		result.biomes = .init(main.worldArena, main.worldArena.dupe(*const Biome, biomes.items));
+
 		return result;
 	}
 };
@@ -53,7 +74,7 @@ var caveLayers: main.List(CaveLayer) = .empty;
 
 fn register(id: []const u8, zon: ZonElement) void {
 	const caveLayer = CaveLayer.init(id, zon) orelse return;
-	caveLayers.append(main.worldArena, caveLayer);
+	caveLayers.append(main.stackAllocator, caveLayer);
 }
 
 pub fn registerCaveLayers(caveLayerMap: *Assets.ZonHashMap) !void {
@@ -85,18 +106,17 @@ pub fn registerCaveLayers(caveLayerMap: *Assets.ZonHashMap) !void {
 		caveLayers.items[i].minHeight = height;
 	}
 
-	var newLayers: main.List(CaveLayer) = .empty;
-
+	var newCaveLayers: main.List(CaveLayer) = .empty;
 	for (caveLayers.items) |layer| {
-		const splitLayers = splitLayer(main.worldArena, layer);
-		if (splitLayers) |layers| {
-			for (layers.items) |newLayer| {
-				newLayers.append(main.worldArena, newLayer);
-			}
+		const split = splitLayer(main.worldArena, layer);
+
+		for (split.items) |newLayer| {
+			newCaveLayers.append(main.worldArena, newLayer);
 		}
 	}
 
-	caveLayers = newLayers;
+	caveLayers.deinit(main.stackAllocator);
+	caveLayers = newCaveLayers;
 
 	std.log.debug("Registered cave layers:", .{});
 	for (caveLayers.items) |caveLayer| {
@@ -104,32 +124,10 @@ pub fn registerCaveLayers(caveLayerMap: *Assets.ZonHashMap) !void {
 	}
 }
 
-fn splitLayer(allocator: NeverFailingAllocator, layer: CaveLayer) ?main.List(CaveLayer) {
-	var possibleBiomes: main.List(*const Biome) = .empty;
-	defer possibleBiomes.deinit(main.stackAllocator);
-	outer: for (terrain.biomes.getCaveBiomes()) |*biome| {
-		for (layer.tags) |tag| {
-			if (biome.hasTag(tag)) {
-				possibleBiomes.append(main.stackAllocator, biome);
-				continue :outer;
-			}
-		}
-	}
-
-	if (possibleBiomes.items.len == 0) {
-		std.log.err("Cave layer with id {s} has no biomes that match the provided tags. Skipping", .{layer.id});
-		return null;
-	}
-	for (possibleBiomes.items) |biome| {
-		if (biome.minHeight == std.math.minInt(i32) and biome.maxHeight == std.math.maxInt(i32) and biome.chance != 0) break;
-	} else {
-		std.log.err("Cave layer with id {s} has no biomes with unbounded height. At least one biome with unbounded height must exist to ensure compatibility with other addons. Skipping", .{layer.id});
-		return null;
-	}
-
+fn splitLayer(allocator: NeverFailingAllocator, layer: CaveLayer) main.List(CaveLayer) {
 	var splitPoints: main.List(i32) = .empty;
 	defer splitPoints.deinit(main.stackAllocator);
-	for (possibleBiomes.items) |biome| {
+	for (layer.biomes.items) |biome| {
 		if (biome.maxHeight > layer.minHeight and biome.maxHeight < layer.maxHeight) {
 			splitPoints.append(main.stackAllocator, biome.maxHeight);
 		}
@@ -155,14 +153,13 @@ fn splitLayer(allocator: NeverFailingAllocator, layer: CaveLayer) ?main.List(Cav
 	while (i <= splitPoints.items.len) : (i += 1) {
 		const point = if (i < splitPoints.items.len) splitPoints.items[i] else layer.maxHeight;
 		var biomes: main.List(*const Biome) = .empty;
-		for (possibleBiomes.items) |biome| {
+		for (layer.biomes.items) |biome| {
 			if (biome.maxHeight >= point and biome.minHeight <= lastPoint) {
 				biomes.append(allocator, biome);
 			}
 		}
 
 		newLayers.append(allocator, CaveLayer{
-			.tags = layer.tags,
 			.biomes = main.utils.AliasTable(*const Biome).init(allocator, biomes.toOwnedSlice(allocator)),
 			.caveDensity = layer.caveDensity,
 			.id = layer.id,

--- a/src/server/terrain/cavebiomegen/RandomBiomeDistribution.zig
+++ b/src/server/terrain/cavebiomegen/RandomBiomeDistribution.zig
@@ -23,10 +23,6 @@ pub fn init(parameters: ZonElement) void {
 }
 
 pub fn generate(map: *CaveBiomeMapFragment, worldSeed: u64) void {
-	const marginDiv = 1024;
-	const marginMulPositive: comptime_int = comptime CaveBiomeMapFragment.rotateInverse(.{marginDiv, 0, marginDiv})[2];
-	const marginMulNegative: comptime_int = comptime CaveBiomeMapFragment.rotateInverse(.{0, marginDiv, 0})[2];
-
 	var seed = random.initSeed3D(worldSeed, .{map.pos.wx, map.pos.wy, map.pos.wz});
 	var z: u31 = 0;
 	while (z < CaveBiomeMapFragment.caveBiomeMapSize) : (z += CaveBiomeMapFragment.caveBiomeSize) {
@@ -39,14 +35,9 @@ pub fn generate(map: *CaveBiomeMapFragment, worldSeed: u64) void {
 					const offset: Vec3i = @splat(if (_map == 0) 0 else CaveBiomeMapFragment.caveBiomeSize/2);
 					const biomeWorldPos = CaveBiomeMapFragment.rotateInverse(pos + offset);
 					const caveLayer = terrain.cave_layers.getLayer(biomeWorldPos[2]);
-					while (true) {
-						const biome = caveLayer.biomes.sample(&seed).*;
-						if (biome.minHeight < biomeWorldPos[2] + CaveBiomeMapFragment.caveBiomeSize*marginMulPositive/marginDiv and biome.maxHeight > biomeWorldPos[2] + CaveBiomeMapFragment.caveBiomeSize*marginMulNegative/marginDiv) {
-							const index = CaveBiomeMapFragment.getIndex(x, y, z);
-							map.biomeMap[index][_map] = biome;
-							break;
-						}
-					}
+					const biome = caveLayer.biomes.sample(&seed).*;
+					const index = CaveBiomeMapFragment.getIndex(x, y, z);
+					map.biomeMap[index][_map] = biome;
 				}
 			}
 		}


### PR DESCRIPTION
Instead of guessing around until we find a biome in the layer, just store what biomes are in the layer as well and use that to sample.
This brought generating a new world seed 101 at max render from 142 sec to 125 sec.

`generate` used to take 28% of CPU time and now takes 15.8% according to AMD uProf


Edit:
Now only down to 130 seconds. And uses 16.89% of CPU time

Edit 2:
Uses only 14.5% of CPU time