### PR TITLE
Some small fixes to make pipelines more vulkan-compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       - run: zig build -Dtarget=aarch64-linux-gnu
       - run: zig build -Dtarget=aarch64-windows-gnu
       - run: zig build test
-      - run: 'find assets/cubyz/shaders -type f ! -name "*.glsl" | xargs -L1 glslangValidator -G100 -P"#extension GL_GOOGLE_include_directive : enable" -Iassets/cubyz/shaders/include'
+      - run: 'find assets/cubyz/shaders -type f ! -name "*.glsl" | xargs -L1 glslangValidator -G100 -P"#extension GL_GOOGLE_include_directive : enable" -Iassets/cubyz/shaders/include -Dgl_VertexIndex=gl_VertexID'

--- a/assets/cubyz/shaders/block_entity/sign.vert
+++ b/assets/cubyz/shaders/block_entity/sign.vert
@@ -30,8 +30,8 @@ layout(std430, binding = 4) buffer _quads
 };
 
 void main() {
-	int faceID = gl_VertexID >> 2;
-	int vertexID = gl_VertexID & 3;
+	int faceID = gl_VertexIndex >> 2;
+	int vertexID = gl_VertexIndex & 3;
 	uint fullLight = lightData[vertexID];
 	vec3 sunLight = vec3(
 		fullLight >> 25 & 31u,

--- a/assets/cubyz/shaders/block_selection_vertex.vert
+++ b/assets/cubyz/shaders/block_selection_vertex.vert
@@ -68,8 +68,8 @@ vec3 lineVertices[] = vec3[] (
 );
 
 void main() {
-	int vertexIndex = gl_VertexID%24;
-	int lineIndex = gl_VertexID/24;
+	int vertexIndex = gl_VertexIndex%24;
+	int lineIndex = gl_VertexIndex/24;
 	vec3 lineStart = lineVertices[lineIndex*2];
 	vec3 lineEnd = lineVertices[lineIndex*2 + 1];
 	vec3 lineCenter = (lineStart + lineEnd)/2*(upperBounds - lowerBounds);

--- a/assets/cubyz/shaders/chunks/chunk_vertex.vert
+++ b/assets/cubyz/shaders/chunks/chunk_vertex.vert
@@ -54,8 +54,8 @@ vec3 square(vec3 x) {
 }
 
 void main() {
-	int faceID = gl_VertexID >> 2;
-	int vertexID = gl_VertexID & 3;
+	int faceID = gl_VertexIndex >> 2;
+	int vertexID = gl_VertexIndex & 3;
 	int chunkID = gl_BaseInstance;
 	int voxelSize = chunks[chunkID].voxelSize;
 	int encodedPositionAndLightIndex = faceData[faceID].encodedPositionAndLightIndex;

--- a/assets/cubyz/shaders/chunks/occlusionTestVertex.vert
+++ b/assets/cubyz/shaders/chunks/occlusionTestVertex.vert
@@ -47,8 +47,8 @@ layout(location = 2) uniform ivec3 playerPositionInteger;
 layout(location = 3) uniform vec3 playerPositionFraction;
 
 void main() {
-	uint chunkIDID = uint(gl_VertexID)/24u;
-	uint vertexID = uint(gl_VertexID)%24u;
+	uint chunkIDID = uint(gl_VertexIndex)/24u;
+	uint vertexID = uint(gl_VertexIndex)%24u;
 	chunkID = chunkIDs[chunkIDID];
 	vec3 modelPosition = vec3(chunks[chunkID].position.xyz - playerPositionInteger) - playerPositionFraction;
 	vec3 margin = vec3(1); // Avoid near plane clipping when the player is at the edge of chunks

--- a/assets/cubyz/shaders/graphics/graph.vert
+++ b/assets/cubyz/shaders/graphics/graph.vert
@@ -14,8 +14,8 @@ layout(std430, binding = 5) buffer _data
 
 
 void main() {
-	float x = gl_VertexID;
-	float y = -data[(gl_VertexID+offset)%points];
+	float x = gl_VertexIndex;
+	float y = -data[(gl_VertexIndex + offset)%points];
 	// Convert to opengl coordinates:
 	vec2 position_percentage = (start + dimension*vec2(x/points, y))/screen;
 

--- a/assets/cubyz/shaders/item_drop.vert
+++ b/assets/cubyz/shaders/item_drop.vert
@@ -69,8 +69,8 @@ const int[24] positions = int[24](
 );
 
 void main() {
-	int faceID = gl_VertexID >> 2;
-	int vertexID = gl_VertexID & 3;
+	int faceID = gl_VertexIndex >> 2;
+	int vertexID = gl_VertexIndex & 3;
 	int voxelModelIndex = modelIndex;
 	bool isBlock = block != 0;
 	vec3 pos;
@@ -87,7 +87,7 @@ void main() {
 		}
 		faceNormal = quads[quadIndex].normal;
 	} else {
-		int position = positions[gl_VertexID];
+		int position = positions[gl_VertexIndex];
 		pos = vec3 (
 			position >> 8 & 1,
 			position >> 4 & 1,

--- a/assets/cubyz/shaders/particles/particles.vert
+++ b/assets/cubyz/shaders/particles/particles.vert
@@ -50,8 +50,8 @@ vec3 square(vec3 x) {
 }
 
 void main() {
-	int particleID = gl_VertexID >> 2;
-	int vertexID = gl_VertexID & 3;
+	int particleID = gl_VertexIndex >> 2;
+	int vertexID = gl_VertexIndex & 3;
 	ParticleData particle = particleData[particleID];
 	ParticleTypeData particleType = particleTypeData[particle.type];
 

--- a/assets/cubyz/shaders/skybox/star.vert
+++ b/assets/cubyz/shaders/skybox/star.vert
@@ -21,9 +21,9 @@ layout(location = 0) uniform mat4 mvp;
 layout(location = 1) uniform float starOpacity;
 
 void main() {
-	gl_Position = mvp*vec4(starData[gl_VertexID/3].vertexPositions[gl_VertexID%3].xyz, 1);
+	gl_Position = mvp*vec4(starData[gl_VertexIndex/3].vertexPositions[gl_VertexIndex%3].xyz, 1);
 
-	pos = starData[gl_VertexID/3].vertexPositions[gl_VertexID%3].xyz;
-	centerPos = starData[gl_VertexID/3].pos;
-	color = starData[gl_VertexID/3].color*starOpacity;
+	pos = starData[gl_VertexIndex/3].vertexPositions[gl_VertexIndex%3].xyz;
+	centerPos = starData[gl_VertexIndex/3].pos;
+	color = starData[gl_VertexIndex/3].color*starOpacity;
 }

--- a/src/graphics/pipelines.zig
+++ b/src/graphics/pipelines.zig
@@ -129,7 +129,9 @@ const Shader = struct { // MARK: Shader
 	}
 
 	fn addShader(self: *const Shader, filename: []const u8, defines: []const u8, shaderStage: c_uint) !void {
-		const source = try loadShaderFile(main.stackAllocator, filename, defines);
+		const extraDefines = std.mem.concat(main.stackAllocator.allocator, u8, &.{defines, "#define gl_VertexIndex gl_VertexID\n"}) catch unreachable;
+		defer main.stackAllocator.free(extraDefines);
+		const source = try loadShaderFile(main.stackAllocator, filename, extraDefines);
 		defer main.stackAllocator.free(source);
 
 		const shader = c.glCreateShader(shaderStage);

--- a/src/graphics/vulkan.zig
+++ b/src/graphics/vulkan.zig
@@ -276,8 +276,13 @@ const deviceExtensions = blk: {
 };
 
 const deviceFeatures: c.VkPhysicalDeviceFeatures = .{
+	// needed for indirect chunk rendering
 	.multiDrawIndirect = c.VK_TRUE,
+	.vertexPipelineStoresAndAtomics = c.VK_TRUE,
+	.fragmentStoresAndAtomics = c.VK_TRUE,
+	// needed for colored glass
 	.dualSrcBlend = c.VK_TRUE,
+	// needed to prevent near-plane clipping
 	.depthClamp = c.VK_TRUE,
 };
 

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -116,12 +116,12 @@ pub fn init() void {
 		.{.depthTest = true, .depthWrite = false},
 		.{.attachments = &.{.{
 			.enabled = false,
-			.srcColorBlendFactor = undefined,
-			.dstColorBlendFactor = undefined,
-			.colorBlendOp = undefined,
-			.srcAlphaBlendFactor = undefined,
-			.dstAlphaBlendFactor = undefined,
-			.alphaBlendOp = undefined,
+			.srcColorBlendFactor = .zero,
+			.dstColorBlendFactor = .zero,
+			.colorBlendOp = .add,
+			.srcAlphaBlendFactor = .zero,
+			.dstAlphaBlendFactor = .zero,
+			.alphaBlendOp = .add,
 			.colorWriteMask = .none,
 		}}},
 	);


### PR DESCRIPTION
- gl_VertexID → gl_VertexIndex (compatibility with OpenGL is kept using a `#define`)
- more device features are needed for some of the shaders
- validation layers do not like undefined enum values (even though they are unused)

progress towards #102 