### PR TITLE
Add rotation to tp command

### DIFF
--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -606,7 +606,6 @@ pub const genericUpdate = struct { // MARK: genericUpdate
 		biome = 4,
 		particles = 5,
 		clear = 6,
-		setRotation = 7,
 	};
 
 	const WorldEditPosition = enum(u2) {
@@ -626,13 +625,6 @@ pub const genericUpdate = struct { // MARK: genericUpdate
 			},
 			.teleport => {
 				game.Player.setPosBlocking(try reader.readVec(Vec3d));
-			},
-			.setRotation => {
-				var rot: Vec3f = try reader.readVec(Vec3f);
-				const bound = std.math.pi/2.0 - 0.001;
-				rot[0] = std.math.clamp(rot[0], -bound, bound);
-				game.camera.rotation[0] = rot[0];
-				game.camera.rotation[2] = rot[2];
 			},
 			.worldEditPos => {
 				const typ = try reader.readEnum(WorldEditPosition);
@@ -712,7 +704,7 @@ pub const genericUpdate = struct { // MARK: genericUpdate
 
 	fn serverReceive(conn: *Connection, reader: *utils.BinaryReader) !void {
 		switch (try reader.readEnum(UpdateType)) {
-			.gamemode, .teleport, .setRotation, .time, .biome, .particles, .clear => return error.InvalidSide,
+			.gamemode, .teleport, .time, .biome, .particles, .clear => return error.InvalidSide,
 			.worldEditPos => {
 				const typ = try reader.readEnum(WorldEditPosition);
 				const pos: ?Vec3i = switch (typ) {
@@ -741,16 +733,6 @@ pub const genericUpdate = struct { // MARK: genericUpdate
 
 		writer.writeEnum(UpdateType, .teleport);
 		writer.writeVec(Vec3d, pos);
-
-		conn.send(.secure, id, writer.data.items);
-	}
-
-	pub fn sendTPRotation(conn: *Connection, rot: Vec3f) void {
-		var writer = utils.BinaryWriter.initCapacity(main.stackAllocator, 20);
-		defer writer.deinit();
-
-		writer.writeEnum(UpdateType, .setRotation);
-		writer.writeVec(Vec3f, rot);
 
 		conn.send(.secure, id, writer.data.items);
 	}

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -606,6 +606,7 @@ pub const genericUpdate = struct { // MARK: genericUpdate
 		biome = 4,
 		particles = 5,
 		clear = 6,
+		setRotation = 7,
 	};
 
 	const WorldEditPosition = enum(u2) {
@@ -625,6 +626,13 @@ pub const genericUpdate = struct { // MARK: genericUpdate
 			},
 			.teleport => {
 				game.Player.setPosBlocking(try reader.readVec(Vec3d));
+			},
+			.setRotation => {
+				var rot: Vec3f = try reader.readVec(Vec3f);
+				const bound = std.math.pi/2.0 - 0.001;
+				rot[0] = std.math.clamp(rot[0], -bound, bound);
+				game.camera.rotation[0] = rot[0];
+				game.camera.rotation[2] = rot[2];
 			},
 			.worldEditPos => {
 				const typ = try reader.readEnum(WorldEditPosition);
@@ -704,7 +712,7 @@ pub const genericUpdate = struct { // MARK: genericUpdate
 
 	fn serverReceive(conn: *Connection, reader: *utils.BinaryReader) !void {
 		switch (try reader.readEnum(UpdateType)) {
-			.gamemode, .teleport, .time, .biome, .particles, .clear => return error.InvalidSide,
+			.gamemode, .teleport, .setRotation, .time, .biome, .particles, .clear => return error.InvalidSide,
 			.worldEditPos => {
 				const typ = try reader.readEnum(WorldEditPosition);
 				const pos: ?Vec3i = switch (typ) {
@@ -733,6 +741,16 @@ pub const genericUpdate = struct { // MARK: genericUpdate
 
 		writer.writeEnum(UpdateType, .teleport);
 		writer.writeVec(Vec3d, pos);
+
+		conn.send(.secure, id, writer.data.items);
+	}
+
+	pub fn sendTPRotation(conn: *Connection, rot: Vec3f) void {
+		var writer = utils.BinaryWriter.initCapacity(main.stackAllocator, 20);
+		defer writer.deinit();
+
+		writer.writeEnum(UpdateType, .setRotation);
+		writer.writeVec(Vec3f, rot);
 
 		conn.send(.secure, id, writer.data.items);
 	}

--- a/src/server/command.zig
+++ b/src/server/command.zig
@@ -108,6 +108,27 @@ pub const Coordinate = union(enum) {
 	}
 };
 
+pub const Rotation = union(enum) {
+	relative: f32, // Relative rotations are indicated by leading `~`.
+	absolute: f32,
+
+	pub fn parse(_: NeverFailingAllocator, name: []const u8, arg: []const u8, errorMessage: *ListManaged(u8)) error{ParseError}!Rotation {
+		const isRelative = arg[0] == '~';
+		const numberSlice = if (isRelative) arg[1..] else arg;
+		if (isRelative and numberSlice.len == 0) return .{.relative = 0};
+		if (isRelative) {
+			return .{.relative = std.fmt.parseFloat(f32, numberSlice) catch {
+				errorMessage.print("Expected number for <{s}>, found \"{s}\"", .{name, numberSlice});
+				return error.ParseError;
+			}};
+		}
+		return .{.absolute = std.fmt.parseFloat(f32, numberSlice) catch {
+			errorMessage.print("Expected number or \"~\" for <{s}>, found \"{s}\"", .{name, arg});
+			return error.ParseError;
+		}};
+	}
+};
+
 pub fn resolveCoordinates(x: Coordinate, y: Coordinate, z: Coordinate, source: Source) error{InvalidArg}!main.vec.Vec3d {
 	if (source != .user and (x == .relative or y == .relative or z == .relative)) {
 		source.sendMessage("Command was run without a user; unable to interpret relative coordinates.", .{});
@@ -118,6 +139,19 @@ pub fn resolveCoordinates(x: Coordinate, y: Coordinate, z: Coordinate, source: S
 		std.math.clamp(if (x == .relative) source.user.player().pos[0] + x.relative else x.absolute, -1e9, 1e9),
 		std.math.clamp(if (y == .relative) source.user.player().pos[1] + y.relative else y.absolute, -1e9, 1e9),
 		std.math.clamp(if (z == .relative) source.user.player().pos[2] + z.relative else z.absolute, -1e9, 1e9),
+	};
+}
+
+pub fn resolveRotation(yaw: Rotation, pitch: Rotation, source: Source) error{InvalidArg}!main.vec.Vec3f {
+	if (source != .user and (yaw == .relative or pitch == .relative)) {
+		source.sendMessage("Command was run without a user; unable to interpret relative rotation.", .{});
+		return error.InvalidArg;
+	}
+	const bound = std.math.pi/2.0 - 0.001;
+	return .{
+		std.math.clamp(if (yaw == .relative) source.user.player().rot[0] + yaw.relative*std.math.pi/180 else yaw.absolute*std.math.pi/180, -bound, bound),
+		0,
+		if (pitch == .relative) source.user.player().rot[2] + @mod(pitch.relative, 360)*std.math.pi/180 else @mod(pitch.absolute, 360)*std.math.pi/180,
 	};
 }
 

--- a/src/server/command.zig
+++ b/src/server/command.zig
@@ -117,15 +117,15 @@ pub const Rotation = union(enum) {
 		const numberSlice = if (isRelative) arg[1..] else arg;
 		if (isRelative and numberSlice.len == 0) return .{.relative = 0};
 		if (isRelative) {
-			return .{.relative = std.fmt.parseFloat(f32, numberSlice) catch {
+			return .{.relative = std.math.degreesToRadians(std.fmt.parseFloat(f32, numberSlice) catch {
 				errorMessage.print("Expected number for <{s}>, found \"{s}\"", .{name, numberSlice});
 				return error.ParseError;
-			}};
+			})};
 		}
-		return .{.absolute = std.fmt.parseFloat(f32, numberSlice) catch {
+		return .{.absolute = std.math.degreesToRadians(std.fmt.parseFloat(f32, numberSlice) catch {
 			errorMessage.print("Expected number or \"~\" for <{s}>, found \"{s}\"", .{name, arg});
 			return error.ParseError;
-		}};
+		})};
 	}
 };
 
@@ -149,9 +149,9 @@ pub fn resolveRotation(yaw: Rotation, pitch: Rotation, source: Source) error{Inv
 	}
 	const bound = std.math.pi/2.0 - 0.001;
 	return .{
-		std.math.clamp(if (yaw == .relative) source.user.player().rot[0] + yaw.relative*std.math.pi/180 else yaw.absolute*std.math.pi/180, -bound, bound),
+		std.math.clamp(if (yaw == .relative) source.user.player().rot[0] + yaw.relative else yaw.absolute, -bound, bound),
 		0,
-		if (pitch == .relative) source.user.player().rot[2] + @mod(pitch.relative, 360)*std.math.pi/180 else @mod(pitch.absolute, 360)*std.math.pi/180,
+		if (pitch == .relative) source.user.player().rot[2] + pitch.relative else pitch.absolute,
 	};
 }
 

--- a/src/server/command/tp.zig
+++ b/src/server/command/tp.zig
@@ -111,7 +111,7 @@ pub fn execute(args: Args, source: Source) void {
 		},
 		.@"/tp <sourcePlayerIndex> <x> <y> <z> <yaw> <pitch>" => |pos| {
 			//main.sync.server.executeCommand(.{.setRotation = .{.target = target.user.id, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, null);
-			main.sync.server.sendSyncOperation(.{.rotation = .{.target = source.user, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, null);
+			main.sync.server.sendSyncOperation(.{.rotation = .{.target = target.user, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, null);
 			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
 		},
 		inline .@"/tp <destinationPlayerIndex>", .@"/tp <sourcePlayerIndex> <destinationPlayerIndex>" => |index| {

--- a/src/server/command/tp.zig
+++ b/src/server/command/tp.zig
@@ -111,7 +111,6 @@ pub fn execute(args: Args, source: Source) void {
 			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
 		},
 		.@"/tp <sourcePlayerIndex> <x> <y> <z> <yaw> <pitch>" => |pos| {
-			//main.sync.server.executeCommand(.{.setRotation = .{.target = target.user.id, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, null);
 			main.sync.server.sendSyncOperation(.{.rotation = .{.target = target.user, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, null);
 			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
 		},

--- a/src/server/command/tp.zig
+++ b/src/server/command/tp.zig
@@ -110,7 +110,8 @@ pub fn execute(args: Args, source: Source) void {
 			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
 		},
 		.@"/tp <sourcePlayerIndex> <x> <y> <z> <yaw> <pitch>" => |pos| {
-			main.sync.server.executeCommand(.{.setRotation = .{.target = target.user.id, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, null);
+			//main.sync.server.executeCommand(.{.setRotation = .{.target = target.user.id, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, null);
+			main.sync.server.sendSyncOperation(.{.rotation = .{.target = source.user, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, null);
 			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
 		},
 		inline .@"/tp <destinationPlayerIndex>", .@"/tp <sourcePlayerIndex> <destinationPlayerIndex>" => |index| {

--- a/src/server/command/tp.zig
+++ b/src/server/command/tp.zig
@@ -107,11 +107,15 @@ pub fn execute(args: Args, source: Source) void {
 		.@"/tp <sourcePlayerIndex> <x> <y> <z>" => |pos| {
 			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
 		},
+		.@"/tp <sourcePlayerIndex> <x> <y> <z> <yaw> <pitch>" => |pos| {
+			main.network.protocols.genericUpdate.sendTPRotation(target.user.conn, command.resolveRotation(pos.yaw, pos.pitch, source) catch return);
+			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
+		},
 		inline .@"/tp <destinationPlayerIndex>", .@"/tp <sourcePlayerIndex> <destinationPlayerIndex>" => |index| {
 			const dest = command.Target.fromPlayerIndex(index.destinationPlayerIndex, source) catch return;
 			break :blk dest.user.player().pos;
 		},
 	};
 
-	if (!std.meta.eql(target.user.player().pos, pos)) main.network.protocols.genericUpdate.sendTPCoordinates(target.conn, pos);
+	if (!std.meta.eql(target.user.player().pos, pos)) main.network.protocols.genericUpdate.sendTPCoordinates(target.user.conn, pos);
 }

--- a/src/server/command/tp.zig
+++ b/src/server/command/tp.zig
@@ -108,7 +108,7 @@ pub fn execute(args: Args, source: Source) void {
 			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
 		},
 		.@"/tp <sourcePlayerIndex> <x> <y> <z> <yaw> <pitch>" => |pos| {
-			main.network.protocols.genericUpdate.sendTPRotation(target.user.conn, command.resolveRotation(pos.yaw, pos.pitch, source) catch return);
+			main.sync.server.executeCommand(.{.setRotation = .{.target = target.user.id, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, source.user);
 			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
 		},
 		inline .@"/tp <destinationPlayerIndex>", .@"/tp <sourcePlayerIndex> <destinationPlayerIndex>" => |index| {

--- a/src/server/command/tp.zig
+++ b/src/server/command/tp.zig
@@ -32,6 +32,14 @@ pub const Args = union(enum) {
 		sourcePlayerIndex: command.PlayerIndex,
 		destinationPlayerIndex: command.PlayerIndex,
 	},
+	@"/tp <sourcePlayerIndex> <x> <y> <z> <yaw> <pitch>": struct {
+		sourcePlayerIndex: ?command.PlayerIndex,
+		x: command.Coordinate,
+		y: command.Coordinate,
+		z: command.Coordinate,
+		yaw: command.Rotation,
+		pitch: command.Rotation,
+	},
 };
 
 pub fn execute(args: Args, source: Source) void {
@@ -104,5 +112,6 @@ pub fn execute(args: Args, source: Source) void {
 			break :blk dest.user.player().pos;
 		},
 	};
-	main.network.protocols.genericUpdate.sendTPCoordinates(target.user.conn, pos);
+
+	if (!std.meta.eql(target.user.player().pos, pos)) main.network.protocols.genericUpdate.sendTPCoordinates(target.conn, pos);
 }

--- a/src/server/command/tp.zig
+++ b/src/server/command/tp.zig
@@ -12,6 +12,8 @@ pub const usage =
 	\\/tp @<sourcePlayerIndex> <x> <y> <z>
 	\\/tp @<destinationPlayerIndex>
 	\\/tp @<sourcePlayerIndex> @<destinationPlayerIndex>
+	\\/tp <x> <y> <z> <yaw> <pitch>
+	\\/tp @<sourcePlayerIndex> <x> <y> <z> <yaw> <pitch>
 ;
 
 pub const Args = union(enum) {

--- a/src/server/command/tp.zig
+++ b/src/server/command/tp.zig
@@ -108,7 +108,7 @@ pub fn execute(args: Args, source: Source) void {
 			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
 		},
 		.@"/tp <sourcePlayerIndex> <x> <y> <z> <yaw> <pitch>" => |pos| {
-			main.sync.server.executeCommand(.{.setRotation = .{.target = target.user.id, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, source.user);
+			main.sync.server.executeCommand(.{.setRotation = .{.target = target.user.id, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, null);
 			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
 		},
 		inline .@"/tp <destinationPlayerIndex>", .@"/tp <sourcePlayerIndex> <destinationPlayerIndex>" => |index| {

--- a/src/server/command/tp.zig
+++ b/src/server/command/tp.zig
@@ -48,6 +48,7 @@ pub fn execute(args: Args, source: Source) void {
 	const target = switch (args) {
 		inline .@"/tp <sourcePlayerIndex> <biome>",
 		.@"/tp <sourcePlayerIndex> <x> <y> <z>",
+		.@"/tp <sourcePlayerIndex> <x> <y> <z> <yaw> <pitch>",
 		.@"/tp <sourcePlayerIndex> <destinationPlayerIndex>",
 		=> |params| command.Target.fromPlayerIndex(params.sourcePlayerIndex, source) catch return,
 		else => command.Target.fromPlayerIndex(null, source) catch return,

--- a/src/server/command/tp.zig
+++ b/src/server/command/tp.zig
@@ -111,7 +111,7 @@ pub fn execute(args: Args, source: Source) void {
 			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
 		},
 		.@"/tp <sourcePlayerIndex> <x> <y> <z> <yaw> <pitch>" => |pos| {
-			main.sync.server.sendSyncOperation(.{.rotation = .{.target = target.user, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, null);
+			main.sync.server.sendSyncOperation(.{.rotation = .{.target = target.user, .rotation = command.resolveRotation(pos.yaw, pos.pitch, source) catch return}}, target.user);
 			break :blk command.resolveCoordinates(pos.x, pos.y, pos.z, source) catch return;
 		},
 		inline .@"/tp <destinationPlayerIndex>", .@"/tp <sourcePlayerIndex> <destinationPlayerIndex>" => |index| {

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -280,7 +280,6 @@ pub const Command = struct { // MARK: Command
 		useDurability = 4,
 		addHealth = 5,
 		addEnergy = 6,
-		setRotation = 9,
 	};
 
 	pub const BaseOperation = union(BaseOperationType) {
@@ -329,11 +328,6 @@ pub const Command = struct { // MARK: Command
 			target: ?*main.server.User,
 			energy: f32,
 			previous: f32,
-		},
-		setRotation: struct {
-			target: ?*main.server.User,
-			rotation: Vec3f,
-			previous: Vec3f,
 		},
 	};
 
@@ -648,9 +642,6 @@ pub const Command = struct { // MARK: Command
 				.addEnergy => |info| {
 					main.game.Player.super.energy = info.previous;
 				},
-				.setRotation => |info| {
-					main.game.camera.rotation = info.previous;
-				},
 			}
 		}
 	}
@@ -658,7 +649,7 @@ pub const Command = struct { // MARK: Command
 	fn finalize(self: Command, allocator: NeverFailingAllocator, side: Side, reader: *BinaryReader) !void {
 		for (self.baseOperations.items) |step| {
 			switch (step) {
-				.move, .swap, .create, .moveToBag, .takeFromBag, .addHealth, .addEnergy, .setRotation => {},
+				.move, .swap, .create, .moveToBag, .takeFromBag, .addHealth, .addEnergy => {},
 				.delete => |info| {
 					info.item.deinit();
 				},
@@ -845,22 +836,6 @@ pub const Command = struct { // MARK: Command
 				} else {
 					info.previous = main.game.Player.super.energy;
 					main.game.Player.super.energy = std.math.clamp(main.game.Player.super.energy + info.energy, 0, main.game.Player.super.maxEnergy);
-				}
-			},
-			.setRotation => |*info| {
-				if (side == .server) {
-					info.previous = info.target.?.player().rot;
-					std.log.debug("SetRotation executed on server; target=TRUNCATED, rotation={}", .{info.rotation}); // MARK: Remove before merging
-
-					info.target.?.player().rot = info.rotation;
-					self.syncOperations.append(allocator, .{.rotation = .{
-						.target = info.target.?,
-						.rotation = info.rotation,
-					}});
-				} else {
-					std.log.debug("SetRotation executed on client; target=TRUNCATED, rotation={}", .{info.rotation});
-					info.previous = main.game.camera.rotation;
-					main.game.camera.rotation = info.rotation;
 				}
 			},
 		}

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -243,6 +243,7 @@ pub const Command = struct { // MARK: Command
 		updateBlock = 9,
 		addHealth = 10,
 		chatCommand = 12,
+		setRotation = 18,
 	};
 	pub const Payload = union(PayloadType) {
 		open: Open,
@@ -264,6 +265,7 @@ pub const Command = struct { // MARK: Command
 		updateBlock: UpdateBlock,
 		addHealth: AddHealth,
 		chatCommand: ChatCommand,
+		setRotation: SetRotation,
 	};
 
 	const BaseOperationType = enum(u8) {
@@ -276,6 +278,7 @@ pub const Command = struct { // MARK: Command
 		useDurability = 4,
 		addHealth = 5,
 		addEnergy = 6,
+		setRotation = 9,
 	};
 
 	pub const BaseOperation = union(BaseOperationType) {
@@ -324,6 +327,11 @@ pub const Command = struct { // MARK: Command
 			target: ?*main.server.User,
 			energy: f32,
 			previous: f32,
+		},
+		setRotation: struct {
+			target: ?*main.server.User,
+			rotation: Vec3f,
+			previous: Vec3f,
 		},
 	};
 
@@ -621,6 +629,9 @@ pub const Command = struct { // MARK: Command
 				.addEnergy => |info| {
 					main.game.Player.super.energy = info.previous;
 				},
+				.setRotation => |info| {
+					main.game.camera.rotation = info.previous;
+				},
 			}
 		}
 	}
@@ -628,7 +639,7 @@ pub const Command = struct { // MARK: Command
 	fn finalize(self: Command, allocator: NeverFailingAllocator, side: Side, reader: *BinaryReader) !void {
 		for (self.baseOperations.items) |step| {
 			switch (step) {
-				.move, .swap, .create, .moveToBag, .takeFromBag, .addHealth, .addEnergy => {},
+				.move, .swap, .create, .moveToBag, .takeFromBag, .addHealth, .addEnergy, .setRotation => {},
 				.delete => |info| {
 					info.item.deinit();
 				},
@@ -815,6 +826,23 @@ pub const Command = struct { // MARK: Command
 				} else {
 					info.previous = main.game.Player.super.energy;
 					main.game.Player.super.energy = std.math.clamp(main.game.Player.super.energy + info.energy, 0, main.game.Player.super.maxEnergy);
+				}
+			},
+			.setRotation => |*info| {
+				if (side == .server) {
+					info.previous = info.target.?.player().rot;
+					std.log.debug("SetRotation executed on server; target=TRUNCATED, rotation={}", .{info.rotation});
+
+					info.target.?.player().rot = info.rotation;
+					self.baseOperations.append(allocator, .{.setRotation = .{
+						.target = info.target.?,
+						.rotation = info.rotation,
+						.previous = info.previous,
+					}});
+				} else {
+					std.log.debug("SetRotation executed on client; target=TRUNCATED, rotation={}", .{info.rotation});
+					info.previous = main.game.camera.rotation;
+					main.game.camera.rotation = info.rotation;
 				}
 			},
 		}
@@ -1754,6 +1782,49 @@ pub const Command = struct { // MARK: Command
 				.target = try reader.readEnum(main.entity.Entity),
 				.health = @bitCast(try reader.readInt(u32)),
 				.cause = try reader.readEnum(main.game.DamageType),
+			};
+			if (user.?.id != result.target) return error.Invalid;
+			return result;
+		}
+	};
+
+	const SetRotation = struct { // MARK: SetRotation
+		target: main.entity.Entity,
+		rotation: Vec3f,
+
+		fn run(self: SetRotation, ctx: Context) error{serverFailure}!void {
+			std.log.debug("SetRotation ran; target={}, rotation={}", .{self.target, self.rotation});
+			var target: ?*main.server.User = null;
+
+			if (ctx.side == .server) {
+				const userList = main.server.getUserList(main.stackAllocator);
+				defer main.stackAllocator.free(userList);
+				for (userList) |user| {
+					if (user.id == self.target) {
+						target = user;
+						break;
+					}
+				}
+
+				if (target == null) return error.serverFailure;
+			}
+
+			ctx.execute(.{.setRotation = .{
+				.target = target,
+				.rotation = self.rotation,
+				.previous = if (ctx.side == .server) target.?.player().rot else main.game.camera.rotation,
+			}});
+		}
+
+		fn serialize(self: SetRotation, writer: *BinaryWriter) void {
+			writer.writeEnum(main.entity.Entity, self.target);
+			writer.writeVec(Vec3f, self.rotation);
+		}
+
+		fn deserialize(reader: *BinaryReader, _: Side, user: ?*main.server.User) !SetRotation {
+			const result: SetRotation = .{
+				.target = try reader.readEnum(main.entity.Entity),
+				.rotation = try reader.readVec(Vec3f),
 			};
 			if (user.?.id != result.target) return error.Invalid;
 			return result;

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -140,17 +140,11 @@ pub const server = struct { // MARK: server
 		threadContext = .other;
 	}
 
-	pub fn sendSyncOperation(op: Command.SyncOperation, source: ?*main.server.User) void {
+	pub fn sendSyncOperation(op: Command.SyncOperation, target: *main.server.User) void {
 		const syncData = op.serialize(main.stackAllocator);
 		defer main.stackAllocator.free(syncData);
 
-		const users = op.getUsers(main.stackAllocator);
-		defer main.stackAllocator.free(users);
-
-		for (users) |user| {
-			if (user == source and op.ignoreSource()) continue;
-			main.network.protocols.inventory.sendSyncOperation(user.conn, syncData);
-		}
+		main.network.protocols.inventory.sendSyncOperation(target.conn, syncData);
 	}
 
 	pub fn executeCommand(payload: Command.Payload, source: ?*main.server.User) void {
@@ -167,7 +161,16 @@ pub const server = struct { // MARK: server
 			main.network.protocols.inventory.sendConfirmation(source.?.conn, confirmationData);
 		}
 		for (command.syncOperations.items) |op| {
-			sendSyncOperation(op, source);
+			const syncData = op.serialize(main.stackAllocator);
+			defer main.stackAllocator.free(syncData);
+
+			const users = op.getUsers(main.stackAllocator);
+			defer main.stackAllocator.free(users);
+
+			for (users) |user| {
+				if (user == source and op.ignoreSource()) continue;
+				main.network.protocols.inventory.sendSyncOperation(user.conn, syncData);
+			}
 		}
 		if (source != null and command.payload == .open) { // Send initial items
 			for (command.payload.open.inv._items, 0..) |stack, slot| {

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -140,6 +140,19 @@ pub const server = struct { // MARK: server
 		threadContext = .other;
 	}
 
+	pub fn sendSyncOperation(op: Command.SyncOperation, source: ?*main.server.User) void {
+		const syncData = op.serialize(main.stackAllocator);
+		defer main.stackAllocator.free(syncData);
+
+		const users = op.getUsers(main.stackAllocator);
+		defer main.stackAllocator.free(users);
+
+		for (users) |user| {
+			if (user == source and op.ignoreSource()) continue;
+			main.network.protocols.inventory.sendSyncOperation(user.conn, syncData);
+		}
+	}
+
 	pub fn executeCommand(payload: Command.Payload, source: ?*main.server.User) void {
 		var command = Command{
 			.payload = payload,
@@ -154,16 +167,7 @@ pub const server = struct { // MARK: server
 			main.network.protocols.inventory.sendConfirmation(source.?.conn, confirmationData);
 		}
 		for (command.syncOperations.items) |op| {
-			const syncData = op.serialize(main.stackAllocator);
-			defer main.stackAllocator.free(syncData);
-
-			const users = op.getUsers(main.stackAllocator);
-			defer main.stackAllocator.free(users);
-
-			for (users) |user| {
-				if (user == source and op.ignoreSource()) continue;
-				main.network.protocols.inventory.sendSyncOperation(user.conn, syncData);
-			}
+			sendSyncOperation(op, source);
 		}
 		if (source != null and command.payload == .open) { // Send initial items
 			for (command.payload.open.inv._items, 0..) |stack, slot| {
@@ -848,7 +852,7 @@ pub const Command = struct { // MARK: Command
 			.setRotation => |*info| {
 				if (side == .server) {
 					info.previous = info.target.?.player().rot;
-					std.log.debug("SetRotation executed on server; target=TRUNCATED, rotation={}", .{info.rotation});
+					std.log.debug("SetRotation executed on server; target=TRUNCATED, rotation={}", .{info.rotation}); // MARK: Remove before merging
 
 					info.target.?.player().rot = info.rotation;
 					self.syncOperations.append(allocator, .{.rotation = .{

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -342,6 +342,7 @@ pub const Command = struct { // MARK: Command
 		health = 3,
 		kill = 4,
 		energy = 5,
+		rotation = 6,
 	};
 
 	const SyncOperation = union(SyncOperationType) { // MARK: SyncOperation
@@ -370,6 +371,10 @@ pub const Command = struct { // MARK: Command
 		energy: struct {
 			target: ?*main.server.User,
 			energy: f32,
+		},
+		rotation: struct {
+			target: ?*main.server.User,
+			rotation: Vec3f,
 		},
 
 		pub fn executeFromData(reader: *BinaryReader) !void {
@@ -417,6 +422,9 @@ pub const Command = struct { // MARK: Command
 				.energy => |energy| {
 					main.game.Player.super.energy = std.math.clamp(main.game.Player.super.energy + energy.energy, 0, main.game.Player.super.maxEnergy);
 				},
+				.rotation => |rotation| {
+					main.game.camera.rotation = rotation.rotation;
+				},
 			}
 		}
 
@@ -430,7 +438,7 @@ pub const Command = struct { // MARK: Command
 					}
 					return result;
 				},
-				inline .health, .kill, .energy => |data| {
+				inline .health, .kill, .energy, .rotation => |data| {
 					const out = allocator.alloc(*main.server.User, 1);
 					out[0] = data.target.?;
 					return out;
@@ -440,7 +448,7 @@ pub const Command = struct { // MARK: Command
 
 		pub fn ignoreSource(self: SyncOperation) bool {
 			return switch (self) {
-				.create, .delete, .useDurability, .health, .energy => true,
+				.create, .delete, .useDurability, .health, .energy, .rotation => true,
 				.kill => false,
 			};
 		}
@@ -491,6 +499,12 @@ pub const Command = struct { // MARK: Command
 						.energy = try reader.readFloat(f32),
 					}};
 				},
+				.rotation => {
+					return .{.rotation = .{
+						.target = null,
+						.rotation = try reader.readVec(Vec3f),
+					}};
+				},
 			}
 		}
 
@@ -521,6 +535,9 @@ pub const Command = struct { // MARK: Command
 				},
 				.energy => |energy| {
 					writer.writeFloat(f32, energy.energy);
+				},
+				.rotation => |rotation| {
+					writer.writeVec(Vec3f, rotation.rotation);
 				},
 			}
 			return writer.data.toOwnedSlice();
@@ -834,10 +851,9 @@ pub const Command = struct { // MARK: Command
 					std.log.debug("SetRotation executed on server; target=TRUNCATED, rotation={}", .{info.rotation});
 
 					info.target.?.player().rot = info.rotation;
-					self.baseOperations.append(allocator, .{.setRotation = .{
+					self.syncOperations.append(allocator, .{.rotation = .{
 						.target = info.target.?,
 						.rotation = info.rotation,
-						.previous = info.previous,
 					}});
 				} else {
 					std.log.debug("SetRotation executed on client; target=TRUNCATED, rotation={}", .{info.rotation});

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -247,7 +247,6 @@ pub const Command = struct { // MARK: Command
 		updateBlock = 9,
 		addHealth = 10,
 		chatCommand = 12,
-		setRotation = 18,
 	};
 	pub const Payload = union(PayloadType) {
 		open: Open,
@@ -269,7 +268,6 @@ pub const Command = struct { // MARK: Command
 		updateBlock: UpdateBlock,
 		addHealth: AddHealth,
 		chatCommand: ChatCommand,
-		setRotation: SetRotation,
 	};
 
 	const BaseOperationType = enum(u8) {
@@ -1802,49 +1800,6 @@ pub const Command = struct { // MARK: Command
 				.target = try reader.readEnum(main.entity.Entity),
 				.health = @bitCast(try reader.readInt(u32)),
 				.cause = try reader.readEnum(main.game.DamageType),
-			};
-			if (user.?.id != result.target) return error.Invalid;
-			return result;
-		}
-	};
-
-	const SetRotation = struct { // MARK: SetRotation
-		target: main.entity.Entity,
-		rotation: Vec3f,
-
-		fn run(self: SetRotation, ctx: Context) error{serverFailure}!void {
-			std.log.debug("SetRotation ran; target={}, rotation={}", .{self.target, self.rotation});
-			var target: ?*main.server.User = null;
-
-			if (ctx.side == .server) {
-				const userList = main.server.getUserList(main.stackAllocator);
-				defer main.stackAllocator.free(userList);
-				for (userList) |user| {
-					if (user.id == self.target) {
-						target = user;
-						break;
-					}
-				}
-
-				if (target == null) return error.serverFailure;
-			}
-
-			ctx.execute(.{.setRotation = .{
-				.target = target,
-				.rotation = self.rotation,
-				.previous = if (ctx.side == .server) target.?.player().rot else main.game.camera.rotation,
-			}});
-		}
-
-		fn serialize(self: SetRotation, writer: *BinaryWriter) void {
-			writer.writeEnum(main.entity.Entity, self.target);
-			writer.writeVec(Vec3f, self.rotation);
-		}
-
-		fn deserialize(reader: *BinaryReader, _: Side, user: ?*main.server.User) !SetRotation {
-			const result: SetRotation = .{
-				.target = try reader.readEnum(main.entity.Entity),
-				.rotation = try reader.readVec(Vec3f),
 			};
 			if (user.?.id != result.target) return error.Invalid;
 			return result;


### PR DESCRIPTION
Adds optional yaw and pitch parameters to the /tp command.  

```
/tp <playerId> <x> <y> <z> <yaw> <pitch>
```

Yaw and pitch are expected to be supplied in degrees as that is the unit most users can be expected to be familiar with and will automatically be converted to radians internally.  
Yaw and pitch can be relative: `/tp ~ ~ ~ ~ ~10`

Closes #2403 