### PR TITLE
Remove reference counting from the User

### DIFF
--- a/src/Inventory.zig
+++ b/src/Inventory.zig
@@ -274,8 +274,8 @@ pub const server = struct { // MARK: server
 						const workbenchInventory = getInventoryFromSource(callbackSource) orelse @panic("Could not find workbench Inventory");
 						const playerInventory = server.getInventoryFromSource(.{.playerInventory = callbackSource.workbench.playerId}) orelse @panic("Could not find player Inventory");
 
-						const userList = main.server.getUserListAndIncreaseRefCount(main.stackAllocator);
-						defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+						const userList = main.server.getUserList(main.stackAllocator);
+						defer main.stackAllocator.free(userList);
 						for (userList) |callbackUser| {
 							if (callbackUser.id == callbackSource.workbench.playerId) {
 								sync.server.executeCommand(.{.depositOrDrop = .initWithInventories(&.{playerInventory}, workbenchInventory, callbackUser.player().pos)}, null);

--- a/src/entity.zig
+++ b/src/entity.zig
@@ -196,8 +196,8 @@ pub const server = struct {
 		var binaryWriter = main.utils.BinaryWriter.init(main.stackAllocator);
 		defer binaryWriter.deinit();
 
-		const users = main.server.getUserListAndIncreaseRefCount(main.stackAllocator);
-		defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, users);
+		const users = main.server.getUserList(main.stackAllocator);
+		defer main.stackAllocator.free(users);
 
 		if (EntityComponent.server.get(entity)) |ptr| {
 			if (ptr.save(&binaryWriter, .playerNearby) == .save) {

--- a/src/gui/windows/debug_network.zig
+++ b/src/gui/windows/debug_network.zig
@@ -27,8 +27,8 @@ pub fn render() void {
 	var y: f32 = 0;
 	if (main.game.world != null) {
 		if (main.server.world != null) {
-			const userList = main.server.getUserListAndIncreaseRefCount(main.stackAllocator);
-			defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+			const userList = main.server.getUserList(main.stackAllocator);
+			defer main.stackAllocator.free(userList);
 			draw.print("Players Connected: {}", .{userList.len}, 0, y, 8);
 			y += 8;
 		}

--- a/src/gui/windows/debug_network_advanced.zig
+++ b/src/gui/windows/debug_network_advanced.zig
@@ -46,8 +46,8 @@ pub fn render() void {
 	}
 	y += 8;
 	if (main.server.world != null) {
-		const userList = main.server.getUserListAndIncreaseRefCount(main.stackAllocator);
-		defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+		const userList = main.server.getUserList(main.stackAllocator);
+		defer main.stackAllocator.free(userList);
 		for (userList) |user| {
 			renderConnectionData(user.conn, user.name, &y);
 		}

--- a/src/gui/windows/invite.zig
+++ b/src/gui/windows/invite.zig
@@ -46,13 +46,12 @@ fn invite() void {
 		_thread.join();
 		thread = null;
 	}
-	const user = main.server.User.initAndIncreaseRefCount(main.server.connectionManager, ipAddressEntry.currentString.items) catch |err| {
+	_ = main.server.User.init(main.server.connectionManager, ipAddressEntry.currentString.items) catch |err| {
 		if (err != error.AlreadyConnected) {
 			std.log.err("Cannot connect user: {s}", .{@errorName(err)});
 		}
 		return;
 	};
-	user.decreaseRefCount();
 }
 
 fn copyIp() void {

--- a/src/gui/windows/players.zig
+++ b/src/gui/windows/players.zig
@@ -20,7 +20,7 @@ pub var window = GuiWindow{
 };
 
 const padding: f32 = 8;
-var userList: []*main.server.User = &.{};
+var lastLen: usize = 0;
 var entityCount: usize = 0;
 
 fn kickbyConnection(conn: *main.network.Connection) void {
@@ -54,12 +54,11 @@ pub fn onOpen() void {
 	} else {
 		main.server.connectionManager.mutex.lock();
 		defer main.server.connectionManager.mutex.unlock();
-		std.debug.assert(userList.len == 0);
-		userList = main.globalAllocator.alloc(*main.server.User, main.server.connectionManager.connections.items.len);
-		for (main.server.connectionManager.connections.items, 0..) |connection, i| {
-			userList[i] = connection.user.?;
-			userList[i].increaseRefCount();
-			if (userList[i].id == main.game.Player.id and connection.isConnected()) continue;
+		std.debug.assert(lastLen == 0);
+		lastLen = main.server.connectionManager.connections.items.len;
+		for (main.server.connectionManager.connections.items) |connection| {
+			const user = connection.user.?;
+			if (user.id == main.game.Player.id and connection.isConnected()) continue;
 			const row = HorizontalList.init();
 			if (connection.handShakeState.load(.monotonic) == .complete) {
 				const string = main.stackAllocator.print("{f}", .{connection.user.?});
@@ -74,7 +73,7 @@ pub fn onOpen() void {
 			}
 			list.add(row);
 		}
-		if (userList.len == 1) {
+		if (lastLen == 1) {
 			list.add(Label.init(.{0, 0}, 200, "No other players", .left));
 		}
 	}
@@ -86,11 +85,7 @@ pub fn onOpen() void {
 
 pub fn onClose() void {
 	if (main.server.world != null) {
-		for (userList) |user| {
-			user.decreaseRefCount();
-		}
-		main.globalAllocator.free(userList);
-		userList = &.{};
+		lastLen = 0;
 	}
 	if (window.rootComponent) |*comp| {
 		comp.deinit();
@@ -107,7 +102,7 @@ pub fn update() void {
 		main.server.connectionManager.mutex.lock();
 		const serverListLen = main.server.connectionManager.connections.items.len;
 		main.server.connectionManager.mutex.unlock();
-		if (userList.len != serverListLen) {
+		if (lastLen != serverListLen) {
 			onClose();
 			onOpen();
 		}

--- a/src/itemdrop.zig
+++ b/src/itemdrop.zig
@@ -255,8 +255,8 @@ pub const ItemDropManager = struct { // MARK: ItemDropManager
 			const updateData = list.toStringEfficient(main.stackAllocator, &.{});
 			defer main.stackAllocator.free(updateData);
 
-			const userList = main.server.getUserListAndIncreaseRefCount(main.stackAllocator);
-			defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+			const userList = main.server.getUserList(main.stackAllocator);
+			defer main.stackAllocator.free(userList);
 			for (userList) |user| {
 				main.network.protocols.entity.send(user.conn, updateData);
 			}
@@ -287,8 +287,8 @@ pub const ItemDropManager = struct { // MARK: ItemDropManager
 			const updateData = list.toStringEfficient(main.stackAllocator, &.{});
 			defer main.stackAllocator.free(updateData);
 
-			const userList = main.server.getUserListAndIncreaseRefCount(main.stackAllocator);
-			defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+			const userList = main.server.getUserList(main.stackAllocator);
+			defer main.stackAllocator.free(userList);
 			for (userList) |user| {
 				main.network.protocols.entity.send(user.conn, updateData);
 			}
@@ -343,8 +343,8 @@ pub const ItemDropManager = struct { // MARK: ItemDropManager
 		const updateData = list.toStringEfficient(main.stackAllocator, &.{});
 		defer main.stackAllocator.free(updateData);
 
-		const userList = main.server.getUserListAndIncreaseRefCount(main.stackAllocator);
-		defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+		const userList = main.server.getUserList(main.stackAllocator);
+		defer main.stackAllocator.free(userList);
 		for (userList) |user| {
 			main.network.protocols.entity.send(user.conn, updateData);
 		}

--- a/src/network.zig
+++ b/src/network.zig
@@ -689,11 +689,10 @@ pub const ConnectionManager = struct { // MARK: ConnectionManager
 			if (data.len != 0 and data[0] == @intFromEnum(Connection.ChannelId.init)) {
 				const ip = main.stackAllocator.print("{f}", .{source});
 				defer main.stackAllocator.free(ip);
-				const user = main.server.User.initAndIncreaseRefCount(main.server.connectionManager, ip) catch |err| {
+				const user = main.server.User.init(main.server.connectionManager, ip) catch |err| {
 					std.log.err("Cannot connect user from external IP {f}: {s}", .{source, @errorName(err)});
 					return;
 				};
-				user.decreaseRefCount();
 				user.conn.receive(data);
 			}
 		} else {

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -312,8 +312,7 @@ pub const chunkRequest = struct { // MARK: chunkRequest
 				.wz = (z << voxelSizeShift + chunk.chunkShift) +% (basePosition[2] & positionMask),
 				.voxelSize = @as(u31, 1) << voxelSizeShift,
 			};
-			conn.user.?.increaseRefCount();
-			main.server.world.?.queueChunkAndDecreaseRefCount(request, conn.user.?);
+			main.server.world.?.queueChunk(request, conn.user.?);
 		}
 	}
 	pub fn sendRequest(conn: *Connection, requests: []chunk.ChunkPosition, basePosition: Vec3i, renderDistance: u16) void {
@@ -838,8 +837,7 @@ pub const lightMapRequest = struct { // MARK: lightMapRequest
 				.voxelSizeShift = voxelSizeShift,
 			};
 			if (conn.user) |user| {
-				user.increaseRefCount();
-				main.server.world.?.queueLightMapAndDecreaseRefCount(request, user);
+				main.server.world.?.queueLightMap(request, user);
 			}
 		}
 	}
@@ -1042,8 +1040,8 @@ pub const blockEntityUpdate = struct { // MARK: blockEntityUpdate
 		defer writer.deinit();
 		blockEntity.getServerToClientData(pos, ch, &writer);
 
-		const users = main.server.getUserListAndIncreaseRefCount(main.stackAllocator);
-		defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, users);
+		const users = main.server.getUserList(main.stackAllocator);
+		defer main.stackAllocator.free(users);
 
 		for (users) |user| {
 			blockUpdate.send(user.conn, &.{.{.pos = pos, .newBlock = block, .blockEntityData = writer.data.items}});

--- a/src/server/command.zig
+++ b/src/server/command.zig
@@ -120,7 +120,6 @@ pub fn resolveCoordinates(x: Coordinate, y: Coordinate, z: Coordinate, source: S
 
 pub const Target = struct {
 	user: *User,
-	increasedRefCount: bool,
 
 	pub fn fromPlayerIndex(arg: ?PlayerIndex, source: Source) !Target {
 		if (arg == null and source != .user) {
@@ -129,19 +128,13 @@ pub const Target = struct {
 		}
 		const playerIndex = arg orelse return .{
 			.user = source.user,
-			.increasedRefCount = false,
 		};
 		return .{
-			.user = main.server.getUserByIndexAndIncreaseRefCount(playerIndex.index) orelse {
+			.user = main.server.getUserByIndex(playerIndex.index) orelse {
 				source.sendMessage("#ff0000Player with index {d} not found or not online", .{playerIndex.index});
 				return error.InvalidArg;
 			},
-			.increasedRefCount = true,
 		};
-	}
-
-	pub fn deinit(self: Target) void {
-		if (self.increasedRefCount) self.user.decreaseRefCount();
 	}
 };
 

--- a/src/server/command/gamemode.zig
+++ b/src/server/command/gamemode.zig
@@ -20,7 +20,6 @@ pub fn execute(args: Args, source: Source) void {
 	switch (args) {
 		.@"/gamemode <playerIndex> <mode>" => |params| {
 			const target = command.Target.fromPlayerIndex(params.playerIndex, source) catch return;
-			defer target.deinit();
 
 			if (params.mode) |mode| {
 				main.sync.setGamemode(target.user, mode);

--- a/src/server/command/invite.zig
+++ b/src/server/command/invite.zig
@@ -12,11 +12,8 @@ pub const Args = union(enum) {
 };
 
 pub fn execute(args: Args, source: Source) void {
-	const user = main.server.User.initAndIncreaseRefCount(main.server.connectionManager, args.@"/invite <ip>".ip) catch |err| {
+	_ = main.server.User.init(main.server.connectionManager, args.@"/invite <ip>".ip) catch |err| {
 		std.log.err("Error while trying to connect: {s}", .{@errorName(err)});
 		source.sendMessage("#ff0000Error while trying to connect: {s}", .{@errorName(err)});
-		return;
 	};
-	user.decreaseRefCount();
-	return;
 }

--- a/src/server/command/kick.zig
+++ b/src/server/command/kick.zig
@@ -14,7 +14,6 @@ pub const Args = union(enum) {
 
 pub fn execute(args: Args, source: Source) void {
 	const target = command.Target.fromPlayerIndex(args.@"/kick <playerIndex>".playerIndex, source) catch return;
-	defer target.deinit();
 
 	target.user.conn.disconnect();
 	main.server.sendMessage("{s}§#ffff00 has been kicked from the server", .{target.user.name});

--- a/src/server/command/kill.zig
+++ b/src/server/command/kill.zig
@@ -16,7 +16,6 @@ pub const Args = union(enum) {
 
 pub fn execute(args: Args, source: Source) void {
 	const target = command.Target.fromPlayerIndex(args.@"/kill <playerIndex>".playerIndex, source) catch return;
-	defer target.deinit();
 
 	main.sync.addHealth(-std.math.floatMax(f32), .kill, .server, target.user.id);
 }

--- a/src/server/command/particles.zig
+++ b/src/server/command/particles.zig
@@ -38,8 +38,8 @@ pub const Args = union(enum) {
 };
 
 pub fn execute(args: Args, source: Source) void {
-	const users = main.server.getUserListAndIncreaseRefCount(main.stackAllocator);
-	defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, users);
+	const users = main.server.getUserList(main.stackAllocator);
+	defer main.stackAllocator.free(users);
 	for (users) |user| {
 		main.network.protocols.genericUpdate.sendParticles(
 			user.conn,

--- a/src/server/command/permission/perm.zig
+++ b/src/server/command/permission/perm.zig
@@ -30,7 +30,6 @@ pub fn execute(args: Args, source: Source) void {
 	switch (args) {
 		.@"/perm <action> <list> <playerIndex> <permissionPath>" => |params| {
 			const target = command.Target.fromPlayerIndex(params.playerIndex, source) catch return;
-			defer target.deinit();
 
 			const listType: ListType = switch (params.list) {
 				.whitelist => .white,
@@ -48,7 +47,6 @@ pub fn execute(args: Args, source: Source) void {
 		},
 		.@"/perm <playerIndex> <permissionPath>" => |params| {
 			const target = command.Target.fromPlayerIndex(params.playerIndex, source) catch return;
-			defer target.deinit();
 
 			if (main.entity.components.@"cubyz:permissions".server.hasPermission(target.user.id, params.permissionPath.path)) {
 				source.sendMessage("#00ff00Player {s}§#00ff00 has permission for path: {s}", .{target.user.name, params.permissionPath.path});

--- a/src/server/command/spawn.zig
+++ b/src/server/command/spawn.zig
@@ -26,12 +26,10 @@ pub fn execute(args: Args, source: Source) void {
 	switch (args) {
 		.@"/spawn <playerIndex> <x> <y> <z>" => |params| {
 			const target = command.Target.fromPlayerIndex(params.playerIndex, source) catch return;
-			defer target.deinit();
 			target.user.spawnPos = command.resolveCoordinates(params.x, params.y, params.z, source) catch return;
 		},
 		.@"/spawn <playerIndex>" => |params| {
 			const target = command.Target.fromPlayerIndex(params.playerIndex, source) catch return;
-			defer target.deinit();
 			source.sendMessage("#ffff00{}", .{target.user.getSpawnPos()});
 		},
 		.@"/spawn <world> <x> <y> <z>" => |params| {

--- a/src/server/command/tp.zig
+++ b/src/server/command/tp.zig
@@ -85,7 +85,6 @@ pub fn execute(args: Args, source: Source) void {
 		},
 		.@"/tp <playerIndex>" => |index| {
 			const target = command.Target.fromPlayerIndex(index.playerIndex, source) catch return;
-			defer target.deinit();
 			break :blk target.user.player().pos;
 		},
 	};

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -96,6 +96,8 @@ pub const WorldEditData = struct {
 	}
 };
 
+pub const PlayerIndex = usize;
+
 pub const User = struct { // MARK: User
 	const maxSimulationDistance = 8;
 	const simulationSize = 2*maxSimulationDistance;
@@ -120,7 +122,7 @@ pub const User = struct { // MARK: User
 	spawnPos: ?Vec3d = null,
 	worldEditData: WorldEditData = undefined,
 
-	playerIndex: usize = undefined,
+	playerIndex: PlayerIndex = undefined,
 
 	jobQueue: main.utils.ConcurrentMaxHeap(main.utils.ThreadPool.Task) = undefined,
 	jobQueueScheduled: bool = false,
@@ -139,8 +141,6 @@ pub const User = struct { // MARK: User
 	connected: Atomic(bool) = .init(true),
 	state: State = .awaitingKeyVerification,
 
-	refCount: Atomic(u32) = .init(1),
-
 	mutex: main.utils.Mutex = .{},
 
 	inventoryCommands: main.List([]const u8) = .empty,
@@ -151,13 +151,12 @@ pub const User = struct { // MARK: User
 		return &self.innerPlayer;
 	}
 
-	pub fn initAndIncreaseRefCount(manager: *ConnectionManager, ipPort: []const u8) !*User {
+	pub fn init(manager: *ConnectionManager, ipPort: []const u8) !*User {
 		const self = main.globalAllocator.create(User);
 		errdefer main.globalAllocator.destroy(self);
 		self.* = .{};
 		self.conn = try Connection.init(manager, ipPort, self);
 		self.@"continue"();
-		self.increaseRefCount();
 		network.protocols.handShake.serverSide(self.conn);
 		return self;
 	}
@@ -175,13 +174,23 @@ pub const User = struct { // MARK: User
 			.jobQueue = .init(main.globalAllocator),
 		};
 	}
-	pub fn deinit(self: *User) void {
-		std.debug.assert(self.refCount.load(.monotonic) == 0);
-
+	fn privateDeinit(self: *User) void {
 		self.conn.deinit();
 		main.globalAllocator.free(self.name);
 		if (self.newKeyString) |str| main.globalAllocator.free(str);
 		main.globalAllocator.destroy(self);
+	}
+	pub fn deferredPauseAndDeinit(self: *User) void {
+		self.conn.disconnect();
+		if (self.inventory != null) {
+			world.?.savePlayer(self) catch |err| {
+				std.log.err("Failed to save player: {s}", .{@errorName(err)});
+				return;
+			};
+		}
+
+		main.heap.GarbageCollection.deferredFree(.{.ptr = self, .freeFunction = main.meta.castFunctionSelfToAnyopaque(privateDeinit)});
+		main.heap.GarbageCollection.deferredFree(.{.ptr = self, .freeFunction = main.meta.castFunctionSelfToAnyopaque(pause)});
 	}
 	pub fn pause(self: *User) void {
 		self.state = switch (self.state) {
@@ -219,19 +228,6 @@ pub const User = struct { // MARK: User
 		self.inventoryCommands.deinit(main.globalAllocator);
 
 		self.jobQueue.deinit();
-	}
-	pub fn increaseRefCount(self: *User) void {
-		const prevVal = self.refCount.fetchAdd(1, .monotonic);
-		std.debug.assert(prevVal != 0);
-	}
-
-	pub fn decreaseRefCount(self: *User) void {
-		const prevVal = self.refCount.fetchSub(1, .monotonic);
-		std.debug.assert(prevVal != 0);
-		if (prevVal == 1) {
-			self.pause();
-			self.deinit();
-		}
 	}
 
 	pub fn identifyFromKeysAndName(self: *User, name: []const u8, keys: main.ZonElement) !void {
@@ -389,7 +385,7 @@ pub const User = struct { // MARK: User
 					};
 
 					pub fn getPriority(_: *anyopaque) f32 {
-						return undefined;
+						unreachable;
 					}
 
 					pub fn isStillNeeded(_: *anyopaque) bool {
@@ -397,8 +393,6 @@ pub const User = struct { // MARK: User
 					}
 
 					pub fn run(user: *User) void {
-						defer user.decreaseRefCount();
-
 						var newTasks: main.List(main.utils.ThreadPool.Task) = .initCapacity(main.stackAllocator, user.jobQueue.size);
 						defer newTasks.deinit(main.stackAllocator);
 						while (user.jobQueue.extractAny()) |_task| {
@@ -419,13 +413,12 @@ pub const User = struct { // MARK: User
 						};
 					}
 
-					pub fn clean(user: *User) void {
-						user.decreaseRefCount();
+					pub fn clean(_: *anyopaque) void {
+						unreachable;
 					}
 				};
 				// Create a task to resort tasks:
 				self.jobQueueLastUpdate.alreadyInUpdate = true;
-				self.increaseRefCount();
 				return .{
 					.{
 						.cachedPriority = undefined,
@@ -603,11 +596,10 @@ fn init(name: []const u8, singlePlayerPort: ?u16, mode: ServerWorld.Mode) void {
 	if (singlePlayerPort) |port| blk: {
 		const ipString = main.stackAllocator.print("127.0.0.1:{}", .{port});
 		defer main.stackAllocator.free(ipString);
-		const user = User.initAndIncreaseRefCount(connectionManager, ipString) catch |err| {
+		const user = User.init(connectionManager, ipString) catch |err| {
 			std.log.err("Cannot create singleplayer user {s}", .{@errorName(err)});
 			break :blk;
 		};
-		defer user.decreaseRefCount();
 		user.isLocal = true;
 	}
 }
@@ -622,14 +614,8 @@ fn deinit() void {
 	users.clearAndFree();
 
 	while (userDeinitList.popFront()) |user| {
-		user.clearJobQueue();
-		if (user.refCount.load(.monotonic) == 1) {
-			user.decreaseRefCount();
-		} else {
-			std.log.err("Leaked user {f}", .{user});
-			user.pause();
-			user.deinit();
-		}
+		user.pause();
+		user.privateDeinit();
 	}
 
 	if (world) |_world| {
@@ -646,21 +632,10 @@ fn deinit() void {
 	main.heap.allocators.destroyWorldArena();
 }
 
-pub fn getUserListAndIncreaseRefCount(allocator: main.heap.NeverFailingAllocator) []*User {
+pub fn getUserList(allocator: main.heap.NeverFailingAllocator) []*User {
 	userMutex.lock();
 	defer userMutex.unlock();
-	const result = allocator.dupe(*User, users.items);
-	for (result) |user| {
-		user.increaseRefCount();
-	}
-	return result;
-}
-
-pub fn freeUserListAndDecreaseRefCount(allocator: main.heap.NeverFailingAllocator, list: []*User) void {
-	for (list) |user| {
-		user.decreaseRefCount();
-	}
-	allocator.free(list);
+	return allocator.dupe(*User, users.items);
 }
 
 fn getInitialEntityList(allocator: main.heap.NeverFailingAllocator) []const u8 {
@@ -683,11 +658,10 @@ fn update() void { // MARK: update()
 
 	while (userConnectList.popFront()) |user| {
 		connectInternal(user);
-		user.decreaseRefCount();
 	}
 
-	const userList = getUserListAndIncreaseRefCount(main.stackAllocator);
-	defer freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+	const userList = getUserList(main.stackAllocator);
+	defer main.stackAllocator.free(userList);
 	for (userList) |user| {
 		user.update();
 	}
@@ -722,12 +696,7 @@ fn update() void { // MARK: update()
 	}
 
 	while (userDeinitList.popFront()) |user| {
-		if (user.refCount.load(.monotonic) == 1) {
-			user.decreaseRefCount();
-		} else {
-			userDeinitList.pushBack(user);
-			break;
-		}
+		user.deferredPauseAndDeinit();
 	}
 }
 
@@ -755,13 +724,7 @@ pub fn startFromExistingThread(name: []const u8, port: ?u16, mode: ServerWorld.M
 		connectionManager = undefined;
 
 		while (userDeinitList.popFront()) |user| {
-			if (user.refCount.load(.monotonic) == 1) {
-				_ = user.refCount.fetchSub(1, .monotonic);
-				user.deinit();
-			} else {
-				std.log.err("Leaked user {f}", .{user});
-				user.deinit();
-			}
+			user.privateDeinit();
 		}
 
 		userDeinitList.deinit();
@@ -829,15 +792,14 @@ pub fn removePlayer(user: *User) void { // MARK: removePlayer()
 	zonArray.array.append(.{.int = @intFromEnum(user.id)});
 	const data = zonArray.toStringEfficient(main.stackAllocator, &.{});
 	defer main.stackAllocator.free(data);
-	const userList = getUserListAndIncreaseRefCount(main.stackAllocator);
-	defer freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+	const userList = getUserList(main.stackAllocator);
+	defer main.stackAllocator.free(userList);
 	for (userList) |other| {
 		main.network.protocols.entity.send(other.conn, data);
 	}
 }
 
 pub fn connect(user: *User) void {
-	user.increaseRefCount();
 	userConnectList.pushBack(user);
 }
 
@@ -847,8 +809,8 @@ pub fn connectInternal(user: *User) void {
 	user.conn.handShakeState.store(.complete, .monotonic);
 
 	// TODO: addEntity(player);
-	const userList = getUserListAndIncreaseRefCount(main.stackAllocator);
-	defer freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+	const userList = getUserList(main.stackAllocator);
+	defer main.stackAllocator.free(userList);
 	// Check if a user with that account is already present
 	if (!world.?.settings.testingMode) {
 		for (userList) |other| {
@@ -900,8 +862,8 @@ fn sendRawMessage(msg: []const u8) void {
 	chatMutex.lock();
 	defer chatMutex.unlock();
 	main.log.chat("{s}", .{msg});
-	const userList = getUserListAndIncreaseRefCount(main.stackAllocator);
-	defer freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+	const userList = getUserList(main.stackAllocator);
+	defer main.stackAllocator.free(userList);
 	for (userList) |user| {
 		user.sendRawMessage(msg);
 	}
@@ -914,12 +876,11 @@ pub fn sendMessage(comptime fmt: []const u8, args: anytype) void {
 	sendRawMessage(msg);
 }
 
-pub fn getUserByIndexAndIncreaseRefCount(index: usize) ?*User {
-	const userList = getUserListAndIncreaseRefCount(main.stackAllocator);
-	defer freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+pub fn getUserByIndex(index: PlayerIndex) ?*User {
+	const userList = getUserList(main.stackAllocator);
+	defer main.stackAllocator.free(userList);
 	for (userList) |user| {
 		if (user.playerIndex == index) {
-			user.increaseRefCount();
 			return user;
 		}
 	}

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -177,7 +177,7 @@ pub const ChunkManager = struct { // MARK: ChunkManager
 	}
 
 	const Source = union(enum) {
-		user: *User,
+		player: server.PlayerIndex,
 		simulationChunk: *SimulationChunk,
 	};
 
@@ -200,7 +200,11 @@ pub const ChunkManager = struct { // MARK: ChunkManager
 				.source = source,
 			};
 			switch (source) {
-				.user => |user| {
+				.player => |player| {
+					const user = server.getUserByIndex(player) orelse {
+						main.globalAllocator.destroy(task);
+						return;
+					};
 					user.addTask(task, &vtable);
 				},
 				else => {
@@ -211,25 +215,25 @@ pub const ChunkManager = struct { // MARK: ChunkManager
 
 		pub fn getPriority(self: *ChunkLoadTask) f32 {
 			switch (self.source) {
-				.user => |user| return self.pos.getPriority(user.player().pos),
+				.player => |player| {
+					const user = server.getUserByIndex(player) orelse return 0;
+					return self.pos.getPriority(user.player().pos);
+				},
 				else => return std.math.floatMax(f32),
 			}
 		}
 
 		pub fn isStillNeeded(self: *ChunkLoadTask) bool {
-			switch (self.source) { // Remove the task if the player disconnected
-				.user => |user| if (!user.connected.load(.monotonic)) return false,
-				.simulationChunk => |ch| if (ch.refCount.load(.monotonic) == 2) return false,
-			}
 			switch (self.source) { // Remove the task if it's far enough away from the player:
-				.user => |user| {
+				.player => |player| {
+					const user = server.getUserByIndex(player) orelse return false;
 					const minDistSquare = self.pos.getMinDistanceSquared(user.clientUpdatePos);
 					//                                                                              ↓ Margin for error. (diagonal of 1 chunk)
 					var targetRenderDistance: i64 = @as(i64, user.renderDistance)*chunk.chunkSize + @as(i64, @ceil(@as(comptime_int, chunk.chunkSize)*@sqrt(3.0)));
 					targetRenderDistance *= self.pos.voxelSize;
 					return minDistSquare <= targetRenderDistance*targetRenderDistance;
 				},
-				.simulationChunk => {},
+				.simulationChunk => |ch| if (ch.refCount.load(.monotonic) == 2) return false,
 			}
 			return true;
 		}
@@ -241,7 +245,7 @@ pub const ChunkManager = struct { // MARK: ChunkManager
 
 		pub fn clean(self: *ChunkLoadTask) void {
 			switch (self.source) {
-				.user => |user| user.decreaseRefCount(),
+				.player => {},
 				.simulationChunk => |ch| ch.decreaseRefCount(),
 			}
 			main.globalAllocator.destroy(self);
@@ -250,7 +254,7 @@ pub const ChunkManager = struct { // MARK: ChunkManager
 
 	const LightMapLoadTask = struct { // MARK: LightMapLoadTask
 		pos: terrain.SurfaceMap.MapFragmentPosition,
-		source: ?*User,
+		source: ?main.server.PlayerIndex,
 
 		const vtable = utils.ThreadPool.VTable{
 			.getPriority = main.meta.castFunctionSelfToAnyopaque(getPriority),
@@ -260,11 +264,11 @@ pub const ChunkManager = struct { // MARK: ChunkManager
 			.taskType = .misc,
 		};
 
-		pub fn scheduleAndDecreaseRefCount(pos: terrain.SurfaceMap.MapFragmentPosition, source: ?*User) void {
+		pub fn schedule(pos: terrain.SurfaceMap.MapFragmentPosition, source: ?*User) void {
 			const task = main.globalAllocator.create(LightMapLoadTask);
 			task.* = LightMapLoadTask{
 				.pos = pos,
-				.source = source,
+				.source = if (source) |u| u.playerIndex else null,
 			};
 			if (source) |user| {
 				user.addTask(task, &vtable);
@@ -274,7 +278,8 @@ pub const ChunkManager = struct { // MARK: ChunkManager
 		}
 
 		pub fn getPriority(self: *LightMapLoadTask) f32 {
-			if (self.source) |user| {
+			if (self.source) |playerIndex| {
+				const user = server.getUserByIndex(playerIndex) orelse return 0;
 				return self.pos.getPriority(user.player().pos, terrain.LightMap.LightMapFragment.mapSize) + 100;
 			} else {
 				return std.math.floatMax(f32);
@@ -290,10 +295,11 @@ pub const ChunkManager = struct { // MARK: ChunkManager
 			defer self.clean();
 			const map = terrain.LightMap.getOrGenerateFragment(self.pos.wx, self.pos.wy, self.pos.voxelSize);
 			if (self.source) |source| {
-				if (source.connected.load(.monotonic)) main.network.protocols.lightMapTransmission.sendLightMap(source.conn, map);
+				const user = server.getUserByIndex(source) orelse return;
+				if (user.connected.load(.monotonic)) main.network.protocols.lightMapTransmission.sendLightMap(user.conn, map);
 			} else {
-				const userList = server.getUserListAndIncreaseRefCount(main.stackAllocator);
-				defer server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+				const userList = server.getUserList(main.stackAllocator);
+				defer main.stackAllocator.free(userList);
 				for (userList) |user| {
 					main.network.protocols.lightMapTransmission.sendLightMap(user.conn, map);
 				}
@@ -301,9 +307,6 @@ pub const ChunkManager = struct { // MARK: ChunkManager
 		}
 
 		pub fn clean(self: *LightMapLoadTask) void {
-			if (self.source) |source| {
-				source.decreaseRefCount();
-			}
 			main.globalAllocator.destroy(self);
 		}
 	};
@@ -330,20 +333,21 @@ pub const ChunkManager = struct { // MARK: ChunkManager
 		storage.deinit();
 	}
 
-	pub fn queueLightMapAndDecreaseRefCount(self: ChunkManager, pos: terrain.SurfaceMap.MapFragmentPosition, source: ?*User) void {
+	pub fn queueLightMap(self: ChunkManager, pos: terrain.SurfaceMap.MapFragmentPosition, source: ?*User) void {
 		_ = self;
-		LightMapLoadTask.scheduleAndDecreaseRefCount(pos, source);
+		LightMapLoadTask.schedule(pos, source);
 	}
 
-	pub fn queueChunkAndDecreaseRefCount(self: ChunkManager, pos: ChunkPosition, source: *User) void {
+	pub fn queueChunk(self: ChunkManager, pos: ChunkPosition, source: *User) void {
 		_ = self;
-		ChunkLoadTask.scheduleAndDecreaseRefCount(pos, .{.user = source});
+		ChunkLoadTask.scheduleAndDecreaseRefCount(pos, .{.player = source.playerIndex});
 	}
 
 	pub fn generateChunk(pos: ChunkPosition, source: Source) void { // MARK: generateChunk()
 		const ch = getOrGenerateChunkAndIncreaseRefCount(pos);
 		switch (source) {
-			.user => |user| {
+			.player => |player| {
+				const user = server.getUserByIndex(player) orelse return;
 				main.network.protocols.chunkTransmission.sendChunk(user.conn, ch);
 				ch.decreaseRefCount();
 			},
@@ -1073,8 +1077,8 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 	}
 
 	pub fn saveAllPlayers(self: *ServerWorld) !void {
-		const userList = server.getUserListAndIncreaseRefCount(main.stackAllocator);
-		defer server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+		const userList = server.getUserList(main.stackAllocator);
+		defer main.stackAllocator.free(userList);
 
 		for (userList) |user| {
 			try savePlayer(self, user);
@@ -1137,8 +1141,8 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		}
 		if (self.lastUnimportantDataSent.durationTo(newTime).toSeconds() > 2) {
 			self.lastUnimportantDataSent = newTime;
-			const userList = server.getUserListAndIncreaseRefCount(main.stackAllocator);
-			defer server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+			const userList = server.getUserList(main.stackAllocator);
+			defer main.stackAllocator.free(userList);
 			for (userList) |user| {
 				main.network.protocols.genericUpdate.sendTime(user.conn, self);
 			}
@@ -1149,8 +1153,8 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		// Item Entities
 		self.itemDropManager.update(deltaTime);
 		{ // Collect item entities:
-			const userList = server.getUserListAndIncreaseRefCount(main.stackAllocator);
-			defer server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+			const userList = server.getUserList(main.stackAllocator);
+			defer main.stackAllocator.free(userList);
 			for (userList) |user| {
 				self.itemDropManager.checkEntity(user);
 			}
@@ -1178,12 +1182,12 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		}
 	}
 
-	pub fn queueChunkAndDecreaseRefCount(self: *ServerWorld, pos: ChunkPosition, source: *User) void {
-		self.chunkManager.queueChunkAndDecreaseRefCount(pos, source);
+	pub fn queueChunk(self: *ServerWorld, pos: ChunkPosition, source: *User) void {
+		self.chunkManager.queueChunk(pos, source);
 	}
 
-	pub fn queueLightMapAndDecreaseRefCount(self: *ServerWorld, pos: terrain.SurfaceMap.MapFragmentPosition, source: *User) void {
-		self.chunkManager.queueLightMapAndDecreaseRefCount(pos, source);
+	pub fn queueLightMap(self: *ServerWorld, pos: terrain.SurfaceMap.MapFragmentPosition, source: *User) void {
+		self.chunkManager.queueLightMap(pos, source);
 	}
 
 	pub fn getSimulationChunkAndIncreaseRefCount(_: *ServerWorld, x: i32, y: i32, z: i32) ?*SimulationChunk {
@@ -1270,8 +1274,8 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 			if (neighborBlock.mode().dependsOnNeighbors and neighborBlock.mode().updateData(&neighborBlock, neighbor.reverse(), newBlock)) {
 				ch.updateBlockAndSetChanged(neighborPos.x, neighborPos.y, neighborPos.z, neighborBlock);
 
-				const userList = server.getUserListAndIncreaseRefCount(main.stackAllocator);
-				defer server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+				const userList = server.getUserList(main.stackAllocator);
+				defer main.stackAllocator.free(userList);
 
 				for (userList) |user| {
 					main.network.protocols.blockUpdate.send(user.conn, &.{.{.pos = .{wx +% neighbor.relX(), wy +% neighbor.relY(), wz +% neighbor.relZ()}, .newBlock = neighborBlock, .blockEntityData = &.{}}});
@@ -1293,8 +1297,8 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		}
 		baseChunk.updateBlockAndSetChanged(pos.x, pos.y, pos.z, newBlock);
 
-		const userList = server.getUserListAndIncreaseRefCount(main.stackAllocator);
-		defer server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+		const userList = server.getUserList(main.stackAllocator);
+		defer main.stackAllocator.free(userList);
 
 		for (userList) |user| {
 			main.network.protocols.blockUpdate.send(user.conn, &.{.{.pos = .{wx, wy, wz}, .newBlock = newBlock, .blockEntityData = &.{}}});

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1689,8 +1689,8 @@ pub const Command = struct { // MARK: Command
 			var target: ?*main.server.User = null;
 
 			if (ctx.side == .server) {
-				const userList = main.server.getUserListAndIncreaseRefCount(main.stackAllocator);
-				defer main.server.freeUserListAndDecreaseRefCount(main.stackAllocator, userList);
+				const userList = main.server.getUserList(main.stackAllocator);
+				defer main.stackAllocator.free(userList);
 				for (userList) |user| {
 					if (user.id == self.target) {
 						target = user;

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -814,7 +814,7 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 	threads: []std.Thread,
 	currentTasks: []Atomic(?*const VTable),
 	loadList: ConcurrentMaxHeap(Task),
-	playerJobQueue: ConcurrentQueue(*main.server.User),
+	playerJobQueue: ConcurrentQueue(main.server.PlayerIndex),
 	taskCountSemaphore: main.utils.Semaphore = .{},
 	stopSemaphore: main.utils.Semaphore = .{},
 	startSemaphore: main.utils.Semaphore = .{},
@@ -853,10 +853,6 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 		// Clear the remaining tasks:
 		while (self.loadList.extractAny()) |task| {
 			task.vtable.clean(task.self);
-		}
-
-		while (self.playerJobQueue.popFront()) |player| {
-			player.decreaseRefCount();
 		}
 
 		for (self.threads) |thread| {
@@ -910,10 +906,9 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 	}
 
 	pub fn unschedulePlayers(self: *ThreadPool) void {
-		while (self.playerJobQueue.popFront()) |player| {
+		while (self.playerJobQueue.popFront()) |_| {
 			self.taskCountSemaphore.timedWait(.zero) catch {};
 			_ = self.trueQueueSize.fetchSub(1, .monotonic);
-			player.decreaseRefCount();
 		}
 	}
 
@@ -923,15 +918,13 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 		}
 		blk: {
 			const player = self.playerJobQueue.popFront() orelse break :blk;
-			const result, const hasMoreTasks = player.getTaskFromJobQueue() orelse {
+			const user = main.server.getUserByIndex(player) orelse break :blk;
+			const result, const hasMoreTasks = user.getTaskFromJobQueue() orelse {
 				_ = self.trueQueueSize.fetchSub(1, .monotonic);
-				player.decreaseRefCount();
 				break :blk;
 			};
 			switch (hasMoreTasks) {
-				.empty => {
-					player.decreaseRefCount();
-				},
+				.empty => {},
 				.hasMoreTasks => {
 					self.playerJobQueue.pushBack(player);
 					self.taskCountSemaphore.post();
@@ -1014,8 +1007,7 @@ pub const ThreadPool = struct { // MARK: ThreadPool
 	}
 
 	pub fn addPlayer(self: *ThreadPool, player: *main.server.User) void {
-		player.increaseRefCount();
-		self.playerJobQueue.pushBack(player);
+		self.playerJobQueue.pushBack(player.playerIndex);
 		self.taskCountSemaphore.post();
 		_ = self.trueQueueSize.fetchAdd(1, .monotonic);
 	}


### PR DESCRIPTION
To allow this, all places that previously kept a `*User` for longer, now reference the `playerIndex` instead.
Note, this does break the ability to join a world twice which is a commonly used thing in debugging.
Apart from that it's mostly straight-forward refactoring.

progress towards #1413
should fix #3383 (now the `User` is guaranteed to be removed in a more timely manner, it may still stick around, but only under immense lag of the other threads)