### PR TITLE
Add `/count` command

### DIFF
--- a/src/server/command.zig
+++ b/src/server/command.zig
@@ -180,6 +180,18 @@ pub const BiomeId = struct {
 	}
 };
 
+pub const BlockId = struct {
+	block: main.blocks.Block,
+
+	pub fn parse(_: NeverFailingAllocator, name: []const u8, args: []const u8, errorMessage: *ListManaged(u8)) error{ParseError}!@This() {
+		const blockTyp = main.blocks.getBlockById(args) catch {
+			errorMessage.print("Couldn't find block for <{s}> with id \"{s}\"", .{name, args});
+			return error.ParseError;
+		};
+		return .{.block = .{.typ = blockTyp, .data = 0}};
+	}
+};
+
 pub const EntityModel = struct {
 	index: main.entityModel.EntityModelIndex,
 

--- a/src/server/command/_list.zig
+++ b/src/server/command/_list.zig
@@ -22,6 +22,7 @@ pub const pos1 = @import("worldedit/pos1.zig");
 pub const pos2 = @import("worldedit/pos2.zig");
 pub const deselect = @import("worldedit/deselect.zig");
 pub const copy = @import("worldedit/copy.zig");
+pub const count = @import("worldedit/count.zig");
 pub const paste = @import("worldedit/paste.zig");
 pub const blueprint = @import("worldedit/blueprint.zig");
 pub const rotate = @import("worldedit/rotate.zig");

--- a/src/server/command/worldedit/count.zig
+++ b/src/server/command/worldedit/count.zig
@@ -7,14 +7,17 @@ const Source = command.Source;
 const Block = main.blocks.Block;
 const Blueprint = main.blueprint.Blueprint;
 
-pub const description = "Count blocks in selection.";
-pub const usage = "/count";
+pub const description = "Count block(s) appearance(s) in selection.";
+pub const usage =
+	\\/count <blockId>
+	\\/count
+;
 
 pub const Args = union(enum) {
-	@"/count": struct {},
+	@"/count": struct { block: ?command.BlockId },
 };
 
-pub fn execute(_: Args, source: Source) void {
+pub fn execute(args: Args, source: Source) void {
 	if (source != .user) {
 		source.sendMessage("Command cannot be run without a user", .{});
 		return;
@@ -31,11 +34,16 @@ pub fn execute(_: Args, source: Source) void {
 			var context: std.AutoHashMapUnmanaged(u16, u32) = .{};
 			defer context.deinit(main.stackAllocator.allocator);
 
-			success.apply(&context, count);
+			success.apply(&context, countBlocks);
 
-			var iterator = context.iterator();
-			while (iterator.next()) |next| {
-				user.sendMessage("#ffff00{s} #ffffff{d}", .{(Block{.typ = next.key_ptr.*, .data = 0}).id(), next.value_ptr.*});
+			if (args.@"/count".block) |block| {
+				const count = context.get(block.block.typ) orelse 0;
+				user.sendMessage("#ffff00{s} #ffffff{d}", .{block.block.id(), count});
+			} else {
+				var iterator = context.iterator();
+				while (iterator.next()) |next| {
+					user.sendMessage("#ffff00{s} #ffffff{d}", .{(Block{.typ = next.key_ptr.*, .data = 0}).id(), next.value_ptr.*});
+				}
 			}
 		},
 		.failure => |e| {
@@ -45,7 +53,7 @@ pub fn execute(_: Args, source: Source) void {
 	}
 }
 
-fn count(context: *std.AutoHashMapUnmanaged(u16, u32), current: Block) Block {
+fn countBlocks(context: *std.AutoHashMapUnmanaged(u16, u32), current: Block) Block {
 	const result = context.getOrPut(main.stackAllocator.allocator, current.typ) catch unreachable;
 	if (result.found_existing) {
 		result.value_ptr.* = result.value_ptr.* + 1;

--- a/src/server/command/worldedit/count.zig
+++ b/src/server/command/worldedit/count.zig
@@ -29,12 +29,12 @@ pub fn execute(args: Args, source: Source) void {
 
 	switch (result) {
 		.success => |*blueprint| {
-			defer success.deinit(main.stackAllocator);
+			defer blueprint.deinit(main.stackAllocator);
 
 			var context: std.AutoHashMapUnmanaged(u16, u32) = .{};
 			defer context.deinit(main.stackAllocator.allocator);
 
-			success.apply(&context, countBlocks);
+			blueprint.apply(&context, countBlocks);
 
 			if (args.@"/count".block) |block| {
 				const count = context.get(block.block.typ) orelse 0;

--- a/src/server/command/worldedit/count.zig
+++ b/src/server/command/worldedit/count.zig
@@ -40,9 +40,20 @@ pub fn execute(args: Args, source: Source) void {
 				const count = context.get(block.block.typ) orelse 0;
 				user.sendMessage("#ffff00{s} #ffffff{d}", .{block.block.id(), count});
 			} else {
+				const TypAndCount = struct { typ: u16, count: u32 };
+				var items: main.List(TypAndCount) = .empty;
+
 				var iterator = context.iterator();
-				while (iterator.next()) |next| {
-					user.sendMessage("#ffff00{s} #ffffff{d}", .{(Block{.typ = next.key_ptr.*, .data = 0}).id(), next.value_ptr.*});
+				while (iterator.next()) |next| items.append(main.stackAllocator, .{.typ = next.key_ptr.*, .count = next.value_ptr.*});
+
+				std.sort.insertion(TypAndCount, items.items, {}, struct {
+					fn lessThan(_: void, a: TypAndCount, b: TypAndCount) bool {
+						return a.count > b.count;
+					}
+				}.lessThan);
+
+				for (items.items) |item| {
+					user.sendMessage("#ffffff{d: <6} #ffff00{s}", .{item.count, (Block{.typ = item.typ, .data = 0}).id()});
 				}
 			}
 		},

--- a/src/server/command/worldedit/count.zig
+++ b/src/server/command/worldedit/count.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+
+const main = @import("main");
+const command = main.server.command;
+const Source = command.Source;
+
+const Block = main.blocks.Block;
+const Blueprint = main.blueprint.Blueprint;
+
+pub const description = "Count blocks in selection.";
+pub const usage = "/count";
+
+pub const Args = union(enum) {
+	@"/count": struct {},
+};
+
+pub fn execute(_: Args, source: Source) void {
+	if (source != .user) {
+		source.sendMessage("Command cannot be run without a user", .{});
+		return;
+	}
+	const user = source.user;
+	const selection = command.getCurrentSelection(user) catch return;
+
+	var result = Blueprint.capture(main.stackAllocator, selection);
+
+	switch (result) {
+		.success => |*success| {
+			defer success.deinit(main.stackAllocator);
+
+			var context: std.AutoHashMapUnmanaged(u16, u32) = .{};
+			defer context.deinit(main.stackAllocator.allocator);
+
+			success.apply(&context, count);
+
+			var iterator = context.iterator();
+			while (iterator.next()) |next| {
+				user.sendMessage("#ffff00{s} #ffffff{d}", .{(Block{.typ = next.key_ptr.*, .data = 0}).id(), next.value_ptr.*});
+			}
+		},
+		.failure => |e| {
+			user.sendMessage("#ff0000Error while capturing block {}: {s}", .{e.pos, e.message});
+			std.log.warn("Error while capturing block {}: {s}", .{e.pos, e.message});
+		},
+	}
+}
+
+fn count(context: *std.AutoHashMapUnmanaged(u16, u32), current: Block) Block {
+	const result = context.getOrPut(main.stackAllocator.allocator, current.typ) catch unreachable;
+	if (result.found_existing) {
+		result.value_ptr.* = result.value_ptr.* + 1;
+	} else {
+		result.value_ptr.* = 1;
+	}
+	return current;
+}

--- a/src/server/command/worldedit/count.zig
+++ b/src/server/command/worldedit/count.zig
@@ -67,7 +67,7 @@ pub fn execute(args: Args, source: Source) void {
 fn countBlocks(context: *std.AutoHashMapUnmanaged(u16, u32), current: Block) Block {
 	const result = context.getOrPut(main.stackAllocator.allocator, current.typ) catch unreachable;
 	if (result.found_existing) {
-		result.value_ptr.* = result.value_ptr.* + 1;
+		result.value_ptr.* += 1;
 	} else {
 		result.value_ptr.* = 1;
 	}

--- a/src/server/command/worldedit/count.zig
+++ b/src/server/command/worldedit/count.zig
@@ -28,7 +28,7 @@ pub fn execute(args: Args, source: Source) void {
 	var result = Blueprint.capture(main.stackAllocator, selection);
 
 	switch (result) {
-		.success => |*success| {
+		.success => |*blueprint| {
 			defer success.deinit(main.stackAllocator);
 
 			var context: std.AutoHashMapUnmanaged(u16, u32) = .{};

--- a/src/server/command/worldedit/count.zig
+++ b/src/server/command/worldedit/count.zig
@@ -42,6 +42,7 @@ pub fn execute(args: Args, source: Source) void {
 			} else {
 				const TypAndCount = struct { typ: u16, count: u32 };
 				var items: main.List(TypAndCount) = .empty;
+				defer items.deinit(main.stackAllocator);
 
 				var iterator = context.iterator();
 				while (iterator.next()) |next| items.append(main.stackAllocator, .{.typ = next.key_ptr.*, .count = next.value_ptr.*});


### PR DESCRIPTION
Adds trivial `/count` command implementation. 

<img width="971" height="564" alt="image" src="https://github.com/user-attachments/assets/149f88f5-d931-47f7-9df2-a17cdfc52936" />

Currently based on hash map, when we swap to palette storage for blueprints (#1896) we can reduce it to just printing palette entries.
It could be useful to get also entity counts and differentiate blocks with different data values, all out of scope, material for future improvements.

Resolves: #3043
