### PR TITLE
Show a clear error when autoEnterWorld names a missing world

### DIFF
--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -581,7 +581,10 @@ fn init(name: []const u8, singlePlayerPort: ?u16, mode: ServerWorld.Mode) void {
 	main.sync.server.init();
 
 	world = ServerWorld.init(name, mode) catch |err| {
-		std.log.err("Failed to create world: {s}", .{@errorName(err)});
+		std.log.err("Failed to open world \"{s}\": {s}", .{name, @errorName(err)});
+		if (err == error.WorldNotFound) {
+			std.process.exit(1);
+		}
 		@panic("Can't create world.");
 	};
 

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -492,6 +492,12 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		const arena = main.stackAllocator.createArena();
 		defer main.stackAllocator.destroyArena(arena);
 
+		// openDir creates missing paths, so check that this is a real save first.
+		if (!files.cubyzDir().hasFile(arena.print("saves/{s}/world.zig.zon", .{path}))) {
+			std.log.err("World \"{s}\" not found. Expected \"{s}/saves/{s}/world.zig.zon\".", .{path, files.cubyzDirStr(), path});
+			return error.WorldNotFound;
+		}
+
 		var dir = try files.cubyzDir().openDir(arena.print("saves/{s}", .{path}));
 		defer dir.close();
 
@@ -513,13 +519,12 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		self.entityComponentPalette = try loadPalette(arena, path, "entity_component_palette", null);
 		errdefer self.entityComponentPalette.deinit();
 
-		errdefer main.assets.unloadAssets();
-
 		const worldData = try dir.readToZon(arena, "world.zig.zon");
 		try self.loadWorldConfig(arena, dir, worldData);
 		try self.loadPlayerLoginInfo(dir);
 
 		try main.assets.loadWorldAssets(arena.print("{s}/saves/{s}/assets/", .{files.cubyzDirStr(), path}), self.blockPalette, self.itemPalette, self.proceduralItemPalette, self.biomePalette, self.entityModelPalette, self.entityComponentPalette);
+		errdefer main.assets.unloadAssets();
 		// Store the block palette now that everything is loaded.
 		try dir.writeZon("palette.zig.zon", self.blockPalette.storeToZon(arena));
 		try dir.writeZon("item_palette.zig.zon", self.itemPalette.storeToZon(arena));


### PR DESCRIPTION
## Summary
Fixes #3436

When `launchConfig.autoEnterWorld` points at a world that does not exist, Cubyz used to:
1. create an empty `saves/<name>/` directory (because `openDir` creates missing paths),
2. fail reading `world.zig.zon` with a raw `FileNotFound` stacktrace,
3. hit `unloadAssets` from an `errdefer` that ran before assets were loaded, which asserted and printed a second stacktrace.

## Changes
- Check for `saves/<name>/world.zig.zon` before opening the save directory.
- Log a clear error that includes the world name and the expected path.
- Return `error.WorldNotFound` and exit cleanly from the server instead of panicking for that case.
- Move the `unloadAssets` `errdefer` to after a successful `loadWorldAssets`, so failed world loads no longer assert during cleanup.

## Test plan
- [x] `zig build -Doptimize=Debug` succeeds
- [ ] Set `headlessServer = true` and `autoEnterWorld = "does_not_exist"` in `launchConfig.zon`; expect a short console error naming the missing world and a non-zero exit, with no assert stacktrace and no empty `saves/does_not_exist/` folder left behind
- [ ] Open an existing world via `autoEnterWorld` still works as before