### PR TITLE
Tag Restriction for Ores

### DIFF
--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -216,7 +216,7 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 			std.log.err("Ore must have rotation mode \"cubyz:ore\"!", .{});
 			break :blk;
 		}
-		const targetBlockTags = Tag.loadTagsFromZon(main.stackAllocator, oreProperties.getChild("tags"));
+		const targetBlockTags = Tag.loadTagsFromZon(main.stackAllocator, oreProperties.getChild("targetTags"));
 		defer main.stackAllocator.free(targetBlockTags);
 		ores.append(main.worldArena, .{
 			.veins = oreProperties.get(f32, "veins") orelse 0,

--- a/src/blocks.zig
+++ b/src/blocks.zig
@@ -66,6 +66,8 @@ pub const Ore = struct {
 	maxHeight: i32,
 	minHeight: i32,
 
+	targetTags: []const Tag,
+
 	blockType: u16,
 	seed: u64,
 };
@@ -214,6 +216,8 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 			std.log.err("Ore must have rotation mode \"cubyz:ore\"!", .{});
 			break :blk;
 		}
+		const targetBlockTags = Tag.loadTagsFromZon(main.stackAllocator, oreProperties.getChild("tags"));
+		defer main.stackAllocator.free(targetBlockTags);
 		ores.append(main.worldArena, .{
 			.veins = oreProperties.get(f32, "veins") orelse 0,
 			.size = oreProperties.get(f32, "size") orelse 0,
@@ -221,6 +225,7 @@ pub fn register(_: []const u8, id: []const u8, zon: ZonElement) u16 {
 			.minHeight = oreProperties.get(i32, "minHeight") orelse std.math.minInt(i32),
 			.density = oreProperties.get(f32, "density") orelse 0.5,
 			.blockType = @intCast(size),
+			.targetTags = targetBlockTags,
 			.seed = std.hash.Wyhash.hash(0, id),
 		});
 	}

--- a/src/server/terrain/chunkgen/OreGenerator.zig
+++ b/src/server/terrain/chunkgen/OreGenerator.zig
@@ -96,7 +96,7 @@ fn considerCoordinates(ore: *const main.blocks.Ore, relX: f32, relY: f32, relZ: 
 				zMin = @max(zMin, 0);
 				zMax = @min(zMax, chunk.super.width);
 				var curZ = zMin;
-				while (curZ < zMax) : (curZ += 1) {
+				outer: while (curZ < zMax) : (curZ += 1) {
 					const distToCenterZ = (@as(f32, @floatFromInt(curZ)) - veinRelZ)/radius;
 					const distSqr = xyDistSqr + distToCenterZ*distToCenterZ;
 					if (distSqr >= 1) continue;
@@ -104,13 +104,11 @@ fn considerCoordinates(ore: *const main.blocks.Ore, relX: f32, relY: f32, relZ: 
 					if ((1 - distSqr)*ore.density < random.nextFloat(&veinSeed)) continue;
 					const stoneBlock = chunk.getBlock(curX, curY, curZ);
 					if (!stoneBlock.allowOres()) continue;
-					var hasCorrectTags: bool = true;
 					for (ore.targetTags) |tag| {
 						if (!stoneBlock.hasTag(tag)) {
 							continue :outer;
 						}
 					}
-					if (!hasCorrectTags) continue;
 					chunk.updateBlockInGeneration(curX, curY, curZ, .{.typ = ore.blockType, .data = stoneBlock.typ});
 				}
 			}

--- a/src/server/terrain/chunkgen/OreGenerator.zig
+++ b/src/server/terrain/chunkgen/OreGenerator.zig
@@ -99,15 +99,20 @@ fn considerCoordinates(ore: *const main.blocks.Ore, relX: f32, relY: f32, relZ: 
 				while (curZ < zMax) : (curZ += 1) {
 					const distToCenterZ = (@as(f32, @floatFromInt(curZ)) - veinRelZ)/radius;
 					const distSqr = xyDistSqr + distToCenterZ*distToCenterZ;
-					if (distSqr < 1) {
-						// Add some roughness. The ore density gets smaller at the edges:
-						if ((1 - distSqr)*ore.density >= random.nextFloat(&veinSeed)) {
-							const stoneBlock = chunk.getBlock(curX, curY, curZ);
-							if (chunk.getBlock(curX, curY, curZ).allowOres()) {
-								chunk.updateBlockInGeneration(curX, curY, curZ, .{.typ = ore.blockType, .data = stoneBlock.typ});
-							}
+					if (distSqr >= 1) continue;
+					// Add some roughness. The ore density gets smaller at the edges:
+					if ((1 - distSqr)*ore.density < random.nextFloat(&veinSeed)) continue;
+					const stoneBlock = chunk.getBlock(curX, curY, curZ);
+					if (!stoneBlock.allowOres()) continue;
+					var hasCorrectTags: bool = true;
+					for (ore.targetTags) |tag| {
+						if (!stoneBlock.hasTag(tag)) {
+							hasCorrectTags = false;
+							break;
 						}
 					}
+					if (!hasCorrectTags) continue;
+					chunk.updateBlockInGeneration(curX, curY, curZ, .{.typ = ore.blockType, .data = stoneBlock.typ});
 				}
 			}
 		}

--- a/src/server/terrain/chunkgen/OreGenerator.zig
+++ b/src/server/terrain/chunkgen/OreGenerator.zig
@@ -107,8 +107,7 @@ fn considerCoordinates(ore: *const main.blocks.Ore, relX: f32, relY: f32, relZ: 
 					var hasCorrectTags: bool = true;
 					for (ore.targetTags) |tag| {
 						if (!stoneBlock.hasTag(tag)) {
-							hasCorrectTags = false;
-							break;
+							continue :outer;
 						}
 					}
 					if (!hasCorrectTags) continue;


### PR DESCRIPTION
Allows a ore to have a target tag restriction where it can decide what kind of block it will try to generate in
useful for limiting ores to certain biomes but not certain depths

Can also be useful for making certain ores more common in certain blocks