### PR TITLE
Fix handshake panic

### DIFF
--- a/src/server/players.zig
+++ b/src/server/players.zig
@@ -83,8 +83,6 @@ pub fn isEmpty() bool {
 }
 
 pub fn allocateNewIndex() usize {
-	mutex.lock();
-	defer mutex.unlock();
 	return nextPlayerIndex.fetchAdd(1, .monotonic);
 }
 
@@ -128,6 +126,7 @@ const EnsureResult = struct { entry: *PlayerRecord, wasNew: bool };
 
 fn ensurePlayerRecord(key: []const u8) EnsureResult {
 	sync.threadContext.assertCorrectContext(.server);
+	mutex.assertLocked();
 
 	const result = playerDatabase.getOrPut(main.worldArena.allocator, key) catch unreachable;
 	if (result.found_existing) return .{.entry = result.value_ptr, .wasNew = false};

--- a/src/server/players.zig
+++ b/src/server/players.zig
@@ -12,6 +12,8 @@ var localPlayerIndex: usize = undefined;
 var nextPlayerIndex: std.atomic.Value(usize) = undefined;
 var worldPath: []const u8 = undefined;
 
+var mutex: main.utils.Mutex = .{};
+
 fn init(path: []const u8, loadedLocalPlayerIndex: usize) void {
 	sync.threadContext.assertCorrectContext(.server);
 	worldPath = main.worldArena.dupe(u8, path);
@@ -68,20 +70,28 @@ pub fn getLocalPlayerIndex() usize {
 }
 
 pub fn lookupIndex(key: []const u8) ?usize {
+	mutex.lock();
+	defer mutex.unlock();
 	const entry = playerDatabase.get(key) orelse return null;
 	return entry.playerIndex;
 }
 
 pub fn isEmpty() bool {
+	mutex.lock();
+	defer mutex.unlock();
 	return playerDatabase.size == 0;
 }
 
 pub fn allocateNewIndex() usize {
+	mutex.lock();
+	defer mutex.unlock();
 	return nextPlayerIndex.fetchAdd(1, .monotonic);
 }
 
 pub fn rebindKey(oldPublicKeyFromFile: ?[]const u8, oldNameFromFile: ?[]const u8, newKey: []const u8, index: usize) void {
 	sync.threadContext.assertCorrectContext(.server);
+	mutex.lock();
+	defer mutex.unlock();
 	var blocked = false;
 	if (oldPublicKeyFromFile) |publicKey| {
 		blocked = playerDatabase.fetchRemove(publicKey).?.value.blocked;
@@ -155,6 +165,8 @@ fn saveBlocked(index: usize, value: bool) void {
 const AddResult = enum { added, alreadyAllowed };
 
 pub fn add(key: []const u8) AddResult {
+	mutex.lock();
+	defer mutex.unlock();
 	const result = ensurePlayerRecord(key);
 	const wasBlocked = result.entry.blocked;
 	result.entry.blocked = false;
@@ -165,6 +177,8 @@ pub fn add(key: []const u8) AddResult {
 const BlockResult = enum { blocked, alreadyBlocked };
 
 pub fn block(key: []const u8) BlockResult {
+	mutex.lock();
+	defer mutex.unlock();
 	const result = ensurePlayerRecord(key);
 	const wasBlocked = result.entry.blocked;
 	result.entry.blocked = true;
@@ -174,6 +188,8 @@ pub fn block(key: []const u8) BlockResult {
 
 pub fn isAllowedToJoin(key: []const u8) bool {
 	sync.threadContext.assertCorrectContext(.server);
+	mutex.lock();
+	defer mutex.unlock();
 	const entry = playerDatabase.get(key) orelse return false;
 	return !entry.blocked;
 }

--- a/src/server/players.zig
+++ b/src/server/players.zig
@@ -68,18 +68,15 @@ pub fn getLocalPlayerIndex() usize {
 }
 
 pub fn lookupIndex(key: []const u8) ?usize {
-	sync.threadContext.assertCorrectContext(.server);
 	const entry = playerDatabase.get(key) orelse return null;
 	return entry.playerIndex;
 }
 
 pub fn isEmpty() bool {
-	sync.threadContext.assertCorrectContext(.server);
 	return playerDatabase.size == 0;
 }
 
 pub fn allocateNewIndex() usize {
-	sync.threadContext.assertCorrectContext(.server);
 	return nextPlayerIndex.fetchAdd(1, .monotonic);
 }
 


### PR DESCRIPTION
My PR #3365 introduced a bug which crashes the game on debug during connection to a server. 3 of the functions I added assert server context, but they're actually called on the network thread (`handShake.serverReceive` calls `User.identifyFromKeysAndName`). This removes those asserts.

fixes #3477