### PR TITLE
Enforce whitelist and add command

### DIFF
--- a/src/network.zig
+++ b/src/network.zig
@@ -1737,16 +1737,11 @@ pub const Connection = struct { // MARK: Connection
 
 	pub fn receive(self: *Connection, data: []const u8) void {
 		self.tryReceive(data) catch |err| {
-			switch (err) {
-				error.NotWhitelisted => {},
-				else => {
-					std.log.err("Got error while processing received network data: {s}", .{@errorName(err)});
-					if (@errorReturnTrace()) |trace| {
-						std.log.info("{f}", .{main.fmt.FormatErrorTrace{.stackTrace = trace.*}});
-					}
-					std.log.debug("Packet data: {any}", .{data});
-				},
+			std.log.warn("Got error while processing received network data: {s}", .{@errorName(err)});
+			if (@errorReturnTrace()) |trace| {
+				std.log.info("{f}", .{main.fmt.FormatErrorTrace{.stackTrace = trace.*}});
 			}
+			std.log.debug("Packet data: {any}", .{data});
 			self.disconnect();
 		};
 	}

--- a/src/network.zig
+++ b/src/network.zig
@@ -1737,11 +1737,16 @@ pub const Connection = struct { // MARK: Connection
 
 	pub fn receive(self: *Connection, data: []const u8) void {
 		self.tryReceive(data) catch |err| {
-			std.log.err("Got error while processing received network data: {s}", .{@errorName(err)});
-			if (@errorReturnTrace()) |trace| {
-				std.log.info("{f}", .{main.fmt.FormatErrorTrace{.stackTrace = trace.*}});
+			switch (err) {
+				error.NotWhitelisted => {},
+				else => {
+					std.log.err("Got error while processing received network data: {s}", .{@errorName(err)});
+					if (@errorReturnTrace()) |trace| {
+						std.log.info("{f}", .{main.fmt.FormatErrorTrace{.stackTrace = trace.*}});
+					}
+					std.log.debug("Packet data: {any}", .{data});
+				},
 			}
-			std.log.debug("Packet data: {any}", .{data});
 			self.disconnect();
 		};
 	}

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -171,7 +171,7 @@ pub const handShake = struct { // MARK: handShake
 						const keys = zon.getChild("keys");
 						try conn.user.?.identifyFromKeysAndName(name, keys);
 
-						if (!main.server.players.isAllowedToJoin(conn.user.?.newKeyString.?, main.server.world.?.whitelistEnabled.load(.monotonic))) {
+						if (!main.server.players.isAllowedToJoin(conn.user.?.newKeyString.?, main.server.world.?.settings.whitelistEnabled.load(.monotonic))) {
 							std.log.info("Rejected connection from '{s}' ({s})", .{name, conn.user.?.newKeyString.?});
 							return error.NotWhitelisted;
 						}

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -171,11 +171,6 @@ pub const handShake = struct { // MARK: handShake
 						const keys = zon.getChild("keys");
 						try conn.user.?.identifyFromKeysAndName(name, keys, main.server.world.?.settings.whitelistEnabled.load(.monotonic));
 
-						if (!conn.user.?.allowedToJoin) {
-							std.log.info("Rejected connection from '{s}' ({s})", .{name, conn.user.?.newKeyString.?});
-							return error.NotWhitelisted;
-						}
-
 						var writer: utils.BinaryWriter = .init(main.stackAllocator);
 						defer writer.deinit();
 						writer.writeEnum(Connection.HandShakeState, .signatureRequest);

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -169,9 +169,9 @@ pub const handShake = struct { // MARK: handShake
 
 					if (main.server.world.?.mode != .singleplayer) {
 						const keys = zon.getChild("keys");
-						try conn.user.?.identifyFromKeysAndName(name, keys);
+						try conn.user.?.identifyFromKeysAndName(name, keys, main.server.world.?.settings.whitelistEnabled.load(.monotonic));
 
-						if (!main.server.players.isAllowedToJoin(conn.user.?.newKeyString.?, main.server.world.?.settings.whitelistEnabled.load(.monotonic))) {
+						if (!conn.user.?.allowedToJoin) {
 							std.log.info("Rejected connection from '{s}' ({s})", .{name, conn.user.?.newKeyString.?});
 							return error.NotWhitelisted;
 						}

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -171,16 +171,9 @@ pub const handShake = struct { // MARK: handShake
 						const keys = zon.getChild("keys");
 						try conn.user.?.identifyFromKeysAndName(name, keys);
 
-						switch (main.server.players.isAllowedToJoin(conn.user.?.newKeyString.?)) {
-							.allowed => {},
-							.blocked => {
-								std.log.info("Rejected connection from '{s}': blocked", .{name});
-								return error.NotWhitelisted;
-							},
-							.neutral => if (main.server.world.?.settings.whitelistEnabled) {
-								std.log.info("Rejected connection from '{s}': not on whitelist", .{name});
-								return error.NotWhitelisted;
-							},
+						if (!main.server.players.isAllowedToJoin(conn.user.?.newKeyString.?, main.server.world.?.whitelistEnabled.load(.monotonic))) {
+							std.log.info("Rejected connection from '{s}' ({s})", .{name, conn.user.?.newKeyString.?});
+							return error.NotWhitelisted;
 						}
 
 						var writer: utils.BinaryWriter = .init(main.stackAllocator);

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -171,9 +171,16 @@ pub const handShake = struct { // MARK: handShake
 						const keys = zon.getChild("keys");
 						try conn.user.?.identifyFromKeysAndName(name, keys);
 
-						if (main.server.world.?.settings.whitelistEnabled and !main.server.players.isAllowedToJoin(conn.user.?.newKeyString.?)) {
-							std.log.info("Rejected connection from '{s}': not on whitelist", .{name});
-							return error.NotWhitelisted;
+						switch (main.server.players.isAllowedToJoin(conn.user.?.newKeyString.?)) {
+							.allowed => {},
+							.blocked => {
+								std.log.info("Rejected connection from '{s}': blocked", .{name});
+								return error.NotWhitelisted;
+							},
+							.neutral => if (main.server.world.?.settings.whitelistEnabled) {
+								std.log.info("Rejected connection from '{s}': not on whitelist", .{name});
+								return error.NotWhitelisted;
+							},
 						}
 
 						var writer: utils.BinaryWriter = .init(main.stackAllocator);

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -171,6 +171,11 @@ pub const handShake = struct { // MARK: handShake
 						const keys = zon.getChild("keys");
 						try conn.user.?.identifyFromKeysAndName(name, keys);
 
+						if (main.server.world.?.settings.whitelistEnabled and !main.server.players.isAllowedToJoin(conn.user.?.newKeyString.?)) {
+							std.log.info("Rejected connection from '{s}': not on whitelist", .{name});
+							return error.NotWhitelisted;
+						}
+
 						var writer: utils.BinaryWriter = .init(main.stackAllocator);
 						defer writer.deinit();
 						writer.writeEnum(Connection.HandShakeState, .signatureRequest);

--- a/src/server/command.zig
+++ b/src/server/command.zig
@@ -177,8 +177,12 @@ pub const KeyString = struct {
 			errorMessage.print("Expected a public key of the form \"<keyType>:<base64>\" for <{s}>, found \"{s}\"", .{name, arg});
 			return error.ParseError;
 		};
-		_ = std.meta.stringToEnum(main.network.authentication.KeyTypeEnum, arg[0..colonIndex]) orelse {
+		const keyType = std.meta.stringToEnum(main.network.authentication.KeyTypeEnum, arg[0..colonIndex]) orelse {
 			errorMessage.print("Unknown key type \"{s}\" for <{s}>", .{arg[0..colonIndex], name});
+			return error.ParseError;
+		};
+		_ = main.network.authentication.PublicKey.initFromBase64(arg[colonIndex + 1 ..], keyType) catch {
+			errorMessage.print("Invalid public key \"{s}\" for <{s}>", .{arg, name});
 			return error.ParseError;
 		};
 		return .{.key = arg};

--- a/src/server/command.zig
+++ b/src/server/command.zig
@@ -169,6 +169,22 @@ pub const PlayerIndex = struct {
 	}
 };
 
+pub const KeyString = struct {
+	key: []const u8,
+
+	pub fn parse(_: NeverFailingAllocator, name: []const u8, arg: []const u8, errorMessage: *ListManaged(u8)) error{ParseError}!KeyString {
+		const colonIndex = std.mem.indexOfScalar(u8, arg, ':') orelse {
+			errorMessage.print("Expected a public key of the form \"<keyType>:<base64>\" for <{s}>, found \"{s}\"", .{name, arg});
+			return error.ParseError;
+		};
+		_ = std.meta.stringToEnum(main.network.authentication.KeyTypeEnum, arg[0..colonIndex]) orelse {
+			errorMessage.print("Unknown key type \"{s}\" for <{s}>", .{arg[0..colonIndex], name});
+			return error.ParseError;
+		};
+		return .{.key = arg};
+	}
+};
+
 pub const BiomeId = struct {
 	biome: *const main.server.terrain.biomes.Biome,
 

--- a/src/server/command/_list.zig
+++ b/src/server/command/_list.zig
@@ -11,6 +11,7 @@ pub const spawn = @import("spawn.zig");
 pub const tickspeed = @import("tickspeed.zig");
 pub const time = @import("time.zig");
 pub const tp = @import("tp.zig");
+pub const whitelist = @import("whitelist.zig");
 
 pub const avatar = @import("entity/avatar.zig");
 

--- a/src/server/command/whitelist.zig
+++ b/src/server/command/whitelist.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 
 const main = @import("main");
-const NeverFailingAllocator = main.heap.NeverFailingAllocator;
-const ListManaged = main.ListManaged;
 const command = main.server.command;
 const Source = command.Source;
 const players = main.server.players;
@@ -16,7 +14,7 @@ pub const usage =
 const Action = enum { add, block };
 
 pub const Args = union(enum) {
-	@"/whitelist <action> <key>": struct { action: Action, key: KeyString },
+	@"/whitelist <action> <key>": struct { action: Action, key: command.KeyString },
 	@"/whitelist <action> <playerIndex>": struct { action: Action, playerIndex: command.PlayerIndex },
 };
 
@@ -40,25 +38,14 @@ fn applyAction(source: Source, action: Action, key: []const u8) void {
 			.added => source.sendMessage("#00ff00Added {s}§#00ff00 to the whitelist", .{key}),
 			.alreadyAllowed => source.sendMessage("#ff0000{s}§#ff0000 is already on the whitelist", .{key}),
 		},
-		.block => switch (players.block(key)) {
-			.blocked => source.sendMessage("#00ff00Blocked {s}§#00ff00 from connecting", .{key}),
-			.alreadyBlocked => source.sendMessage("#ff0000{s}§#ff0000 is already blocked", .{key}),
+		.block => {
+			switch (players.block(key)) {
+				.blocked => source.sendMessage("#00ff00Blocked {s}§#00ff00 from connecting", .{key}),
+				.alreadyBlocked => source.sendMessage("#ff0000{s}§#ff0000 is already blocked", .{key}),
+			}
+			if (main.server.getUserByKey(key)) |user| {
+				user.conn.disconnect();
+			}
 		},
 	}
 }
-
-const KeyString = struct {
-	key: []const u8,
-
-	pub fn parse(_: NeverFailingAllocator, name: []const u8, arg: []const u8, errorMessage: *ListManaged(u8)) error{ParseError}!KeyString {
-		const colonIndex = std.mem.indexOfScalar(u8, arg, ':') orelse {
-			errorMessage.print("Expected a public key of the form \"<keyType>:<base64>\" for <{s}>, found \"{s}\"", .{name, arg});
-			return error.ParseError;
-		};
-		_ = std.meta.stringToEnum(main.network.authentication.KeyTypeEnum, arg[0..colonIndex]) orelse {
-			errorMessage.print("Unknown key type \"{s}\" for <{s}>", .{arg[0..colonIndex], name});
-			return error.ParseError;
-		};
-		return .{.key = arg};
-	}
-};

--- a/src/server/command/whitelist.zig
+++ b/src/server/command/whitelist.zig
@@ -9,13 +9,16 @@ pub const description = "Manages the connection whitelist";
 pub const usage =
 	\\/whitelist <add/block> <keyType>:<base64Key>
 	\\/whitelist <add/block> @<playerIndex>
+	\\/whitelist <enable/disable>
 ;
 
 const Action = enum { add, block };
+const Toggle = enum { enable, disable };
 
 pub const Args = union(enum) {
 	@"/whitelist <action> <key>": struct { action: Action, key: command.KeyString },
 	@"/whitelist <action> <playerIndex>": struct { action: Action, playerIndex: command.PlayerIndex },
+	@"/whitelist <enable/disable>": struct { toggle: Toggle },
 };
 
 pub fn execute(args: Args, source: Source) void {
@@ -28,6 +31,10 @@ pub fn execute(args: Args, source: Source) void {
 				return;
 			};
 			applyAction(source, params.action, key);
+		},
+		.@"/whitelist <enable/disable>" => |params| {
+			main.server.world.?.whitelistEnabled.store(params.toggle == .enable, .monotonic);
+			source.sendMessage("#00ff00Whitelist {s}", .{if (params.toggle == .enable) "enabled" else "disabled"});
 		},
 	}
 }
@@ -43,8 +50,15 @@ fn applyAction(source: Source, action: Action, key: []const u8) void {
 				.blocked => source.sendMessage("#00ff00Blocked {s}§#00ff00 from connecting", .{key}),
 				.alreadyBlocked => source.sendMessage("#ff0000{s}§#ff0000 is already blocked", .{key}),
 			}
-			if (main.server.getUserByKey(key)) |user| {
-				user.conn.disconnect();
+			const userList = main.server.getUserList(main.stackAllocator);
+			defer main.stackAllocator.free(userList);
+			for (userList) |user| {
+				if (user.newKeyString) |userKey| {
+					if (std.mem.eql(u8, userKey, key)) {
+						user.conn.disconnect();
+						break;
+					}
+				}
 			}
 		},
 	}

--- a/src/server/command/whitelist.zig
+++ b/src/server/command/whitelist.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+
+const main = @import("main");
+const NeverFailingAllocator = main.heap.NeverFailingAllocator;
+const ListManaged = main.ListManaged;
+const command = main.server.command;
+const Source = command.Source;
+const players = main.server.players;
+
+pub const description = "Manages the connection whitelist";
+pub const usage =
+	\\/whitelist <add/block> <keyType>:<base64Key>
+	\\/whitelist <add/block> @<playerIndex>
+;
+
+const Action = enum { add, block };
+
+pub const Args = union(enum) {
+	@"/whitelist <action> <key>": struct { action: Action, key: KeyString },
+	@"/whitelist <action> <playerIndex>": struct { action: Action, playerIndex: command.PlayerIndex },
+};
+
+pub fn execute(args: Args, source: Source) void {
+	switch (args) {
+		.@"/whitelist <action> <key>" => |params| applyAction(source, params.action, params.key.key),
+		.@"/whitelist <action> <playerIndex>" => |params| {
+			const target = command.Target.fromPlayerIndex(params.playerIndex, source) catch return;
+			const key = target.user.newKeyString orelse {
+				source.sendMessage("#ff0000Player {s}§#ff0000 has no public key to whitelist", .{target.user.name});
+				return;
+			};
+			applyAction(source, params.action, key);
+		},
+	}
+}
+
+fn applyAction(source: Source, action: Action, key: []const u8) void {
+	switch (action) {
+		.add => switch (players.add(key)) {
+			.added => source.sendMessage("#00ff00Added {s}§#00ff00 to the whitelist", .{key}),
+			.alreadyAllowed => source.sendMessage("#ff0000{s}§#ff0000 is already on the whitelist", .{key}),
+		},
+		.block => switch (players.block(key)) {
+			.blocked => source.sendMessage("#00ff00Blocked {s}§#00ff00 from connecting", .{key}),
+			.alreadyBlocked => source.sendMessage("#ff0000{s}§#ff0000 is already blocked", .{key}),
+		},
+	}
+}
+
+const KeyString = struct {
+	key: []const u8,
+
+	pub fn parse(_: NeverFailingAllocator, name: []const u8, arg: []const u8, errorMessage: *ListManaged(u8)) error{ParseError}!KeyString {
+		const colonIndex = std.mem.indexOfScalar(u8, arg, ':') orelse {
+			errorMessage.print("Expected a public key of the form \"<keyType>:<base64>\" for <{s}>, found \"{s}\"", .{name, arg});
+			return error.ParseError;
+		};
+		_ = std.meta.stringToEnum(main.network.authentication.KeyTypeEnum, arg[0..colonIndex]) orelse {
+			errorMessage.print("Unknown key type \"{s}\" for <{s}>", .{arg[0..colonIndex], name});
+			return error.ParseError;
+		};
+		return .{.key = arg};
+	}
+};

--- a/src/server/command/whitelist.zig
+++ b/src/server/command/whitelist.zig
@@ -34,6 +34,9 @@ pub fn execute(args: Args, source: Source) void {
 		},
 		.@"/whitelist <enable/disable>" => |params| {
 			main.server.world.?.settings.whitelistEnabled.store(params.toggle == .enable, .monotonic);
+			main.server.world.?.saveWorldConfig() catch |err| {
+				std.log.err("Error while saving world config: {s}", .{@errorName(err)});
+			};
 			source.sendMessage("#00ff00Whitelist {s}", .{if (params.toggle == .enable) "enabled" else "disabled"});
 		},
 	}

--- a/src/server/command/whitelist.zig
+++ b/src/server/command/whitelist.zig
@@ -33,7 +33,7 @@ pub fn execute(args: Args, source: Source) void {
 			applyAction(source, params.action, key);
 		},
 		.@"/whitelist <enable/disable>" => |params| {
-			main.server.world.?.whitelistEnabled.store(params.toggle == .enable, .monotonic);
+			main.server.world.?.settings.whitelistEnabled.store(params.toggle == .enable, .monotonic);
 			source.sendMessage("#00ff00Whitelist {s}", .{if (params.toggle == .enable) "enabled" else "disabled"});
 		},
 	}

--- a/src/server/players.zig
+++ b/src/server/players.zig
@@ -185,11 +185,13 @@ pub fn block(key: []const u8) BlockResult {
 	return if (result.wasNew or !wasBlocked) .blocked else .alreadyBlocked;
 }
 
-pub fn isAllowedToJoin(key: []const u8) bool {
+pub const JoinResult = enum { allowed, neutral, blocked };
+
+pub fn isAllowedToJoin(key: []const u8) JoinResult {
 	mutex.lock();
 	defer mutex.unlock();
-	const entry = playerDatabase.get(key) orelse return false;
-	return !entry.blocked;
+	const entry = playerDatabase.get(key) orelse return .neutral;
+	return if (entry.blocked) .blocked else .allowed;
 }
 
 test "addContainsRemove" {
@@ -198,13 +200,13 @@ test "addContainsRemove" {
 
 	init("test", 0);
 
-	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:abc"));
+	try std.testing.expectEqual(.neutral, isAllowedToJoin("ed25519:abc"));
 	try std.testing.expectEqual(.added, add("ed25519:abc"));
 	try std.testing.expectEqual(.alreadyAllowed, add("ed25519:abc"));
-	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:abc"));
+	try std.testing.expectEqual(.allowed, isAllowedToJoin("ed25519:abc"));
 	try std.testing.expectEqual(.blocked, block("ed25519:abc"));
 	try std.testing.expectEqual(.alreadyBlocked, block("ed25519:abc"));
-	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:abc"));
+	try std.testing.expectEqual(.blocked, isAllowedToJoin("ed25519:abc"));
 }
 
 test "addUnblocks" {
@@ -214,12 +216,12 @@ test "addUnblocks" {
 	init("test", 0);
 
 	try std.testing.expectEqual(.blocked, block("ed25519:xyz"));
-	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:xyz"));
+	try std.testing.expectEqual(.blocked, isAllowedToJoin("ed25519:xyz"));
 	try std.testing.expectEqual(.added, add("ed25519:xyz"));
-	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:xyz"));
+	try std.testing.expectEqual(.allowed, isAllowedToJoin("ed25519:xyz"));
 }
 
-test "knownPlayerAllowedByDefaultButBlockable" {
+test "allowedNeutralAndBlockedStates" {
 	main.heap.allocators.createWorldArena();
 	defer main.heap.allocators.destroyWorldArena();
 
@@ -227,12 +229,12 @@ test "knownPlayerAllowedByDefaultButBlockable" {
 
 	playerDatabase.put(main.worldArena.allocator, main.worldArena.dupe(u8, "ed25519:known"), .{.playerIndex = 0, .blocked = false}) catch unreachable;
 
-	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:known"));
-	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:unknown"));
+	try std.testing.expectEqual(.allowed, isAllowedToJoin("ed25519:known"));
+	try std.testing.expectEqual(.neutral, isAllowedToJoin("ed25519:unknown"));
 
 	try std.testing.expectEqual(.blocked, block("ed25519:known"));
-	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:known"));
+	try std.testing.expectEqual(.blocked, isAllowedToJoin("ed25519:known"));
 
 	try std.testing.expectEqual(.added, add("ed25519:known"));
-	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:known"));
+	try std.testing.expectEqual(.allowed, isAllowedToJoin("ed25519:known"));
 }

--- a/src/server/players.zig
+++ b/src/server/players.zig
@@ -69,11 +69,13 @@ pub fn getLocalPlayerIndex() usize {
 	return localPlayerIndex;
 }
 
-pub fn lookupIndex(key: []const u8) ?usize {
+const LookupResult = struct { playerIndex: usize, blocked: bool };
+
+pub fn lookupIndex(key: []const u8) ?LookupResult {
 	mutex.lock();
 	defer mutex.unlock();
 	const entry = playerDatabase.get(key) orelse return null;
-	return entry.playerIndex;
+	return .{.playerIndex = entry.playerIndex, .blocked = entry.blocked};
 }
 
 pub fn isEmpty() bool {
@@ -187,26 +189,19 @@ pub fn block(key: []const u8) BlockResult {
 	return if (result.wasNew or !wasBlocked) .blocked else .alreadyBlocked;
 }
 
-pub fn isAllowedToJoin(key: []const u8, whitelistEnabled: bool) bool {
-	mutex.lock();
-	defer mutex.unlock();
-	const entry = playerDatabase.get(key) orelse return !whitelistEnabled;
-	return !entry.blocked;
-}
-
 test "addContainsRemove" {
 	main.heap.allocators.createWorldArena();
 	defer main.heap.allocators.destroyWorldArena();
 
 	init("test", 0);
 
-	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:abc", true));
+	try std.testing.expectEqual(null, lookupIndex("ed25519:abc"));
 	try std.testing.expectEqual(.added, add("ed25519:abc"));
 	try std.testing.expectEqual(.alreadyAllowed, add("ed25519:abc"));
-	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:abc", true));
+	try std.testing.expectEqual(false, lookupIndex("ed25519:abc").?.blocked);
 	try std.testing.expectEqual(.blocked, block("ed25519:abc"));
 	try std.testing.expectEqual(.alreadyBlocked, block("ed25519:abc"));
-	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:abc", true));
+	try std.testing.expectEqual(true, lookupIndex("ed25519:abc").?.blocked);
 }
 
 test "addUnblocks" {
@@ -216,12 +211,12 @@ test "addUnblocks" {
 	init("test", 0);
 
 	try std.testing.expectEqual(.blocked, block("ed25519:xyz"));
-	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:xyz", false));
+	try std.testing.expectEqual(true, lookupIndex("ed25519:xyz").?.blocked);
 	try std.testing.expectEqual(.added, add("ed25519:xyz"));
-	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:xyz", false));
+	try std.testing.expectEqual(false, lookupIndex("ed25519:xyz").?.blocked);
 }
 
-test "whitelistToggleAffectsUnknownKeysOnly" {
+test "lookupIndexDistinguishesKnownAndUnknownKeys" {
 	main.heap.allocators.createWorldArena();
 	defer main.heap.allocators.destroyWorldArena();
 
@@ -229,13 +224,12 @@ test "whitelistToggleAffectsUnknownKeysOnly" {
 
 	playerDatabase.put(main.worldArena.allocator, main.worldArena.dupe(u8, "ed25519:known"), .{.playerIndex = 0, .blocked = false}) catch unreachable;
 
-	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:known", true));
-	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:unknown", false));
-	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:unknown", true));
+	try std.testing.expectEqual(false, lookupIndex("ed25519:known").?.blocked);
+	try std.testing.expectEqual(null, lookupIndex("ed25519:unknown"));
 
 	try std.testing.expectEqual(.blocked, block("ed25519:known"));
-	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:known", false));
+	try std.testing.expectEqual(true, lookupIndex("ed25519:known").?.blocked);
 
 	try std.testing.expectEqual(.added, add("ed25519:known"));
-	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:known", false));
+	try std.testing.expectEqual(false, lookupIndex("ed25519:known").?.blocked);
 }

--- a/src/server/players.zig
+++ b/src/server/players.zig
@@ -164,6 +164,7 @@ fn saveBlocked(index: usize, value: bool) void {
 const AddResult = enum { added, alreadyAllowed };
 
 pub fn add(key: []const u8) AddResult {
+	sync.threadContext.assertCorrectContext(.server);
 	mutex.lock();
 	defer mutex.unlock();
 	const result = ensurePlayerRecord(key);
@@ -176,6 +177,7 @@ pub fn add(key: []const u8) AddResult {
 const BlockResult = enum { blocked, alreadyBlocked };
 
 pub fn block(key: []const u8) BlockResult {
+	sync.threadContext.assertCorrectContext(.server);
 	mutex.lock();
 	defer mutex.unlock();
 	const result = ensurePlayerRecord(key);

--- a/src/server/players.zig
+++ b/src/server/players.zig
@@ -185,7 +185,7 @@ pub fn block(key: []const u8) BlockResult {
 	return if (result.wasNew or !wasBlocked) .blocked else .alreadyBlocked;
 }
 
-pub const JoinResult = enum { allowed, neutral, blocked };
+const JoinResult = enum { allowed, neutral, blocked };
 
 pub fn isAllowedToJoin(key: []const u8) JoinResult {
 	mutex.lock();

--- a/src/server/players.zig
+++ b/src/server/players.zig
@@ -69,13 +69,10 @@ pub fn getLocalPlayerIndex() usize {
 	return localPlayerIndex;
 }
 
-const LookupResult = struct { playerIndex: usize, blocked: bool };
-
-pub fn lookupIndex(key: []const u8) ?LookupResult {
+pub fn lookupIndex(key: []const u8) ?PlayerRecord {
 	mutex.lock();
 	defer mutex.unlock();
-	const entry = playerDatabase.get(key) orelse return null;
-	return .{.playerIndex = entry.playerIndex, .blocked = entry.blocked};
+	return playerDatabase.get(key);
 }
 
 pub fn isEmpty() bool {

--- a/src/server/players.zig
+++ b/src/server/players.zig
@@ -186,7 +186,6 @@ pub fn block(key: []const u8) BlockResult {
 }
 
 pub fn isAllowedToJoin(key: []const u8) bool {
-	sync.threadContext.assertCorrectContext(.server);
 	mutex.lock();
 	defer mutex.unlock();
 	const entry = playerDatabase.get(key) orelse return false;

--- a/src/server/players.zig
+++ b/src/server/players.zig
@@ -187,13 +187,11 @@ pub fn block(key: []const u8) BlockResult {
 	return if (result.wasNew or !wasBlocked) .blocked else .alreadyBlocked;
 }
 
-const JoinResult = enum { allowed, neutral, blocked };
-
-pub fn isAllowedToJoin(key: []const u8) JoinResult {
+pub fn isAllowedToJoin(key: []const u8, whitelistEnabled: bool) bool {
 	mutex.lock();
 	defer mutex.unlock();
-	const entry = playerDatabase.get(key) orelse return .neutral;
-	return if (entry.blocked) .blocked else .allowed;
+	const entry = playerDatabase.get(key) orelse return !whitelistEnabled;
+	return !entry.blocked;
 }
 
 test "addContainsRemove" {
@@ -202,13 +200,13 @@ test "addContainsRemove" {
 
 	init("test", 0);
 
-	try std.testing.expectEqual(.neutral, isAllowedToJoin("ed25519:abc"));
+	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:abc", true));
 	try std.testing.expectEqual(.added, add("ed25519:abc"));
 	try std.testing.expectEqual(.alreadyAllowed, add("ed25519:abc"));
-	try std.testing.expectEqual(.allowed, isAllowedToJoin("ed25519:abc"));
+	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:abc", true));
 	try std.testing.expectEqual(.blocked, block("ed25519:abc"));
 	try std.testing.expectEqual(.alreadyBlocked, block("ed25519:abc"));
-	try std.testing.expectEqual(.blocked, isAllowedToJoin("ed25519:abc"));
+	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:abc", true));
 }
 
 test "addUnblocks" {
@@ -218,12 +216,12 @@ test "addUnblocks" {
 	init("test", 0);
 
 	try std.testing.expectEqual(.blocked, block("ed25519:xyz"));
-	try std.testing.expectEqual(.blocked, isAllowedToJoin("ed25519:xyz"));
+	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:xyz", false));
 	try std.testing.expectEqual(.added, add("ed25519:xyz"));
-	try std.testing.expectEqual(.allowed, isAllowedToJoin("ed25519:xyz"));
+	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:xyz", false));
 }
 
-test "allowedNeutralAndBlockedStates" {
+test "whitelistToggleAffectsUnknownKeysOnly" {
 	main.heap.allocators.createWorldArena();
 	defer main.heap.allocators.destroyWorldArena();
 
@@ -231,12 +229,13 @@ test "allowedNeutralAndBlockedStates" {
 
 	playerDatabase.put(main.worldArena.allocator, main.worldArena.dupe(u8, "ed25519:known"), .{.playerIndex = 0, .blocked = false}) catch unreachable;
 
-	try std.testing.expectEqual(.allowed, isAllowedToJoin("ed25519:known"));
-	try std.testing.expectEqual(.neutral, isAllowedToJoin("ed25519:unknown"));
+	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:known", true));
+	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:unknown", false));
+	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:unknown", true));
 
 	try std.testing.expectEqual(.blocked, block("ed25519:known"));
-	try std.testing.expectEqual(.blocked, isAllowedToJoin("ed25519:known"));
+	try std.testing.expectEqual(false, isAllowedToJoin("ed25519:known", false));
 
 	try std.testing.expectEqual(.added, add("ed25519:known"));
-	try std.testing.expectEqual(.allowed, isAllowedToJoin("ed25519:known"));
+	try std.testing.expectEqual(true, isAllowedToJoin("ed25519:known", false));
 }

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -891,3 +891,14 @@ pub fn getUserByIndex(index: PlayerIndex) ?*User {
 	}
 	return null;
 }
+
+pub fn getUserByKey(key: []const u8) ?*User {
+	const userList = getUserList(main.stackAllocator);
+	defer main.stackAllocator.free(userList);
+	for (userList) |user| {
+		if (user.newKeyString) |userKey| {
+			if (std.mem.eql(u8, userKey, key)) return user;
+		}
+	}
+	return null;
+}

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -135,6 +135,7 @@ pub const User = struct { // MARK: User
 	newKeyString: ?[]const u8 = null,
 	key: network.authentication.PublicKey = undefined,
 	legacyKey: ?network.authentication.PublicKey = null,
+	allowedToJoin: bool = false,
 
 	inventoryClientToServerIdMap: std.AutoHashMap(InventoryId, InventoryId) = undefined,
 	inventory: ?InventoryId = null,
@@ -232,9 +233,10 @@ pub const User = struct { // MARK: User
 		self.jobQueue.deinit();
 	}
 
-	pub fn identifyFromKeysAndName(self: *User, name: []const u8, keys: main.ZonElement) !void {
+	pub fn identifyFromKeysAndName(self: *User, name: []const u8, keys: main.ZonElement, whitelistEnabled: bool) !void {
 		std.debug.assert(self.name.len == 0);
 		self.name = main.globalAllocator.dupe(u8, name);
+		self.allowedToJoin = !whitelistEnabled;
 		{
 			const keyBase64 = keys.get([]const u8, @tagName(main.settings.launchConfig.preferredAuthenticationAlgorithm)) orelse return error.PublicKeyNotPresent;
 			self.key = try .initFromBase64(keyBase64, main.settings.launchConfig.preferredAuthenticationAlgorithm);
@@ -245,7 +247,9 @@ pub const User = struct { // MARK: User
 			const keyBase64 = keys.get([]const u8, keyTypeName) orelse continue;
 			const keyWithType = main.stackAllocator.print("{s}:{s}", .{keyTypeName, keyBase64});
 			defer main.stackAllocator.free(keyWithType);
-			self.playerIndex = main.server.players.lookupIndex(keyWithType) orelse continue;
+			const lookup = main.server.players.lookupIndex(keyWithType) orelse continue;
+			self.playerIndex = lookup.playerIndex;
+			self.allowedToJoin = !lookup.blocked;
 			foundKey = true;
 			const keyType = std.meta.stringToEnum(main.network.authentication.KeyTypeEnum, keyTypeName).?;
 			if (keyType == self.key) break;
@@ -256,10 +260,16 @@ pub const User = struct { // MARK: User
 			if (main.server.players.isEmpty()) { // Claim the local player
 				std.log.info("Here", .{});
 				self.playerIndex = main.server.players.getLocalPlayerIndex();
+				self.allowedToJoin = true;
 			} else {
 				const nameEntry = main.stackAllocator.print("name:{s}", .{name});
 				defer main.stackAllocator.free(nameEntry);
-				self.playerIndex = main.server.players.lookupIndex(nameEntry) orelse main.server.players.allocateNewIndex();
+				if (main.server.players.lookupIndex(nameEntry)) |lookup| {
+					self.playerIndex = lookup.playerIndex;
+					self.allowedToJoin = !lookup.blocked;
+				} else {
+					self.playerIndex = main.server.players.allocateNewIndex();
+				}
 			}
 		}
 	}

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -135,7 +135,6 @@ pub const User = struct { // MARK: User
 	newKeyString: ?[]const u8 = null,
 	key: network.authentication.PublicKey = undefined,
 	legacyKey: ?network.authentication.PublicKey = null,
-	allowedToJoin: bool = false,
 
 	inventoryClientToServerIdMap: std.AutoHashMap(InventoryId, InventoryId) = undefined,
 	inventory: ?InventoryId = null,
@@ -236,7 +235,7 @@ pub const User = struct { // MARK: User
 	pub fn identifyFromKeysAndName(self: *User, name: []const u8, keys: main.ZonElement, whitelistEnabled: bool) !void {
 		std.debug.assert(self.name.len == 0);
 		self.name = main.globalAllocator.dupe(u8, name);
-		self.allowedToJoin = !whitelistEnabled;
+		var allowedToJoin = !whitelistEnabled;
 		{
 			const keyBase64 = keys.get([]const u8, @tagName(main.settings.launchConfig.preferredAuthenticationAlgorithm)) orelse return error.PublicKeyNotPresent;
 			self.key = try .initFromBase64(keyBase64, main.settings.launchConfig.preferredAuthenticationAlgorithm);
@@ -249,7 +248,7 @@ pub const User = struct { // MARK: User
 			defer main.stackAllocator.free(keyWithType);
 			const lookup = main.server.players.lookupIndex(keyWithType) orelse continue;
 			self.playerIndex = lookup.playerIndex;
-			self.allowedToJoin = !lookup.blocked;
+			allowedToJoin = !lookup.blocked;
 			foundKey = true;
 			const keyType = std.meta.stringToEnum(main.network.authentication.KeyTypeEnum, keyTypeName).?;
 			if (keyType == self.key) break;
@@ -260,17 +259,21 @@ pub const User = struct { // MARK: User
 			if (main.server.players.isEmpty()) { // Claim the local player
 				std.log.info("Here", .{});
 				self.playerIndex = main.server.players.getLocalPlayerIndex();
-				self.allowedToJoin = true;
+				allowedToJoin = true;
 			} else {
 				const nameEntry = main.stackAllocator.print("name:{s}", .{name});
 				defer main.stackAllocator.free(nameEntry);
 				if (main.server.players.lookupIndex(nameEntry)) |lookup| {
 					self.playerIndex = lookup.playerIndex;
-					self.allowedToJoin = !lookup.blocked;
+					allowedToJoin = !lookup.blocked;
 				} else {
 					self.playerIndex = main.server.players.allocateNewIndex();
 				}
 			}
+		}
+		if (!allowedToJoin) {
+			std.log.info("Rejected connection from '{s}' ({s})", .{name, self.newKeyString.?});
+			return error.NotWhitelisted;
 		}
 	}
 

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -891,14 +891,3 @@ pub fn getUserByIndex(index: PlayerIndex) ?*User {
 	}
 	return null;
 }
-
-pub fn getUserByKey(key: []const u8) ?*User {
-	const userList = getUserList(main.stackAllocator);
-	defer main.stackAllocator.free(userList);
-	for (userList) |user| {
-		if (user.newKeyString) |userKey| {
-			if (std.mem.eql(u8, userKey, key)) return user;
-		}
-	}
-	return null;
-}

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -35,6 +35,7 @@ pub const Settings = struct {
 	defaultGamemode: Gamemode = .creative,
 	allowCheats: bool = true,
 	testingMode: bool = false,
+	whitelistEnabled: std.atomic.Value(bool) = .init(false),
 	seed: u64 = undefined,
 
 	pub const defaults: Settings = .{};
@@ -48,15 +49,17 @@ pub const Settings = struct {
 			.defaultGamemode = std.meta.stringToEnum(main.game.Gamemode, zon.get([]const u8, "defaultGamemode") orelse @tagName(defaults.defaultGamemode)) orelse defaults.defaultGamemode,
 			.allowCheats = zon.get(bool, "allowCheats") orelse defaults.allowCheats,
 			.testingMode = zon.get(bool, "testingMode") orelse defaults.testingMode,
+			.whitelistEnabled = .init(zon.get(bool, "whitelistEnabled") orelse defaults.whitelistEnabled.load(.monotonic)),
 		};
 	}
 
-	pub fn toZon(self: Settings, allocator: NeverFailingAllocator) ZonElement {
+	pub fn toZon(self: *const Settings, allocator: NeverFailingAllocator) ZonElement {
 		const zon = main.ZonElement.initObject(allocator);
 
 		zon.put("defaultGamemode", @tagName(self.defaultGamemode));
 		zon.put("allowCheats", self.allowCheats);
 		zon.put("testingMode", self.testingMode);
+		zon.put("whitelistEnabled", self.whitelistEnabled.load(.monotonic));
 		zon.put("seed", self.seed);
 
 		return zon;
@@ -443,7 +446,6 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 	doGameTimeCycle: bool = true,
 
 	tickSpeed: std.atomic.Value(u32) = .init(12),
-	whitelistEnabled: std.atomic.Value(bool) = .init(false),
 
 	settings: Settings = undefined,
 
@@ -651,7 +653,6 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		self.biomeChecksum = worldData.get(i64, "biomeChecksum") orelse 0;
 		self.name = main.globalAllocator.dupe(u8, worldData.get([]const u8, "name") orelse self.path);
 		self.tickSpeed = .init(worldData.get(u32, "tickSpeed") orelse 12);
-		self.whitelistEnabled = .init(worldData.get(bool, "whitelistEnabled") orelse false);
 	}
 
 	pub fn saveWorldConfig(self: *ServerWorld) !void {
@@ -667,7 +668,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		worldData.put("name", self.name);
 		worldData.put("lastUsedTime", std.Io.Clock.Timestamp.now(main.io, .real).raw.toMilliseconds());
 		worldData.put("tickSpeed", self.tickSpeed.load(.monotonic));
-		worldData.put("whitelistEnabled", self.whitelistEnabled.load(.monotonic));
+		worldData.put("settings", self.settings.toZon(main.stackAllocator));
 		worldData.put("localPlayer", players.getLocalPlayerIndex());
 
 		try files.cubyzDir().writeZon(path, worldData);

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -35,7 +35,6 @@ pub const Settings = struct {
 	defaultGamemode: Gamemode = .creative,
 	allowCheats: bool = true,
 	testingMode: bool = false,
-	whitelistEnabled: bool = false,
 	seed: u64 = undefined,
 
 	pub const defaults: Settings = .{};
@@ -49,7 +48,6 @@ pub const Settings = struct {
 			.defaultGamemode = std.meta.stringToEnum(main.game.Gamemode, zon.get([]const u8, "defaultGamemode") orelse @tagName(defaults.defaultGamemode)) orelse defaults.defaultGamemode,
 			.allowCheats = zon.get(bool, "allowCheats") orelse defaults.allowCheats,
 			.testingMode = zon.get(bool, "testingMode") orelse defaults.testingMode,
-			.whitelistEnabled = zon.get(bool, "whitelistEnabled") orelse defaults.whitelistEnabled,
 		};
 	}
 
@@ -59,7 +57,6 @@ pub const Settings = struct {
 		zon.put("defaultGamemode", @tagName(self.defaultGamemode));
 		zon.put("allowCheats", self.allowCheats);
 		zon.put("testingMode", self.testingMode);
-		zon.put("whitelistEnabled", self.whitelistEnabled);
 		zon.put("seed", self.seed);
 
 		return zon;
@@ -446,6 +443,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 	doGameTimeCycle: bool = true,
 
 	tickSpeed: std.atomic.Value(u32) = .init(12),
+	whitelistEnabled: std.atomic.Value(bool) = .init(false),
 
 	settings: Settings = undefined,
 
@@ -653,6 +651,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		self.biomeChecksum = worldData.get(i64, "biomeChecksum") orelse 0;
 		self.name = main.globalAllocator.dupe(u8, worldData.get([]const u8, "name") orelse self.path);
 		self.tickSpeed = .init(worldData.get(u32, "tickSpeed") orelse 12);
+		self.whitelistEnabled = .init(worldData.get(bool, "whitelistEnabled") orelse false);
 	}
 
 	pub fn saveWorldConfig(self: *ServerWorld) !void {
@@ -668,6 +667,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		worldData.put("name", self.name);
 		worldData.put("lastUsedTime", std.Io.Clock.Timestamp.now(main.io, .real).raw.toMilliseconds());
 		worldData.put("tickSpeed", self.tickSpeed.load(.monotonic));
+		worldData.put("whitelistEnabled", self.whitelistEnabled.load(.monotonic));
 		worldData.put("localPlayer", players.getLocalPlayerIndex());
 
 		try files.cubyzDir().writeZon(path, worldData);

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -35,6 +35,7 @@ pub const Settings = struct {
 	defaultGamemode: Gamemode = .creative,
 	allowCheats: bool = true,
 	testingMode: bool = false,
+	whitelistEnabled: bool = false,
 	seed: u64 = undefined,
 
 	pub const defaults: Settings = .{};
@@ -48,6 +49,7 @@ pub const Settings = struct {
 			.defaultGamemode = std.meta.stringToEnum(main.game.Gamemode, zon.get([]const u8, "defaultGamemode") orelse @tagName(defaults.defaultGamemode)) orelse defaults.defaultGamemode,
 			.allowCheats = zon.get(bool, "allowCheats") orelse defaults.allowCheats,
 			.testingMode = zon.get(bool, "testingMode") orelse defaults.testingMode,
+			.whitelistEnabled = zon.get(bool, "whitelistEnabled") orelse defaults.whitelistEnabled,
 		};
 	}
 
@@ -57,6 +59,7 @@ pub const Settings = struct {
 		zon.put("defaultGamemode", @tagName(self.defaultGamemode));
 		zon.put("allowCheats", self.allowCheats);
 		zon.put("testingMode", self.testingMode);
+		zon.put("whitelistEnabled", self.whitelistEnabled);
 		zon.put("seed", self.seed);
 
 		return zon;


### PR DESCRIPTION
Enforces the player whitelist during the connection handshake and adds a `/whitelist` command to manage it.

After a connecting player's key is resolved, the server checks `players.isAllowedToJoin` when `world.settings.whitelistEnabled` is set, rejecting the connection with `error.NotWhitelisted`.

Command syntax: `/whitelist <add/block> <keyType>:<base64Key>` or `/whitelist <add/block> @<playerIndex>`

Also removes error logging for `error.NotWhitelisted` since it's expected to reject and already logs the reason right after rejection.

Closes #2566