### PR TITLE
Allow the time difference to jump when it notices that its consistently too far off from the true value

### DIFF
--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1620,19 +1620,26 @@ pub fn GenericInterpolation(comptime elements: comptime_int) type { // MARK: Gen
 
 pub const TimeDifference = struct { // MARK: TimeDifference
 	difference: Atomic(i16) = .init(0),
-	firstValue: bool = true,
+	// Checks how many times in a row we are off in the same direction
+	biasCounter: Atomic(i16) = .init(std.math.maxInt(i16)),
 
 	pub fn addDataPoint(self: *TimeDifference, time: i16) void {
 		const currentTime: i16 = @truncate(main.timestamp().toMilliseconds());
 		const timeDifference = currentTime -% time;
-		if (self.firstValue) {
+		if (@abs(self.biasCounter.load(.monotonic)) > main.server.updatesPerSec*5) {
 			self.difference.store(timeDifference, .monotonic);
-			self.firstValue = false;
+			self.biasCounter.store(0, .monotonic);
 		}
 		if (timeDifference -% self.difference.load(.monotonic) > 0) {
 			_ = @atomicRmw(i16, &self.difference.raw, .Add, 1, .monotonic);
+			if (self.biasCounter.fetchAdd(1, .monotonic) < 0) {
+				self.biasCounter.store(0, .monotonic);
+			}
 		} else if (timeDifference -% self.difference.load(.monotonic) < 0) {
 			_ = @atomicRmw(i16, &self.difference.raw, .Add, -1, .monotonic);
+			if (self.biasCounter.fetchAdd(-1, .monotonic) > 0) {
+				self.biasCounter.store(0, .monotonic);
+			}
 		}
 	}
 };


### PR DESCRIPTION
This is detected by checking whether the last 5 seconds worth of samples were off in the same direction, at which point it should be obvious that the old estimate is wrong by a big margin.

This improves correction of an issue on startup where the initial time difference is overestimated, causing interpolation on the client to be incorrect.

(Note this does not fix the root issue, I'll make an issue for the root issue in a bit)

@iNiKKo Please confirm that this fixes the issue, it will still be present for 5 seconds, but then it should fix itself.