### PR TITLE
Fix incorrect initial RTT estimate for localhost

### DIFF
--- a/src/network.zig
+++ b/src/network.zig
@@ -1711,6 +1711,7 @@ pub const Connection = struct { // MARK: Connection
 			self.rttUncertainty = (1 - beta)*self.rttUncertainty + beta*largestDifference;
 			self.lastRttSampleTime = timestamp;
 			if (!self.hasRttEstimate) { // Kill the 1 second delay caused by the first packet
+				self.rttEstimate = averageRtt;
 				self.nextPacketTimestamp = timestamp;
 				self.hasRttEstimate = true;
 			}


### PR DESCRIPTION
I forgot to set it when the connection has no RTT estimate yet.
This alone was responsible for about 1-2 seconds of debug mode startup time. oops
I found this while investigating the issue described in #3479, and in fact this also fixes it (somewhat).