### PR TITLE
Add more info to the first Account setup screen and put save as file first

### DIFF
--- a/src/gui/windows/authentication/create_account_general_info.zig
+++ b/src/gui/windows/authentication/create_account_general_info.zig
@@ -31,7 +31,8 @@ fn next() void {
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
 	const width = 420;
-	list.add(Label.init(.{0, 0}, width, "An Account Code acts as a password and identity.", .left));
+	list.add(Label.init(.{0, 0}, width, "Cubyz does not store any of your personal data on a server. This makes account setup a bit unusual. Please continue carefully to make sure you don't lose access.", .left));
+	list.add(Label.init(.{0, 0}, width, "We will give you an Account Code which acts as a password and identity.", .left));
 	list.add(Label.init(.{0, 0}, width, "If you lose your Account Code, you lose your Account. There are no recovery options, so please store it somewhere safe.", .left));
 	button = Button.initText(.{0, 0}, 300, "Continue (8)", .{.onAction = .init(next), .disabled = true});
 	list.add(button);

--- a/src/gui/windows/authentication/create_account_storage_method.zig
+++ b/src/gui/windows/authentication/create_account_storage_method.zig
@@ -32,8 +32,8 @@ fn next(storageMethod: usize) void {
 pub fn onOpen() void {
 	const list = VerticalList.init(.{padding, 16 + padding}, 300, 16);
 	list.add(Label.init(.{0, 0}, 300, "Please select how you would like to store your Account Code", .left));
-	list.add(Button.initText(.{0, 0}, 300, "Password Manager (recommended)", .{.onAction = .initWithInt(next, @intFromEnum(StorageMethod.passwordManager))}));
 	list.add(Button.initText(.{0, 0}, 300, "Save as file", .{.onAction = .initWithInt(next, @intFromEnum(StorageMethod.file))}));
+	list.add(Button.initText(.{0, 0}, 300, "Password Manager (recommended)", .{.onAction = .initWithInt(next, @intFromEnum(StorageMethod.passwordManager))}));
 	list.add(Button.initText(.{0, 0}, 300, "Write it down yourself", .{.onAction = .initWithInt(next, @intFromEnum(StorageMethod.paper))}));
 	list.finish(.center);
 	window.rootComponent = list.toComponent();


### PR DESCRIPTION
Related discussion
https://discord.com/channels/443805812390100992/895731509972058194/1534991669106315495

Putting this in waiting for artistic review so Ikabod can take a look at it too.

Only the following two screens were changed:
First one has more text
<img width="1280" height="745" alt="Screenshot at 2026-08-06 20-28-10" src="https://github.com/user-attachments/assets/09dfca5c-3900-48bb-bac6-d73c50e9b977" />
Second one has the order changed to put save as file first
<img width="1280" height="745" alt="Screenshot at 2026-08-06 20-45-15" src="https://github.com/user-attachments/assets/888fed57-6065-4e3e-8e42-967e3ad2cfe2" />
