### PR TITLE
0.17.0 vector changes

### DIFF
--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -1926,7 +1926,7 @@ pub const Texture = struct { // MARK: Texture
 
 	pub fn size(self: Texture) Vec2i {
 		self.bind();
-		var result: Vec2i = undefined;
+		var result: [2]i32 = undefined;
 		c.glGetTexLevelParameteriv(c.GL_TEXTURE_2D, 0, c.GL_TEXTURE_WIDTH, &result[0]);
 		c.glGetTexLevelParameteriv(c.GL_TEXTURE_2D, 0, c.GL_TEXTURE_HEIGHT, &result[1]);
 		return result;

--- a/src/renderer/chunk_meshing.zig
+++ b/src/renderer/chunk_meshing.zig
@@ -285,10 +285,10 @@ pub const FaceData = extern struct {
 };
 
 pub const ChunkData = extern struct {
-	position: Vec3i align(16),
-	min: Vec3f align(16),
-	max: Vec3f align(16),
-	voxelSize: i32,
+	position: [3]i32 align(16),
+	min: [3]f32 align(16),
+	max: [3]f32 align(16),
+	voxelSize: i32 align(16),
 	lightStart: u32,
 	vertexStartOpaque: u32,
 	faceCountsByNormalOpaque: [14]u32,


### PR DESCRIPTION
Fixes #3465 
While the size function now on 0.17.0 gives an error, I still kept that change in here.
