### PR TITLE
set source.amount to the actual amount

### DIFF
--- a/src/sync.zig
+++ b/src/sync.zig
@@ -742,11 +742,11 @@ pub const Command = struct { // MARK: Command
 			.moveToBag => |*info| {
 				const source = info.source.ref();
 				const amount = @min(source.amount, info.amount);
-				source.amount = info.dest.push(.{.item = source.item, .amount = amount});
+				info.amount = amount - info.dest.push(.{.item = source.item, .amount = amount});
+				source.amount -= info.amount;
 				if (source.amount == 0) {
 					source.item = .null;
 				}
-				info.amount = amount - source.amount;
 			},
 			.takeFromBag => |*info| {
 				const dest = info.dest.ref();


### PR DESCRIPTION
Fixes #3516 
The code thought that `info.amount` is always >= than `source.amount` as it seems. But as seen through #3516 it sometimes sends `moveToBag` with amount 0, this also seems to make #3515 more likely, when picking items up + shit clicking into bag)