### PR TITLE
Exclusively render stuff that works in the vulkan window

### DIFF
--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -193,17 +193,8 @@ pub const draw = struct { // MARK: draw
 		pos += translation;
 		dim *= @splat(scale);
 
-		rectPipeline.bind(getScissor());
-
 		var viewport: [4]c_int = undefined;
 		c.glGetIntegerv(c.GL_VIEWPORT, &viewport);
-		c.glUniform2f(rectUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
-		c.glUniform2f(rectUniforms.start, pos[0], pos[1]);
-		c.glUniform2f(rectUniforms.size, dim[0], dim[1]);
-		c.glUniform1i(rectUniforms.rectColor, @bitCast(getColor()));
-
-		rectVao.bind();
-		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 
 		if (main.settings.launchConfig.vulkanTestingMode) {
 			vulkan.currentFrame.guiCommands.bindPipeline(rectPipeline, getScissor());
@@ -215,6 +206,16 @@ pub const draw = struct { // MARK: draw
 			});
 			vulkan.currentFrame.guiCommands.bindVertexArray(rectVao);
 			vulkan.currentFrame.guiCommands.draw(4, 0);
+		} else {
+			rectPipeline.bind(getScissor());
+
+			c.glUniform2f(rectUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
+			c.glUniform2f(rectUniforms.start, pos[0], pos[1]);
+			c.glUniform2f(rectUniforms.size, dim[0], dim[1]);
+			c.glUniform1i(rectUniforms.rectColor, @bitCast(getColor()));
+
+			rectVao.bind();
+			c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
 		}
 	}
 
@@ -293,18 +294,8 @@ pub const draw = struct { // MARK: draw
 		dim *= @splat(scale);
 		width *= scale;
 
-		rectBorderPipeline.bind(getScissor());
-
 		var viewport: [4]c_int = undefined;
 		c.glGetIntegerv(c.GL_VIEWPORT, &viewport);
-		c.glUniform2f(rectBorderUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
-		c.glUniform2f(rectBorderUniforms.start, pos[0], pos[1]);
-		c.glUniform2f(rectBorderUniforms.size, dim[0], dim[1]);
-		c.glUniform1i(rectBorderUniforms.rectColor, @bitCast(getColor()));
-		c.glUniform1f(rectBorderUniforms.lineWidth, width);
-
-		rectBorderVao.bind();
-		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 10);
 
 		if (main.settings.launchConfig.vulkanTestingMode) {
 			vulkan.currentFrame.guiCommands.bindPipeline(rectBorderPipeline, getScissor());
@@ -317,6 +308,17 @@ pub const draw = struct { // MARK: draw
 			});
 			vulkan.currentFrame.guiCommands.bindVertexArray(rectBorderVao);
 			vulkan.currentFrame.guiCommands.draw(10, 0);
+		} else {
+			rectBorderPipeline.bind(getScissor());
+
+			c.glUniform2f(rectBorderUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
+			c.glUniform2f(rectBorderUniforms.start, pos[0], pos[1]);
+			c.glUniform2f(rectBorderUniforms.size, dim[0], dim[1]);
+			c.glUniform1i(rectBorderUniforms.rectColor, @bitCast(getColor()));
+			c.glUniform1f(rectBorderUniforms.lineWidth, width);
+
+			rectBorderVao.bind();
+			c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 10);
 		}
 	}
 
@@ -373,17 +375,8 @@ pub const draw = struct { // MARK: draw
 		pos2 *= @splat(scale);
 		pos2 += translation;
 
-		linePipeline.bind(getScissor());
-
 		var viewport: [4]c_int = undefined;
 		c.glGetIntegerv(c.GL_VIEWPORT, &viewport);
-		c.glUniform2f(lineUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
-		c.glUniform2f(lineUniforms.start, pos1[0], pos1[1]);
-		c.glUniform2f(lineUniforms.direction, pos2[0] - pos1[0], pos2[1] - pos1[1]);
-		c.glUniform1i(lineUniforms.lineColor, @bitCast(getColor()));
-
-		lineVao.bind();
-		c.glDrawArrays(c.GL_LINE_STRIP, 0, 2);
 
 		if (main.settings.launchConfig.vulkanTestingMode) {
 			vulkan.currentFrame.guiCommands.bindPipeline(linePipeline, getScissor());
@@ -395,6 +388,16 @@ pub const draw = struct { // MARK: draw
 			});
 			vulkan.currentFrame.guiCommands.bindVertexArray(rectBorderVao);
 			vulkan.currentFrame.guiCommands.draw(10, 0);
+		} else {
+			linePipeline.bind(getScissor());
+
+			c.glUniform2f(lineUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
+			c.glUniform2f(lineUniforms.start, pos1[0], pos1[1]);
+			c.glUniform2f(lineUniforms.direction, pos2[0] - pos1[0], pos2[1] - pos1[1]);
+			c.glUniform1i(lineUniforms.lineColor, @bitCast(getColor()));
+
+			lineVao.bind();
+			c.glDrawArrays(c.GL_LINE_STRIP, 0, 2);
 		}
 	}
 

--- a/src/gui/windows/performance_graph.zig
+++ b/src/gui/windows/performance_graph.zig
@@ -86,10 +86,6 @@ pub fn render() void {
 		draw.line(.{border, 40}, .{window.contentSize[0] - border, 40});
 		draw.line(.{border, 56}, .{window.contentSize[0] - border, 56});
 	}
-	pipeline.bind(null);
-	c.glUniform1i(uniforms.points, lastFrameTime.len);
-	c.glUniform1i(uniforms.offset, index);
-	c.glUniform3f(uniforms.lineColor, 1, 1, 1);
 	var pos = Vec2f{border, border};
 	var dim = window.contentSize - @as(Vec2f, @splat(2*border));
 	pos *= @splat(draw.setScale(1));
@@ -99,12 +95,7 @@ pub fn render() void {
 	dim = @ceil(dim);
 	pos[1] += dim[1];
 
-	c.glUniform2f(uniforms.screen, @floatFromInt(main.Window.width), @floatFromInt(main.Window.height));
-	c.glUniform2f(uniforms.start, pos[0], pos[1]);
-	c.glUniform2f(uniforms.dimension, dim[0], draw.setScale(1));
 	ssbo.bufferData(f32, &lastFrameTime);
-	ssbo.bind(5);
-	c.glDrawArrays(c.GL_LINE_STRIP, 0, lastFrameTime.len);
 
 	if (main.settings.launchConfig.vulkanTestingMode) {
 		vulkan.currentFrame.guiCommands.bindPipeline(pipeline, null);
@@ -120,5 +111,15 @@ pub fn render() void {
 			.lineColor = .{1, 1, 1},
 		});
 		vulkan.currentFrame.guiCommands.draw(lastFrameTime.len, 0);
+	} else {
+		pipeline.bind(null);
+		c.glUniform1i(uniforms.points, lastFrameTime.len);
+		c.glUniform1i(uniforms.offset, index);
+		c.glUniform3f(uniforms.lineColor, 1, 1, 1);
+		c.glUniform2f(uniforms.screen, @floatFromInt(main.Window.width), @floatFromInt(main.Window.height));
+		c.glUniform2f(uniforms.start, pos[0], pos[1]);
+		c.glUniform2f(uniforms.dimension, dim[0], draw.setScale(1));
+		ssbo.bind(5);
+		c.glDrawArrays(c.GL_LINE_STRIP, 0, lastFrameTime.len);
 	}
 }


### PR DESCRIPTION
Before fully deprecating the old OpenGL mode, we probably want to do some performance testing.
So all render paths that are added to vulkan should be disabled in the OpenGL window (once everything is converted the OpenGL window should be removed entirely in vulkan testing mode).
<img width="2509" height="732" alt="Screenshot at 2026-08-17 07-40-59" src="https://github.com/user-attachments/assets/024847b7-f5ed-403c-8211-4ec22392aa75" />
