### PR TITLE
Run tests in CI on both Windows and Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     name: Unit Tests (${{ matrix.os }})
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,21 @@ jobs:
       - run: zig build -Dtarget=x86_64-windows-gnu
       - run: zig build -Dtarget=aarch64-linux-gnu
       - run: zig build -Dtarget=aarch64-windows-gnu
-      - run: zig build test
       - run: 'find assets/cubyz/shaders -type f ! -name "*.glsl" | xargs -L1 glslangValidator -G100 -P"#extension GL_GOOGLE_include_directive : enable" -Iassets/cubyz/shaders/include -Dgl_VertexIndex=gl_VertexID -DOPEN_GL'
+
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    name: Unit Tests (${{ matrix.os }})
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo "VERSION=$(cat .zigversion)" >> $GITHUB_ENV
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.VERSION }}
+      - run: zig build test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ on:
     branches: [ "master" ]
 
 jobs:
-  compile:
+  checks:
     runs-on: ubuntu-latest
-    name: Compilation Check
+    name: Format & Shader Checks
     steps:
       - uses: actions/checkout@v3
       - run: echo "VERSION=$(cat .zigversion)" >> $GITHUB_ENV
@@ -34,18 +34,14 @@ jobs:
       - run: wget -O ./Cubyz-linter https://github.com/PixelGuys/Cubyz-linter/releases/download/0.16.0+4/Cubyz-linter-x86_64-linux
       - run: chmod +x ./Cubyz-linter
       - run: ./Cubyz-linter assets/ mods/ src/ *.zon
-      - run: zig build
-      - run: zig build -Dtarget=x86_64-windows-gnu
-      - run: zig build -Dtarget=aarch64-linux-gnu
-      - run: zig build -Dtarget=aarch64-windows-gnu
       - run: 'find assets/cubyz/shaders -type f ! -name "*.glsl" | xargs -L1 glslangValidator -G100 -P"#extension GL_GOOGLE_include_directive : enable" -Iassets/cubyz/shaders/include -Dgl_VertexIndex=gl_VertexID -DOPEN_GL'
 
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    name: Unit Tests (${{ matrix.os }})
+    name: Build & Test (${{ matrix.os }})
     defaults:
       run:
         shell: bash
@@ -55,4 +51,9 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.VERSION }}
+      - run: zig build
+      - if: matrix.os == 'ubuntu-latest'
+        run: zig build -Dtarget=aarch64-linux-gnu
+      - if: matrix.os == 'windows-latest'
+        run: zig build -Dtarget=aarch64-windows-gnu
       - run: zig build test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,5 @@ jobs:
         with:
           version: ${{ env.VERSION }}
       - run: zig build -Dtarget=x86_64-native
-      - run: zig build -Dtarget=aarch64-native-gnu
+      - run: zig build -Dtarget=aarch64-native
       - run: zig build test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,5 @@ jobs:
         with:
           version: ${{ env.VERSION }}
       - run: zig build -Dtarget=x86_64-native
-      - run: zig build -Dtarget=aarch64-native
+      - run: zig build -Dtarget=aarch64-native-gnu
       - run: zig build test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,6 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.VERSION }}
-      - run: zig build
-      - if: matrix.os == 'ubuntu-latest'
-        run: zig build -Dtarget=aarch64-linux-gnu
-      - if: matrix.os == 'windows-latest'
-        run: zig build -Dtarget=aarch64-windows-gnu
+      - run: zig build -Dtarget=x86_64-native
+      - run: zig build -Dtarget=aarch64-native-gnu
       - run: zig build test


### PR DESCRIPTION
Split the CI workflow's `zig build test` step out of the `compile` job into its own `test` job that runs on a matrix, so unit tests execute on both operating systems.

Closes #3535