### PR TITLE
Fix file selection UI problems

### DIFF
--- a/src/gui/windows/authentication/create_account_account_code.zig
+++ b/src/gui/windows/authentication/create_account_account_code.zig
@@ -29,6 +29,7 @@ var accountCodeLabel: *Label = undefined;
 var accountCode: ?main.network.authentication.AccountCode = null;
 var fileNameEntry: *Label = undefined;
 var fileName: []const u8 = undefined;
+var fileSaved: bool = undefined;
 
 pub const StorageMethod = enum(usize) {
 	file = 0,
@@ -45,15 +46,6 @@ pub fn setStorageMethod(method: StorageMethod) void {
 }
 
 fn next() void {
-	switch (storageMethod) {
-		.file => {
-			main.files.cwd().write(fileName, accountCode.?.text) catch |err| {
-				std.log.err("Failed to write Account Code to file: {s}", .{@errorName(err)});
-				return;
-			};
-		},
-		.paper, .passwordManager => {},
-	}
 	gui.closeWindowFromRef(&window);
 	gui.openWindow("authentication/login");
 	// Make sure there remains no trace of the account code in memory
@@ -73,7 +65,19 @@ fn copy() void {
 fn selectFile() void {
 	const result: [*:0]const u8 = c.tinyfd_saveFileDialog("Select File to save Account Code", "Cubyz Account.txt", 1, @as([*]const [*:0]const u8, &.{"*.txt"}), "Text Files") orelse return;
 	fileName = std.mem.span(result);
-	fileNameEntry.updateText(fileName);
+	main.files.cwd().write(fileName, accountCode.?.text) catch |err| {
+		std.log.err("Failed to write Account Code to file: {s}", .{@errorName(err)});
+		fileSaved = false;
+		fileNameEntry.updateText("Failed to save, please pick a different location.");
+		return;
+	};
+	fileSaved = true;
+	const displayName = main.stackAllocator.dupe(u8, fileName);
+	defer main.stackAllocator.free(displayName);
+	if (builtin.os.tag == .windows) {
+		std.mem.replaceScalar(u8, displayName, '\\', '/');
+	}
+	fileNameEntry.updateText(displayName);
 }
 
 pub fn onOpen() void {
@@ -89,11 +93,13 @@ pub fn onOpen() void {
 	list.add(row);
 	switch (storageMethod) {
 		.file => {
+			fileName = "";
+			fileSaved = false;
 			list.add(Label.init(.{0, 0}, width, "Please enter a file name, we will store it there.", .left));
 			list.add(Button.initText(.{0, 0}, 250, "Select File", .{.onAction = .init(selectFile)}));
 			fileNameEntry = Label.init(.{0, 0}, width, "", .center);
 			list.add(fileNameEntry);
-			button = Button.initText(.{0, 0}, 250, "Save and return to login", .{.onAction = .init(next), .disabled = true});
+			button = Button.initText(.{0, 0}, 250, "Return to login", .{.onAction = .init(next), .disabled = true});
 		},
 		.paper, .passwordManager => {
 			if (storageMethod == .paper) list.add(Label.init(.{0, 0}, width, "We will give you some time to write it down.", .left));
@@ -117,7 +123,7 @@ pub fn onOpen() void {
 pub fn update() void {
 	switch (storageMethod) {
 		.file => {
-			button.disabled = fileName.len == 0;
+			button.disabled = !fileSaved;
 		},
 		.paper, .passwordManager => {
 			if (button.disabled) {

--- a/src/gui/windows/authentication/create_account_account_code.zig
+++ b/src/gui/windows/authentication/create_account_account_code.zig
@@ -28,8 +28,6 @@ const padding: f32 = 8;
 var accountCodeLabel: *Label = undefined;
 var accountCode: ?main.network.authentication.AccountCode = null;
 var fileNameEntry: *Label = undefined;
-var fileName: []const u8 = undefined;
-var fileSaved: bool = undefined;
 
 pub const StorageMethod = enum(usize) {
 	file = 0,
@@ -64,14 +62,14 @@ fn copy() void {
 
 fn selectFile() void {
 	const result: [*:0]const u8 = c.tinyfd_saveFileDialog("Select File to save Account Code", "Cubyz Account.txt", 1, @as([*]const [*:0]const u8, &.{"*.txt"}), "Text Files") orelse return;
-	fileName = std.mem.span(result);
+	const fileName = std.mem.span(result);
 	main.files.cwd().write(fileName, accountCode.?.text) catch |err| {
 		std.log.err("Failed to write Account Code to file: {s}", .{@errorName(err)});
-		fileSaved = false;
+		button.disabled = true;
 		fileNameEntry.updateText("Failed to save, please pick a different location.");
 		return;
 	};
-	fileSaved = true;
+	button.disabled = false;
 	const displayName = main.stackAllocator.dupe(u8, fileName);
 	defer main.stackAllocator.free(displayName);
 	if (builtin.os.tag == .windows) {
@@ -95,8 +93,6 @@ pub fn onOpen() void {
 	list.add(row);
 	switch (storageMethod) {
 		.file => {
-			fileName = "";
-			fileSaved = false;
 			list.add(Label.init(.{0, 0}, width, "Please enter a file name, we will store it there.", .left));
 			list.add(Button.initText(.{0, 0}, 250, "Select File", .{.onAction = .init(selectFile)}));
 			fileNameEntry = Label.init(.{0, 0}, width, "", .center);
@@ -124,9 +120,7 @@ pub fn onOpen() void {
 
 pub fn update() void {
 	switch (storageMethod) {
-		.file => {
-			button.disabled = !fileSaved;
-		},
+		.file => {},
 		.paper, .passwordManager => {
 			if (button.disabled) {
 				const remainingTime = enableTime.nanoseconds -% main.timestamp().nanoseconds;

--- a/src/gui/windows/authentication/create_account_account_code.zig
+++ b/src/gui/windows/authentication/create_account_account_code.zig
@@ -77,7 +77,9 @@ fn selectFile() void {
 	if (builtin.os.tag == .windows) {
 		std.mem.replaceScalar(u8, displayName, '\\', '/');
 	}
-	fileNameEntry.updateText(displayName);
+	const labelText = main.stackAllocator.print("Saved to: {s}", .{displayName});
+	defer main.stackAllocator.free(labelText);
+	fileNameEntry.updateText(labelText);
 }
 
 pub fn onOpen() void {


### PR DESCRIPTION
The account code is now written once a path is chosen, and the second button, now labelled "Return to login", stays disabled until the write succeeds. The label now shows a normalized copy of the path with / separators.

<img width="1282" height="752" alt="file_selection" src="https://github.com/user-attachments/assets/755e7ae2-93ed-4d28-a491-ce0bfb224598" />

Fixes #3489