### PR TITLE
Fix player spawn sometimes chosen midair above cavern

### DIFF
--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -884,9 +884,9 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 					}
 				}
 				std.log.err("Found no valid spawn location", .{});
+				const map = terrain.SurfaceMap.getOrGenerateFragment(self.spawn[0], self.spawn[1], 1);
+				self.spawn[2] = map.getHeight(self.spawn[0], self.spawn[1]) + 1;
 			}
-			const map = terrain.SurfaceMap.getOrGenerateFragment(self.spawn[0], self.spawn[1], 1);
-			self.spawn[2] = map.getHeight(self.spawn[0], self.spawn[1]) + 1;
 		}
 		const newBiomeCheckSum: i64 = @bitCast(terrain.biomes.getBiomeCheckSum(self.settings.seed));
 		if (newBiomeCheckSum != self.biomeChecksum) {
@@ -1045,9 +1045,18 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		try files.cubyzDir().write(itemsPath, itemDropData.data.items);
 	}
 
-	fn isValidSpawnLocation(_: *ServerWorld, wx: i32, wy: i32) bool {
+	fn isValidSpawnLocation(self: *ServerWorld, wx: i32, wy: i32) bool {
 		const map = terrain.SurfaceMap.getOrGenerateFragment(wx, wy, 1);
-		return map.getBiome(wx, wy).isValidPlayerSpawn;
+		if (!map.getBiome(wx, wy).isValidPlayerSpawn) return false;
+		const height = map.getHeight(wx, wy);
+
+		const caveMap = terrain.CaveMap.CaveMapView.init(main.stackAllocator, .{.wx = wx, .wy = wy, .wz = height, .voxelSize = 1}, 0, 1);
+		defer caveMap.deinit(main.stackAllocator);
+		if (!caveMap.isSolid(0, 0, -1)) return false;
+		if (caveMap.isSolid(0, 0, 0) or caveMap.isSolid(0, 0, 1)) return false;
+
+		self.spawn[2] = height + 1;
+		return true;
 	}
 
 	pub fn dropWithCooldown(self: *ServerWorld, stack: ItemStack, pos: Vec3d, dir: Vec3f, velocity: f32, pickupCooldown: i32) void {

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -1045,6 +1045,16 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		try files.cubyzDir().write(itemsPath, itemDropData.data.items);
 	}
 
+	fn getGeneratedBlock(wx: i32, wy: i32, wz: i32) Block {
+		const pos = chunk.ChunkPosition.initFromWorldPos(.{wx, wy, wz}, 1);
+		const ch = ChunkManager.getOrGenerateChunkAndIncreaseRefCount(pos);
+		defer ch.decreaseRefCount();
+		ch.mutex.lock();
+		defer ch.mutex.unlock();
+		const relPos = chunk.BlockPos.fromWorldCoords(wx, wy, wz);
+		return ch.getBlock(relPos.x, relPos.y, relPos.z);
+	}
+
 	fn isValidSpawnLocation(self: *ServerWorld, wx: i32, wy: i32) bool {
 		const map = terrain.SurfaceMap.getOrGenerateFragment(wx, wy, 1);
 		if (!map.getBiome(wx, wy).isValidPlayerSpawn) return false;
@@ -1054,6 +1064,14 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		defer caveMap.deinit(main.stackAllocator);
 		if (!caveMap.isSolid(0, 0, -1)) return false;
 		if (caveMap.isSolid(0, 0, 0) or caveMap.isSolid(0, 0, 1)) return false;
+
+		const groundBlock = getGeneratedBlock(wx, wy, height - 1);
+		if (!groundBlock.collide() or !groundBlock.onTouch().isNoop()) return false;
+		const feetBlock = getGeneratedBlock(wx, wy, height);
+		const headBlock = getGeneratedBlock(wx, wy, height + 1);
+		inline for (.{feetBlock, headBlock}) |block| {
+			if (block.collide() or !block.onTouch().isNoop()) return false;
+		}
 
 		self.spawn[2] = height + 1;
 		return true;

--- a/src/server/world.zig
+++ b/src/server/world.zig
@@ -1045,7 +1045,7 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		try files.cubyzDir().write(itemsPath, itemDropData.data.items);
 	}
 
-	fn getGeneratedBlock(wx: i32, wy: i32, wz: i32) Block {
+	fn getOrGenerateBlock(wx: i32, wy: i32, wz: i32) Block {
 		const pos = chunk.ChunkPosition.initFromWorldPos(.{wx, wy, wz}, 1);
 		const ch = ChunkManager.getOrGenerateChunkAndIncreaseRefCount(pos);
 		defer ch.decreaseRefCount();
@@ -1060,16 +1060,10 @@ pub const ServerWorld = struct { // MARK: ServerWorld
 		if (!map.getBiome(wx, wy).isValidPlayerSpawn) return false;
 		const height = map.getHeight(wx, wy);
 
-		const caveMap = terrain.CaveMap.CaveMapView.init(main.stackAllocator, .{.wx = wx, .wy = wy, .wz = height, .voxelSize = 1}, 0, 1);
-		defer caveMap.deinit(main.stackAllocator);
-		if (!caveMap.isSolid(0, 0, -1)) return false;
-		if (caveMap.isSolid(0, 0, 0) or caveMap.isSolid(0, 0, 1)) return false;
-
-		const groundBlock = getGeneratedBlock(wx, wy, height - 1);
+		const groundBlock = getOrGenerateBlock(wx, wy, height - 1);
 		if (!groundBlock.collide() or !groundBlock.onTouch().isNoop()) return false;
-		const feetBlock = getGeneratedBlock(wx, wy, height);
-		const headBlock = getGeneratedBlock(wx, wy, height + 1);
-		inline for (.{feetBlock, headBlock}) |block| {
+		inline for (.{height, height + 1}) |h| {
+			const block = getOrGenerateBlock(wx, wy, h);
 			if (block.collide() or !block.onTouch().isNoop()) return false;
 		}
 


### PR DESCRIPTION
`isValidSpawnLocation` now also queries the `CaveMap` at the candidate column to confirm there's solid ground at the surface height and clear air above it to stand in, rejecting the candidate and letting the spiral search keep looking otherwise. Also made the 2D height calculation run when no valid location was found.

Example test seed with this bug: 9071844392573517448

Fixes #2097