### PR TITLE
Fix false displayBlockData error for migration-collapsed items

### DIFF
--- a/src/assets.zig
+++ b/src/assets.zig
@@ -687,9 +687,10 @@ pub fn loadWorldAssets(assetFolder: []const u8, blockPalette: *Palette, itemPale
 		try assignBlockItem(stringId);
 	}
 
-	for (items.itemList) |item| {
-		if (item.displayBlockData != null and item.block == null) {
-			std.log.err("displayBlockData field was set, but there is no block defined for item: '{s}'", .{item.id});
+	var itemIndexIterator = items.iterator();
+	while (itemIndexIterator.next()) |index| {
+		if (index.displayBlockData() != null and index.block() == null) {
+			std.log.err("displayBlockData field was set, but there is no block defined for item: '{s}'", .{index.id()});
 		}
 	}
 

--- a/src/items.zig
+++ b/src/items.zig
@@ -268,6 +268,9 @@ pub const BaseItemIndex = enum(u16) { // MARK: BaseItemIndex
 	pub fn block(self: BaseItemIndex) ?u16 {
 		return itemList[@intFromEnum(self)].block;
 	}
+	pub fn displayBlockData(self: BaseItemIndex) ?u16 {
+		return itemList[@intFromEnum(self)].displayBlockData;
+	}
 	pub fn hasTag(self: BaseItemIndex, tag: Tag) bool {
 		return itemList[@intFromEnum(self)].hasTag(tag);
 	}


### PR DESCRIPTION
`assets.zig` now walks items via `items.iterator()`, instead of the raw `items.itemList` array which includes duplicate migration slots (and `assignBlockItem` sets `.block` for only one of them).

Fixes #3545