### PR TITLE
Add a section on working together and finishing existing things instead of starting new systems to the contributing guidelines

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,7 +55,7 @@ And it is probably pretty easy to get the basics going, but at the end of the da
 New systems are of course still required, but they should be approached cautiously. Sometimes a bold leap forward is the right approach, but some discussions ahead of time can prevent a lot of frustration and wasted effort. And even if you are the best programmer in the world, a system that only you understand is just a waste of time in Open Source.
 
 At the same time we already have many half-baked systems and half-finished refactorings, some completely abandoned, that are justing waiting for someone like you to finish them.
-So instead of going out on your own to implement something new that may get stalled for months, maybe take a look around the codebase, the issue tracker, and talk to some fellow contributors on [Discord](https://discord.gg/XtqCRRG) on how you can best collaborate and bring value to the project.
+So instead of going out on your own to implement something new that may get stalled for months, maybe take a look around the codebase, the issue tracker, existing PRs, and talk to some fellow contributors on [Discord](https://discord.gg/XtqCRRG) on how you can best collaborate and bring value to the project.
 
 The best and most useful pull requests, are the ones that were made by multiple people.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -45,6 +45,22 @@ To have more success it would help to split things up into smaller PRs, maybe st
 
 This saves time on your end spent reworking your large pull request 10 times. And reviewing your large pull request 10 times is also not fun.
 
+# Build on existing systems and collaborate instead of making your own thing
+
+It seems easy to start out by making something that is new and isolated, entirely written by you, but such contributions are the most difficult to review, and the least helpful to the project, as they often require lengthy design discussion and may end up getting abandoned half-way wasting everyone's time and energy.
+
+Cubyz is still early in development and still missing many core systems, so it's even more tempting to make them by yourself, and how hard can it be?
+And it is probably pretty easy to get the basics going, but at the end of the day basic is not good enough for Cubyz. We want to have solid and future-proof systems, not something that we need to painstackingly refactor (including migrations for old worlds) next year.
+
+New systems are of course still required, but they should be approached cautiously. Sometimes a bold leap forward is the right approach, but some discussions ahead of time can prevent a lot of frustration and wasted effort. And even if you are the best programmer in the world, a system that only you understand is just a waste of time in Open Source.
+
+At the same time we already have many half-baked systems and half-finished refactorings, some completely abandoned, that are justing waiting for someone like you to finish them.
+So instead of going out on your own to implement something new that may get stalled for months, maybe take a look around the codebase, the issue tracker, and talk to some fellow contributors on [Discord](https://discord.gg/XtqCRRG) on how you can best collaborate and bring value to the project.
+
+The best and most useful pull requests, are the ones that were made by multiple people.
+
+Stronger Together
+
 # Write correct, readable and maintainable code
 
 ## Explicitly handle all errors


### PR DESCRIPTION
This is an attempt to discourage the creation of new systems, which are hardest to review and most frustrating for all sides involved.

It ends with a call to action for collaborating with other contributors, in my opinion this has lead to the best results in the past.

On that I want to highlight @RanPix and @tillpp's collaboration towards entity animations, @Wunka who jumped in to help on the migrations in #3073, and of course the countless times @careeoki has helped with texture contributions to existing PRs.