### PR TITLE
Vulkan image rendering

### DIFF
--- a/assets/cubyz/shaders/graphics/Image.vert
+++ b/assets/cubyz/shaders/graphics/Image.vert
@@ -5,6 +5,7 @@ layout(location = 0) in vec2 vertex_pos;
 layout(location = 0) out vec2 uv;
 layout(location = 1) flat out vec4 fColor;
 
+#ifdef OPEN_GL
 // in pixel
 layout(location = 0) uniform vec2 start;
 layout(location = 1) uniform vec2 size;
@@ -13,6 +14,16 @@ layout(location = 3) uniform vec2 uvOffset;
 layout(location = 4) uniform vec2 uvDim;
 
 layout(location = 5) uniform int color;
+#else
+layout(push_constant, std430) uniform _ {
+	vec2 start;
+	vec2 size;
+	vec2 screen;
+	int color;
+	vec2 uvOffset;
+	vec2 uvDim;
+};
+#endif
 
 void main() {
 	// Convert to opengl coordinates:

--- a/assets/cubyz/shaders/ui/button.frag
+++ b/assets/cubyz/shaders/ui/button.frag
@@ -7,7 +7,17 @@ layout(location = 1) flat in vec4 fColor;
 
 layout(binding = 0) uniform sampler2D image;
 
+#ifdef OPEN_GL
 layout(location = 4) uniform float scale;
+#else
+layout(push_constant, std430) uniform _ {
+	vec2 start;
+	vec2 size;
+	vec2 screen;
+	int color;
+	float scale;
+};
+#endif
 
 void main() {
 	frag_color = texture(image, (gl_FragCoord.xy - startCoord)/(2*scale)/textureSize(image, 0));

--- a/assets/cubyz/shaders/ui/button.vert
+++ b/assets/cubyz/shaders/ui/button.vert
@@ -5,12 +5,22 @@ layout(location = 0) in vec2 vertex_pos;
 layout(location = 0) out vec2 startCoord;
 layout(location = 1) flat out vec4 fColor;
 
+#ifdef OPEN_GL
 // in pixel
 layout(location = 0) uniform vec2 start;
 layout(location = 1) uniform vec2 size;
 layout(location = 2) uniform vec2 screen;
 
 layout(location = 3) uniform int color;
+#else
+layout(push_constant, std430) uniform _ {
+	vec2 start;
+	vec2 size;
+	vec2 screen;
+	int color;
+	float scale;
+};
+#endif
 
 void main() {
 	// Convert to opengl coordinates:

--- a/assets/cubyz/shaders/ui/window_border.frag
+++ b/assets/cubyz/shaders/ui/window_border.frag
@@ -6,11 +6,22 @@ layout(location = 0) flat in vec2 startCoord;
 layout(location = 1) flat in vec2 endCoord;
 layout(location = 2) flat in vec4 fColor;
 
+#ifdef OPEN_GL
 layout(location = 0) uniform vec2 start;
 layout(location = 1) uniform vec2 size;
 
 layout(location = 4) uniform float scale;
 layout(location = 5) uniform vec2 effectLength;
+#else
+layout(push_constant, std430) uniform _ {
+	vec2 start;
+	vec2 size;
+	vec2 screen;
+	int color;
+	float scale;
+	vec2 effectLength;
+};
+#endif
 
 void main() {
 	vec2 distanceToBorder = min(gl_FragCoord.xy - startCoord, endCoord - gl_FragCoord.xy)/effectLength/scale;

--- a/assets/cubyz/shaders/ui/window_border.vert
+++ b/assets/cubyz/shaders/ui/window_border.vert
@@ -6,12 +6,23 @@ layout(location = 0) flat out vec2 startCoord;
 layout(location = 1) flat out vec2 endCoord;
 layout(location = 2) flat out vec4 fColor;
 
+#ifdef OPEN_GL
 // in pixel
 layout(location = 0) uniform vec2 start;
 layout(location = 1) uniform vec2 size;
 layout(location = 2) uniform vec2 screen;
 
 layout(location = 3) uniform int color;
+#else
+layout(push_constant, std430) uniform _ {
+	vec2 start;
+	vec2 size;
+	vec2 screen;
+	int color;
+	float scale;
+	vec2 effectLength;
+};
+#endif
 
 void main() {
 	// Convert to opengl coordinates:

--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -412,6 +412,14 @@ pub const draw = struct { // MARK: draw
 		uvOffset: c_int,
 		uvDim: c_int,
 	} = undefined;
+	const ImageUniforms = extern struct {
+		start: [2]f32 align(8),
+		size: [2]f32 align(8),
+		screen: [2]f32 align(8),
+		color: i32,
+		uvOffset: [2]f32 align(8),
+		uvDim: [2]f32 align(8),
+	};
 	var imagePipeline: Pipeline = undefined;
 
 	fn initImage() void {
@@ -422,9 +430,12 @@ pub const draw = struct { // MARK: draw
 			&imageUniforms,
 			SimpleVertex2D,
 			.{
+				.bindings = &.{.sampler(0, .{.fragment = true})},
 				.rasterState = .{.cullMode = .none},
 				.depthStencilState = .{.depthTest = false, .depthWrite = false},
 				.blendState = .{.attachments = &.{.alphaBlending}, .formats = &.{.swapChain}},
+				.inputAssemblyState = .{.topology = .triangleStrip},
+				.pushConstantSize = @sizeOf(ImageUniforms),
 			},
 		);
 	}
@@ -433,10 +444,52 @@ pub const draw = struct { // MARK: draw
 		imagePipeline.deinit();
 	}
 
-	pub fn boundImage(_pos: Vec2f, _dim: Vec2f) void {
+	pub fn image(texture: Texture, _pos: Vec2f, _dim: Vec2f) void {
+		texture.bindTo(0);
 		imagePipeline.bind(getScissor());
 
-		customShadedImage(&imageUniforms, _pos, _dim);
+		var pos = _pos;
+		var dim = _dim;
+		pos *= @splat(scale);
+		pos += translation;
+		dim *= @splat(scale);
+		pos = @floor(pos);
+		dim = @ceil(dim);
+
+		var viewport: [4]c_int = undefined;
+		c.glGetIntegerv(c.GL_VIEWPORT, &viewport);
+
+		if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
+
+			vulkan.currentFrame.guiCommands.bindPipeline(imagePipeline, getScissor());
+			vulkan.currentFrame.guiCommands.bindDescriptors(imagePipeline, .graphics, 0, &.{
+				.{ .image = .{
+					.binding = 0,
+					.imageView = texture.vulkanImage.?.view,
+					.sampler = texture.vulkanImage.?.sampler,
+				}},
+			});
+			vulkan.currentFrame.guiCommands.pushConstants(imagePipeline, &ImageUniforms{
+				.start = pos,
+				.size = dim,
+				.screen = .{@floatFromInt(viewport[2]), @floatFromInt(viewport[3])},
+				.color = @bitCast(getColor()),
+				.uvOffset = .{0, 0},
+				.uvDim = .{1, 1},
+			});
+			vulkan.currentFrame.guiCommands.bindVertexArray(rectVao);
+			vulkan.currentFrame.guiCommands.draw(4, 0);
+		} else {
+			c.glUniform2f(imageUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
+			c.glUniform2f(imageUniforms.start, pos[0], pos[1]);
+			c.glUniform2f(imageUniforms.size, dim[0], dim[1]);
+			c.glUniform1i(imageUniforms.color, @bitCast(getColor()));
+			c.glUniform2f(imageUniforms.uvOffset, 0, 0);
+			c.glUniform2f(imageUniforms.uvDim, 1, 1);
+
+			rectVao.bind();
+			c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
+		}
 	}
 
 	pub fn boundSubImage(_pos: Vec2f, _dim: Vec2f, uvOffset: Vec2f, uvDim: Vec2f) void {
@@ -1959,8 +2012,7 @@ pub const Texture = struct { // MARK: Texture
 	}
 
 	pub fn render(self: Texture, pos: Vec2f, dim: Vec2f) void {
-		self.bindTo(0);
-		draw.boundImage(pos, dim);
+		draw.image(self, pos, dim);
 	}
 
 	pub fn size(self: Texture) Vec2i {

--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -445,9 +445,6 @@ pub const draw = struct { // MARK: draw
 	}
 
 	pub fn image(texture: Texture, _pos: Vec2f, _dim: Vec2f) void {
-		texture.bindTo(0);
-		imagePipeline.bind(getScissor());
-
 		var pos = _pos;
 		var dim = _dim;
 		pos *= @splat(scale);
@@ -480,6 +477,9 @@ pub const draw = struct { // MARK: draw
 			vulkan.currentFrame.guiCommands.bindVertexArray(rectVao);
 			vulkan.currentFrame.guiCommands.draw(4, 0);
 		} else {
+			texture.bindTo(0);
+			imagePipeline.bind(getScissor());
+
 			c.glUniform2f(imageUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
 			c.glUniform2f(imageUniforms.start, pos[0], pos[1]);
 			c.glUniform2f(imageUniforms.size, dim[0], dim[1]);

--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -451,11 +451,7 @@ pub const draw = struct { // MARK: draw
 		if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
 			vulkan.currentFrame.guiCommands.bindPipeline(imagePipeline, getScissor());
 			vulkan.currentFrame.guiCommands.bindDescriptors(imagePipeline, .graphics, 0, &.{
-				.{ .image = .{
-					.binding = 0,
-					.imageView = texture.vulkanImage.?.view,
-					.sampler = texture.vulkanImage.?.sampler,
-				}},
+				.{.image = .{.binding = 0, .image = texture.vulkanImage.?}},
 			});
 			customShadedImage(@as(ImageUniforms, undefined), imagePipeline, _pos, _dim);
 		} else {
@@ -480,11 +476,7 @@ pub const draw = struct { // MARK: draw
 		if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
 			vulkan.currentFrame.guiCommands.bindPipeline(imagePipeline, getScissor());
 			vulkan.currentFrame.guiCommands.bindDescriptors(imagePipeline, .graphics, 0, &.{
-				.{ .image = .{
-					.binding = 0,
-					.imageView = texture.vulkanImage.?.view,
-					.sampler = texture.vulkanImage.?.sampler,
-				}},
+				.{.image = .{.binding = 0, .image = texture.vulkanImage.?}},
 			});
 			vulkan.currentFrame.guiCommands.pushConstants(imagePipeline, &ImageUniforms{
 				.start = pos,

--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -586,7 +586,7 @@ pub const draw = struct { // MARK: draw
 	// ----------------------------------------------------------------------------
 	// MARK: customShadedRect()
 
-	pub fn customShadedRect(uniforms: anytype, _pos: Vec2f, _dim: Vec2f) void {
+	pub fn customShadedRectOpenGl(uniforms: anytype, _pos: Vec2f, _dim: Vec2f) void {
 		var pos = _pos;
 		var dim = _dim;
 		pos *= @splat(scale);
@@ -605,6 +605,29 @@ pub const draw = struct { // MARK: draw
 
 		rectVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
+	}
+
+	pub fn customShadedRect(_uniforms: anytype, pipeline: Pipeline, _pos: Vec2f, _dim: Vec2f) void {
+		var pos = _pos;
+		var dim = _dim;
+		pos *= @splat(scale);
+		pos += translation;
+		dim *= @splat(scale);
+		pos = @floor(pos);
+		dim = @ceil(dim);
+
+		var viewport: [4]c_int = undefined;
+		c.glGetIntegerv(c.GL_VIEWPORT, &viewport);
+		var uniforms = _uniforms;
+		uniforms.start = pos;
+		uniforms.size = dim;
+		uniforms.screen = .{@floatFromInt(viewport[2]), @floatFromInt(viewport[3])};
+		uniforms.color = @bitCast(getColor());
+		uniforms.scale = scale;
+
+		vulkan.currentFrame.guiCommands.pushConstants(pipeline, &uniforms);
+		vulkan.currentFrame.guiCommands.bindVertexArray(rectVao);
+		vulkan.currentFrame.guiCommands.draw(4, 0);
 	}
 
 	// ----------------------------------------------------------------------------

--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -562,7 +562,7 @@ pub const draw = struct { // MARK: draw
 		drawSlice(texture, .{pos[0] + dim[0] - widthSlice, pos[1] + dim[1] - heightSlice}, .{pos[0] + dim[0], pos[1] + dim[1]}, .{u[1], v[1]}, .{1, 1});
 	}
 
-	pub fn customShadedImage(uniforms: anytype, _pos: Vec2f, _dim: Vec2f) void {
+	pub fn customShadedImageOpenGl(uniforms: anytype, _pos: Vec2f, _dim: Vec2f) void {
 		var pos = _pos;
 		var dim = _dim;
 		pos *= @splat(scale);
@@ -582,6 +582,31 @@ pub const draw = struct { // MARK: draw
 
 		rectVao.bind();
 		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
+	}
+
+	pub fn customShadedImage(_uniforms: anytype, pipeline: Pipeline, _pos: Vec2f, _dim: Vec2f) void {
+		var pos = _pos;
+		var dim = _dim;
+		pos *= @splat(scale);
+		pos += translation;
+		dim *= @splat(scale);
+		pos = @floor(pos);
+		dim = @ceil(dim);
+
+		var viewport: [4]c_int = undefined;
+		c.glGetIntegerv(c.GL_VIEWPORT, &viewport);
+
+		var uniforms = _uniforms;
+		uniforms.start = pos;
+		uniforms.size = dim;
+		uniforms.screen = .{@floatFromInt(viewport[2]), @floatFromInt(viewport[3])};
+		uniforms.color = @bitCast(getColor());
+		uniforms.uvOffset = .{0, 0};
+		uniforms.uvDim = .{1, 1};
+
+		vulkan.currentFrame.guiCommands.pushConstants(pipeline, &uniforms);
+		vulkan.currentFrame.guiCommands.bindVertexArray(rectVao);
+		vulkan.currentFrame.guiCommands.draw(4, 0);
 	}
 
 	// ----------------------------------------------------------------------------

--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -457,7 +457,6 @@ pub const draw = struct { // MARK: draw
 		c.glGetIntegerv(c.GL_VIEWPORT, &viewport);
 
 		if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
-
 			vulkan.currentFrame.guiCommands.bindPipeline(imagePipeline, getScissor());
 			vulkan.currentFrame.guiCommands.bindDescriptors(imagePipeline, .graphics, 0, &.{
 				.{ .image = .{
@@ -492,7 +491,7 @@ pub const draw = struct { // MARK: draw
 		}
 	}
 
-	pub fn boundSubImage(_pos: Vec2f, _dim: Vec2f, uvOffset: Vec2f, uvDim: Vec2f) void {
+	pub fn subImage(texture: Texture, _pos: Vec2f, _dim: Vec2f, uvOffset: Vec2f, uvDim: Vec2f) void {
 		var pos = _pos;
 		var dim = _dim;
 		pos *= @splat(scale);
@@ -501,26 +500,49 @@ pub const draw = struct { // MARK: draw
 		pos = @floor(pos);
 		dim = @ceil(dim);
 
-		imagePipeline.bind(getScissor());
-
 		var viewport: [4]c_int = undefined;
 		c.glGetIntegerv(c.GL_VIEWPORT, &viewport);
-		c.glUniform2f(imageUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
-		c.glUniform2f(imageUniforms.start, pos[0], pos[1]);
-		c.glUniform2f(imageUniforms.size, dim[0], dim[1]);
-		c.glUniform1i(imageUniforms.color, @bitCast(getColor()));
-		c.glUniform2f(imageUniforms.uvOffset, uvOffset[0], 1 - uvOffset[1] - uvDim[1]);
-		c.glUniform2f(imageUniforms.uvDim, uvDim[0], uvDim[1]);
 
-		rectVao.bind();
-		c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
+		if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
+			vulkan.currentFrame.guiCommands.bindPipeline(imagePipeline, getScissor());
+			vulkan.currentFrame.guiCommands.bindDescriptors(imagePipeline, .graphics, 0, &.{
+				.{ .image = .{
+					.binding = 0,
+					.imageView = texture.vulkanImage.?.view,
+					.sampler = texture.vulkanImage.?.sampler,
+				}},
+			});
+			vulkan.currentFrame.guiCommands.pushConstants(imagePipeline, &ImageUniforms{
+				.start = pos,
+				.size = dim,
+				.screen = .{@floatFromInt(viewport[2]), @floatFromInt(viewport[3])},
+				.color = @bitCast(getColor()),
+				.uvOffset = .{uvOffset[0], 1 - uvOffset[1] - uvDim[1]},
+				.uvDim = .{uvDim[0], uvDim[1]},
+			});
+			vulkan.currentFrame.guiCommands.bindVertexArray(rectVao);
+			vulkan.currentFrame.guiCommands.draw(4, 0);
+		} else {
+			imagePipeline.bind(getScissor());
+			texture.bindTo(0);
+
+			c.glUniform2f(imageUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
+			c.glUniform2f(imageUniforms.start, pos[0], pos[1]);
+			c.glUniform2f(imageUniforms.size, dim[0], dim[1]);
+			c.glUniform1i(imageUniforms.color, @bitCast(getColor()));
+			c.glUniform2f(imageUniforms.uvOffset, uvOffset[0], 1 - uvOffset[1] - uvDim[1]);
+			c.glUniform2f(imageUniforms.uvDim, uvDim[0], uvDim[1]);
+
+			rectVao.bind();
+			c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
+		}
 	}
 
-	fn drawSlice(destMin: Vec2f, destMax: Vec2f, uvMin: Vec2f, uvMax: Vec2f) void {
-		boundSubImage(destMin, destMax - destMin, uvMin, uvMax - uvMin);
+	fn drawSlice(texture: Texture, destMin: Vec2f, destMax: Vec2f, uvMin: Vec2f, uvMax: Vec2f) void {
+		subImage(texture, destMin, destMax - destMin, uvMin, uvMax - uvMin);
 	}
 
-	pub fn bound9SliceImage(pos: Vec2f, dim: Vec2f, textureSize: Vec2f, slices: Vec2f, sliceScale: f32) void {
+	pub fn nineSliceImage(texture: Texture, pos: Vec2f, dim: Vec2f, textureSize: Vec2f, slices: Vec2f, sliceScale: f32) void {
 		const widthSlice = slices[0]*sliceScale;
 		const heightSlice = slices[1]*sliceScale;
 
@@ -529,15 +551,15 @@ pub const draw = struct { // MARK: draw
 		const v: Vec2f = .{slices[1]/textureSize[1], (textureSize[1] - slices[1])/textureSize[1]};
 
 		// Draw all Slices
-		drawSlice(.{pos[0], pos[1]}, .{pos[0] + widthSlice, pos[1] + heightSlice}, .{0, 0}, .{u[0], v[0]});
-		drawSlice(.{pos[0] + widthSlice, pos[1]}, .{pos[0] + dim[0] - widthSlice, pos[1] + heightSlice}, .{u[0], 0}, .{u[1], v[0]});
-		drawSlice(.{pos[0] + dim[0] - widthSlice, pos[1]}, .{pos[0] + dim[0], pos[1] + heightSlice}, .{u[1], 0}, .{1, v[0]});
-		drawSlice(.{pos[0], pos[1] + heightSlice}, .{pos[0] + widthSlice, pos[1] + dim[1] - heightSlice}, .{0, v[0]}, .{u[0], v[1]});
-		drawSlice(.{pos[0] + widthSlice, pos[1] + heightSlice}, .{pos[0] + dim[0] - widthSlice, pos[1] + dim[1] - heightSlice}, .{u[0], v[0]}, .{u[1], v[1]});
-		drawSlice(.{pos[0] + dim[0] - widthSlice, pos[1] + heightSlice}, .{pos[0] + dim[0], pos[1] + dim[1] - heightSlice}, .{u[1], v[0]}, .{1, v[1]});
-		drawSlice(.{pos[0], pos[1] + dim[1] - heightSlice}, .{pos[0] + widthSlice, pos[1] + dim[1]}, .{0, v[1]}, .{u[0], 1});
-		drawSlice(.{pos[0] + widthSlice, pos[1] + dim[1] - heightSlice}, .{pos[0] + dim[0] - widthSlice, pos[1] + dim[1]}, .{u[0], v[1]}, .{u[1], 1});
-		drawSlice(.{pos[0] + dim[0] - widthSlice, pos[1] + dim[1] - heightSlice}, .{pos[0] + dim[0], pos[1] + dim[1]}, .{u[1], v[1]}, .{1, 1});
+		drawSlice(texture, .{pos[0], pos[1]}, .{pos[0] + widthSlice, pos[1] + heightSlice}, .{0, 0}, .{u[0], v[0]});
+		drawSlice(texture, .{pos[0] + widthSlice, pos[1]}, .{pos[0] + dim[0] - widthSlice, pos[1] + heightSlice}, .{u[0], 0}, .{u[1], v[0]});
+		drawSlice(texture, .{pos[0] + dim[0] - widthSlice, pos[1]}, .{pos[0] + dim[0], pos[1] + heightSlice}, .{u[1], 0}, .{1, v[0]});
+		drawSlice(texture, .{pos[0], pos[1] + heightSlice}, .{pos[0] + widthSlice, pos[1] + dim[1] - heightSlice}, .{0, v[0]}, .{u[0], v[1]});
+		drawSlice(texture, .{pos[0] + widthSlice, pos[1] + heightSlice}, .{pos[0] + dim[0] - widthSlice, pos[1] + dim[1] - heightSlice}, .{u[0], v[0]}, .{u[1], v[1]});
+		drawSlice(texture, .{pos[0] + dim[0] - widthSlice, pos[1] + heightSlice}, .{pos[0] + dim[0], pos[1] + dim[1] - heightSlice}, .{u[1], v[0]}, .{1, v[1]});
+		drawSlice(texture, .{pos[0], pos[1] + dim[1] - heightSlice}, .{pos[0] + widthSlice, pos[1] + dim[1]}, .{0, v[1]}, .{u[0], 1});
+		drawSlice(texture, .{pos[0] + widthSlice, pos[1] + dim[1] - heightSlice}, .{pos[0] + dim[0] - widthSlice, pos[1] + dim[1]}, .{u[0], v[1]}, .{u[1], 1});
+		drawSlice(texture, .{pos[0] + dim[0] - widthSlice, pos[1] + dim[1] - heightSlice}, .{pos[0] + dim[0], pos[1] + dim[1]}, .{u[1], v[1]}, .{1, 1});
 	}
 
 	pub fn customShadedImage(uniforms: anytype, _pos: Vec2f, _dim: Vec2f) void {

--- a/src/graphics.zig
+++ b/src/graphics.zig
@@ -445,14 +445,6 @@ pub const draw = struct { // MARK: draw
 	}
 
 	pub fn image(texture: Texture, _pos: Vec2f, _dim: Vec2f) void {
-		var pos = _pos;
-		var dim = _dim;
-		pos *= @splat(scale);
-		pos += translation;
-		dim *= @splat(scale);
-		pos = @floor(pos);
-		dim = @ceil(dim);
-
 		var viewport: [4]c_int = undefined;
 		c.glGetIntegerv(c.GL_VIEWPORT, &viewport);
 
@@ -465,29 +457,11 @@ pub const draw = struct { // MARK: draw
 					.sampler = texture.vulkanImage.?.sampler,
 				}},
 			});
-			vulkan.currentFrame.guiCommands.pushConstants(imagePipeline, &ImageUniforms{
-				.start = pos,
-				.size = dim,
-				.screen = .{@floatFromInt(viewport[2]), @floatFromInt(viewport[3])},
-				.color = @bitCast(getColor()),
-				.uvOffset = .{0, 0},
-				.uvDim = .{1, 1},
-			});
-			vulkan.currentFrame.guiCommands.bindVertexArray(rectVao);
-			vulkan.currentFrame.guiCommands.draw(4, 0);
+			customShadedImage(@as(ImageUniforms, undefined), imagePipeline, _pos, _dim);
 		} else {
 			texture.bindTo(0);
 			imagePipeline.bind(getScissor());
-
-			c.glUniform2f(imageUniforms.screen, @floatFromInt(viewport[2]), @floatFromInt(viewport[3]));
-			c.glUniform2f(imageUniforms.start, pos[0], pos[1]);
-			c.glUniform2f(imageUniforms.size, dim[0], dim[1]);
-			c.glUniform1i(imageUniforms.color, @bitCast(getColor()));
-			c.glUniform2f(imageUniforms.uvOffset, 0, 0);
-			c.glUniform2f(imageUniforms.uvDim, 1, 1);
-
-			rectVao.bind();
-			c.glDrawArrays(c.GL_TRIANGLE_STRIP, 0, 4);
+			customShadedImageOpenGl(imageUniforms, _pos, _dim);
 		}
 	}
 

--- a/src/graphics/CommandBuffer.zig
+++ b/src/graphics/CommandBuffer.zig
@@ -204,8 +204,7 @@ const BindingInfo = union(enum) {
 	},
 	image: struct {
 		binding: u32,
-		imageView: c.VkImageView,
-		sampler: c.VkSampler,
+		image: vulkan.Image,
 		imageLayout: c.VkImageLayout = c.VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL,
 	},
 };
@@ -237,8 +236,8 @@ pub fn bindDescriptors(self: CommandBuffer, pipeline: main.graphics.Pipeline, bi
 				writeInfo[i].descriptorType = c.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
 				const imageInfo = arena.create(c.VkDescriptorImageInfo);
 				imageInfo.* = .{
-					.sampler = image.sampler,
-					.imageView = image.imageView,
+					.sampler = image.image.sampler,
+					.imageView = image.image.view,
 					.imageLayout = image.imageLayout,
 				};
 				writeInfo[i].pImageInfo = imageInfo;

--- a/src/graphics/CommandBuffer.zig
+++ b/src/graphics/CommandBuffer.zig
@@ -202,6 +202,12 @@ const BindingInfo = union(enum) {
 		offset: usize = 0,
 		range: usize = c.VK_WHOLE_SIZE,
 	},
+	image: struct {
+		binding: u32,
+		imageView: c.VkImageView,
+		sampler: c.VkSampler,
+		imageLayout: c.VkImageLayout = c.VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL,
+	},
 };
 
 pub fn bindDescriptors(self: CommandBuffer, pipeline: main.graphics.Pipeline, bindPoint: DescriptorBindPoint, set: u32, bindings: []const BindingInfo) void {
@@ -227,6 +233,17 @@ pub fn bindDescriptors(self: CommandBuffer, pipeline: main.graphics.Pipeline, bi
 				};
 				writeInfo[i].pBufferInfo = bufferInfo;
 			},
+			.image => |image| {
+				writeInfo[i].descriptorType = c.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+				const imageInfo = arena.create(c.VkDescriptorImageInfo);
+				imageInfo.* = .{
+					.sampler = image.sampler,
+					.imageView = image.imageView,
+					.imageLayout = image.imageLayout,
+				};
+				writeInfo[i].pImageInfo = imageInfo;
+
+			}
 		}
 	}
 	c.vkCmdPushDescriptorSetKHR(self.handle, @intFromEnum(bindPoint), pipeline.pipelineLayout, set, @intCast(writeInfo.len), writeInfo.ptr);

--- a/src/graphics/CommandBuffer.zig
+++ b/src/graphics/CommandBuffer.zig
@@ -233,6 +233,7 @@ pub fn bindDescriptors(self: CommandBuffer, pipeline: main.graphics.Pipeline, bi
 }
 
 pub fn pushConstants(self: CommandBuffer, pipeline: main.graphics.Pipeline, constants: anytype) void {
+	comptime std.debug.assert(@typeInfo(@TypeOf(constants.*)).@"struct".layout == .@"extern");
 	c.vkCmdPushConstants(self.handle, pipeline.pipelineLayout, c.VK_SHADER_STAGE_ALL, 0, @sizeOf(@TypeOf(constants.*)), constants);
 }
 

--- a/src/graphics/CommandBuffer.zig
+++ b/src/graphics/CommandBuffer.zig
@@ -241,8 +241,7 @@ pub fn bindDescriptors(self: CommandBuffer, pipeline: main.graphics.Pipeline, bi
 					.imageLayout = image.imageLayout,
 				};
 				writeInfo[i].pImageInfo = imageInfo;
-
-			}
+			},
 		}
 	}
 	c.vkCmdPushDescriptorSetKHR(self.handle, @intFromEnum(bindPoint), pipeline.pipelineLayout, set, @intCast(writeInfo.len), writeInfo.ptr);

--- a/src/graphics/vulkan.zig
+++ b/src/graphics/vulkan.zig
@@ -587,11 +587,11 @@ pub const SwapChain = struct { // MARK: SwapChain
 
 		fn chooseFormat(self: SupportDetails) c.VkSurfaceFormatKHR {
 			for (self.formats) |format| {
-				if (format.format == c.VK_FORMAT_B8G8R8A8_SRGB and format.colorSpace == c.VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+				if (format.format == c.VK_FORMAT_B8G8R8A8_UNORM and format.colorSpace == c.VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
 					return format;
 				}
 			}
-			@panic("Couldn't find swapchain format BGRA8 SRGB");
+			@panic("Couldn't find swapchain format BGRA8 UNORM");
 		}
 
 		fn chooseSwapPresentMode(self: SupportDetails) c.VkPresentModeKHR {

--- a/src/graphics/vulkan.zig
+++ b/src/graphics/vulkan.zig
@@ -850,6 +850,8 @@ pub const Image = struct { // MARK: Image
 	allocation: c.VmaAllocation = undefined,
 	mipLevels: u32,
 	size: main.vec.Vec3i,
+	view: c.VkImageView = undefined,
+	sampler: c.VkSampler = undefined,
 
 	const ImageOptions = struct {
 		usage: c.VkImageUsageFlags,
@@ -860,6 +862,26 @@ pub const Image = struct { // MARK: Image
 		mipLevels: u32 = 1,
 		arrayLayers: u32 = 1,
 		samples: c.VkSampleCountFlags = c.VK_SAMPLE_COUNT_1_BIT,
+
+		magFilter: Filter = .nearest,
+		minFilter: Filter = .nearest,
+		mipmapFilter: Filter = .nearest,
+		addressMode: AddressMode = .repeat,
+		mipLodBias: f32 = 0,
+		maxAnisotropy: ?f32 = null,
+
+		const Filter = enum(c.VkFilter) {
+			nearest = c.VK_FILTER_NEAREST,
+			linear = c.VK_FILTER_LINEAR,
+		};
+
+		const AddressMode = enum(c.VkSamplerAddressMode) {
+			repeat = c.VK_SAMPLER_ADDRESS_MODE_REPEAT,
+			mirroredRepeat = c.VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT,
+			clampToEdge = c.VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+			clampToBorder = c.VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+			mirrorClampToEdge = c.VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE,
+		};
 	};
 	pub fn init(size: main.vec.Vec3i, options: ImageOptions) Image {
 		var self: Image = .{
@@ -885,10 +907,55 @@ pub const Image = struct { // MARK: Image
 			.flags = if (options.hostAccessible) c.VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT else 0,
 		};
 		checkResult(c.vmaCreateImage(gpu_allocator.handle, &imageInfo, &allocCreateInfo, &self.handle, &self.allocation, null));
+
+		const imageViewInfo: c.VkImageViewCreateInfo = .{
+			.sType = c.VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+			.image = self.handle,
+			.format = options.format,
+			.subresourceRange = .{
+				.aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT,
+				.baseMipLevel = 0,
+				.levelCount = options.mipLevels,
+				.baseArrayLayer = 0,
+				.layerCount = options.arrayLayers,
+			},
+			.viewType = switch (options.imageType) {
+				c.VK_IMAGE_TYPE_1D => c.VK_IMAGE_VIEW_TYPE_1D,
+				c.VK_IMAGE_TYPE_2D => c.VK_IMAGE_VIEW_TYPE_2D,
+				c.VK_IMAGE_TYPE_3D => c.VK_IMAGE_VIEW_TYPE_3D,
+				else => unreachable,
+			}
+		};
+		checkResult(c.vkCreateImageView(device, &imageViewInfo, null, &self.view));
+
+		const samplerInfo: c.VkSamplerCreateInfo = .{
+			.sType = c.VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+			.magFilter = @intFromEnum(options.magFilter),
+			.minFilter = @intFromEnum(options.minFilter),
+			.mipmapMode = switch (options.mipmapFilter) {
+				.nearest => c.VK_SAMPLER_MIPMAP_MODE_NEAREST,
+				.linear => c.VK_SAMPLER_MIPMAP_MODE_LINEAR,
+			},
+			.addressModeU = @intFromEnum(options.addressMode),
+			.addressModeV = @intFromEnum(options.addressMode),
+			.addressModeW = @intFromEnum(options.addressMode),
+			.mipLodBias = options.mipLodBias,
+			.anisotropyEnable = if (options.maxAnisotropy != null) c.VK_TRUE else c.VK_FALSE,
+			.maxAnisotropy = options.maxAnisotropy orelse 0,
+			.compareEnable = c.VK_FALSE, // TODO: This may be useful for shadow map sampling
+			.minLod = 0,
+			.maxLod = c.VK_LOD_CLAMP_NONE,
+			.borderColor = c.VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
+			.unnormalizedCoordinates = c.VK_FALSE,
+		};
+		checkResult(c.vkCreateSampler(device, &samplerInfo, null, &self.sampler));
+		
 		return self;
 	}
 
 	fn privateDeinit(self: Image) void {
+		c.vkDestroySampler(device, self.sampler, null);
+		c.vkDestroyImageView(device, self.view, null);
 		c.vmaDestroyImage(gpu_allocator.handle, self.handle, self.allocation);
 	}
 

--- a/src/graphics/vulkan.zig
+++ b/src/graphics/vulkan.zig
@@ -924,7 +924,7 @@ pub const Image = struct { // MARK: Image
 				c.VK_IMAGE_TYPE_2D => c.VK_IMAGE_VIEW_TYPE_2D,
 				c.VK_IMAGE_TYPE_3D => c.VK_IMAGE_VIEW_TYPE_3D,
 				else => unreachable,
-			}
+			},
 		};
 		checkResult(c.vkCreateImageView(device, &imageViewInfo, null, &self.view));
 
@@ -949,7 +949,7 @@ pub const Image = struct { // MARK: Image
 			.unnormalizedCoordinates = c.VK_FALSE,
 		};
 		checkResult(c.vkCreateSampler(device, &samplerInfo, null, &self.sampler));
-		
+
 		return self;
 	}
 

--- a/src/gui/GuiWindow.zig
+++ b/src/gui/GuiWindow.zig
@@ -91,6 +91,13 @@ var windowUniforms: struct {
 	color: c_int,
 	scale: c_int,
 } = undefined;
+pub const WindowUniforms = extern struct {
+	start: [2]f32 align(8),
+	size: [2]f32 align(8),
+	screen: [2]f32 align(8),
+	color: i32,
+	scale: f32,
+};
 pub var borderPipeline: graphics.Pipeline = undefined;
 pub var borderUniforms: struct {
 	screen: c_int,
@@ -100,6 +107,14 @@ pub var borderUniforms: struct {
 	scale: c_int,
 	effectLength: c_int,
 } = undefined;
+pub const BorderUniforms = extern struct {
+	start: [2]f32 align(8),
+	size: [2]f32 align(8),
+	screen: [2]f32 align(8),
+	color: i32,
+	scale: f32,
+	effectLength: [2]f32 align(8),
+};
 
 pub fn globalInit() void {
 	pipeline = graphics.Pipeline.init(
@@ -109,9 +124,12 @@ pub fn globalInit() void {
 		&windowUniforms,
 		graphics.draw.SimpleVertex2D,
 		.{
+			.bindings = &.{.sampler(0, .{.fragment = true})},
 			.rasterState = .{.cullMode = .none},
 			.depthStencilState = .{.depthTest = false, .depthWrite = false},
 			.blendState = .{.attachments = &.{.alphaBlending}, .formats = &.{.swapChain}},
+			.inputAssemblyState = .{.topology = .triangleStrip},
+			.pushConstantSize = @sizeOf(WindowUniforms),
 		},
 	);
 	borderPipeline = graphics.Pipeline.init(
@@ -124,6 +142,8 @@ pub fn globalInit() void {
 			.rasterState = .{.cullMode = .none},
 			.depthStencilState = .{.depthTest = false, .depthWrite = false},
 			.blendState = .{.attachments = &.{.alphaBlending}, .formats = &.{.swapChain}},
+			.inputAssemblyState = .{.topology = .triangleStrip},
+			.pushConstantSize = @sizeOf(BorderUniforms),
 		},
 	);
 
@@ -519,18 +539,42 @@ pub fn render(self: *const GuiWindow, mousePosition: Vec2f) void {
 	const oldTranslation = draw.setTranslation(self.pos);
 	const oldScale = draw.setScale(self.scale);
 	if (self.hasBackground) {
-		pipeline.bind(draw.getScissor());
-		backgroundTexture.bindTo(0);
-		draw.customShadedRect(windowUniforms, .{0, 0}, self.size/@as(Vec2f, @splat(self.scale)));
+		if (main.settings.launchConfig.vulkanTestingMode and backgroundTexture.vulkanImage != null) {
+			graphics.vulkan.currentFrame.guiCommands.bindPipeline(pipeline, graphics.draw.getScissor());
+			graphics.vulkan.currentFrame.guiCommands.bindDescriptors(pipeline, .graphics, 0, &.{
+				.{ .image = .{
+					.binding = 0,
+					.imageView = backgroundTexture.vulkanImage.?.view,
+					.sampler = backgroundTexture.vulkanImage.?.sampler,
+				}},
+			});
+			draw.customShadedRect(@as(WindowUniforms, undefined), pipeline, .{0, 0}, self.size/@as(Vec2f, @splat(self.scale)));
+		} else {
+			pipeline.bind(draw.getScissor());
+			backgroundTexture.bindTo(0);
+			draw.customShadedRectOpenGl(windowUniforms, .{0, 0}, self.size/@as(Vec2f, @splat(self.scale)));
+		}
 	}
 	self.renderFn();
 	if (self.rootComponent) |*component| {
 		component.render((mousePosition - self.pos)/@as(Vec2f, @splat(self.scale)));
 	}
 	if (self.showTitleBar or gui.reorderWindows) {
-		pipeline.bind(draw.getScissor());
-		titleTexture.bindTo(0);
-		draw.customShadedRect(windowUniforms, .{0, 0}, .{self.size[0]/self.scale, titleBarHeight});
+		if (main.settings.launchConfig.vulkanTestingMode and titleTexture.vulkanImage != null) {
+			graphics.vulkan.currentFrame.guiCommands.bindPipeline(pipeline, graphics.draw.getScissor());
+			graphics.vulkan.currentFrame.guiCommands.bindDescriptors(pipeline, .graphics, 0, &.{
+				.{ .image = .{
+					.binding = 0,
+					.imageView = titleTexture.vulkanImage.?.view,
+					.sampler = titleTexture.vulkanImage.?.sampler,
+				}},
+			});
+			draw.customShadedRect(@as(WindowUniforms, undefined), pipeline, .{0, 0}, .{self.size[0]/self.scale, titleBarHeight});
+		} else {
+			pipeline.bind(draw.getScissor());
+			titleTexture.bindTo(0);
+			draw.customShadedRectOpenGl(windowUniforms, .{0, 0}, .{self.size[0]/self.scale, titleBarHeight});
+		}
 		self.drawIcons();
 	}
 	if (self.hasBackground or (!main.Window.grabbed and gui.reorderWindows)) {

--- a/src/gui/GuiWindow.zig
+++ b/src/gui/GuiWindow.zig
@@ -542,11 +542,7 @@ pub fn render(self: *const GuiWindow, mousePosition: Vec2f) void {
 		if (main.settings.launchConfig.vulkanTestingMode and backgroundTexture.vulkanImage != null) {
 			graphics.vulkan.currentFrame.guiCommands.bindPipeline(pipeline, graphics.draw.getScissor());
 			graphics.vulkan.currentFrame.guiCommands.bindDescriptors(pipeline, .graphics, 0, &.{
-				.{ .image = .{
-					.binding = 0,
-					.imageView = backgroundTexture.vulkanImage.?.view,
-					.sampler = backgroundTexture.vulkanImage.?.sampler,
-				}},
+				.{.image = .{.binding = 0, .image = backgroundTexture.vulkanImage.?}},
 			});
 			draw.customShadedRect(@as(WindowUniforms, undefined), pipeline, .{0, 0}, self.size/@as(Vec2f, @splat(self.scale)));
 		} else {
@@ -563,11 +559,7 @@ pub fn render(self: *const GuiWindow, mousePosition: Vec2f) void {
 		if (main.settings.launchConfig.vulkanTestingMode and titleTexture.vulkanImage != null) {
 			graphics.vulkan.currentFrame.guiCommands.bindPipeline(pipeline, graphics.draw.getScissor());
 			graphics.vulkan.currentFrame.guiCommands.bindDescriptors(pipeline, .graphics, 0, &.{
-				.{ .image = .{
-					.binding = 0,
-					.imageView = titleTexture.vulkanImage.?.view,
-					.sampler = titleTexture.vulkanImage.?.sampler,
-				}},
+				.{.image = .{.binding = 0, .image = titleTexture.vulkanImage.?}},
 			});
 			draw.customShadedRect(@as(WindowUniforms, undefined), pipeline, .{0, 0}, .{self.size[0]/self.scale, titleBarHeight});
 		} else {

--- a/src/gui/components/BagSlot.zig
+++ b/src/gui/components/BagSlot.zig
@@ -82,7 +82,7 @@ pub fn mainButtonReleased(self: *BagSlot, mousePosition: Vec2f) void {
 
 pub fn render(self: *BagSlot, _: Vec2f) void {
 	texture.bindTo(0);
-	draw.boundImage(self.pos, @splat(sizeWithBorder));
+	draw.image(texture, self.pos, @splat(sizeWithBorder));
 
 	for (0..5) |_i| {
 		const i = 4 - _i;

--- a/src/gui/components/Button.zig
+++ b/src/gui/components/Button.zig
@@ -163,8 +163,7 @@ pub fn render(self: *Button, mousePosition: Vec2f) void {
 
 	const cornerSize = (textures.outlineTextureSize - Vec2f{1, 1})/Vec2f{2, 2};
 
-	textures.outlineTexture.bindTo(0);
-	graphics.draw.bound9SliceImage(self.pos, self.size, textures.outlineTextureSize, cornerSize, 2);
+	graphics.draw.nineSliceImage(textures.outlineTexture, self.pos, self.size, textures.outlineTextureSize, cornerSize, 2);
 
 	const oldColor = draw.setColor(if (self.disabled) 0xff808080 else 0xffffffff);
 	defer draw.restoreColor(oldColor);

--- a/src/gui/components/Button.zig
+++ b/src/gui/components/Button.zig
@@ -168,11 +168,7 @@ pub fn render(self: *Button, mousePosition: Vec2f) void {
 		if (main.settings.launchConfig.vulkanTestingMode and textures.texture.vulkanImage != null) {
 			graphics.vulkan.currentFrame.guiCommands.bindPipeline(pipeline, graphics.draw.getScissor());
 			graphics.vulkan.currentFrame.guiCommands.bindDescriptors(pipeline, .graphics, 0, &.{
-				.{ .image = .{
-					.binding = 0,
-					.imageView = textures.texture.vulkanImage.?.view,
-					.sampler = textures.texture.vulkanImage.?.sampler,
-				}},
+				.{.image = .{.binding = 0, .image = textures.texture.vulkanImage.?}},
 			});
 			draw.customShadedRect(@as(ButtonUniforms, undefined), pipeline, self.pos + Vec2f{2, 2}, self.size - Vec2f{4, 4});
 		} else {

--- a/src/gui/components/Button.zig
+++ b/src/gui/components/Button.zig
@@ -51,6 +51,13 @@ pub var buttonUniforms: struct {
 	color: c_int,
 	scale: c_int,
 } = undefined;
+pub const ButtonUniforms = extern struct {
+	start: [2]f32 align(8),
+	size: [2]f32 align(8),
+	screen: [2]f32 align(8),
+	color: i32,
+	scale: f32,
+};
 
 pos: Vec2f,
 size: Vec2f,
@@ -68,9 +75,12 @@ pub fn globalInit() void {
 		&buttonUniforms,
 		graphics.draw.SimpleVertex2D,
 		.{
+			.bindings = &.{.sampler(0, .{.fragment = true})},
 			.rasterState = .{.cullMode = .none},
 			.depthStencilState = .{.depthTest = false, .depthWrite = false},
 			.blendState = .{.attachments = &.{.alphaBlending}, .formats = &.{.swapChain}},
+			.inputAssemblyState = .{.topology = .triangleStrip},
+			.pushConstantSize = @sizeOf(ButtonUniforms),
 		},
 	);
 	normalTextures = Textures.init("assets/cubyz/ui/button");
@@ -155,10 +165,22 @@ pub fn render(self: *Button, mousePosition: Vec2f) void {
 		break :blk normalTextures;
 	};
 	{
-		textures.texture.bindTo(0);
-		pipeline.bind(draw.getScissor());
+		if (main.settings.launchConfig.vulkanTestingMode and textures.texture.vulkanImage != null) {
+			graphics.vulkan.currentFrame.guiCommands.bindPipeline(pipeline, graphics.draw.getScissor());
+			graphics.vulkan.currentFrame.guiCommands.bindDescriptors(pipeline, .graphics, 0, &.{
+				.{ .image = .{
+					.binding = 0,
+					.imageView = textures.texture.vulkanImage.?.view,
+					.sampler = textures.texture.vulkanImage.?.sampler,
+				}},
+			});
+			draw.customShadedRect(@as(ButtonUniforms, undefined), pipeline, self.pos + Vec2f{2, 2}, self.size - Vec2f{4, 4});
+		} else {
+			textures.texture.bindTo(0);
+			pipeline.bind(draw.getScissor());
+			draw.customShadedRectOpenGl(buttonUniforms, self.pos + Vec2f{2, 2}, self.size - Vec2f{4, 4});
+		}
 		self.hovered = false;
-		draw.customShadedRect(buttonUniforms, self.pos + Vec2f{2, 2}, self.size - Vec2f{4, 4});
 	}
 
 	const cornerSize = (textures.outlineTextureSize - Vec2f{1, 1})/Vec2f{2, 2};

--- a/src/gui/components/CheckBox.zig
+++ b/src/gui/components/CheckBox.zig
@@ -117,11 +117,7 @@ pub fn render(self: *CheckBox, mousePosition: Vec2f) void {
 	if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
 		graphics.vulkan.currentFrame.guiCommands.bindPipeline(Button.pipeline, graphics.draw.getScissor());
 		graphics.vulkan.currentFrame.guiCommands.bindDescriptors(Button.pipeline, .graphics, 0, &.{
-			.{ .image = .{
-				.binding = 0,
-				.imageView = texture.vulkanImage.?.view,
-				.sampler = texture.vulkanImage.?.sampler,
-			}},
+			.{.image = .{.binding = 0, .image = texture.vulkanImage.?}},
 		});
 		draw.customShadedRect(@as(Button.ButtonUniforms, undefined), Button.pipeline, self.pos + Vec2f{0, self.size[1]/2 - boxSize/2}, @as(Vec2f, @splat(boxSize)));
 	} else {

--- a/src/gui/components/CheckBox.zig
+++ b/src/gui/components/CheckBox.zig
@@ -95,26 +95,41 @@ pub fn mainButtonReleased(self: *CheckBox, mousePosition: Vec2f) void {
 }
 
 pub fn render(self: *CheckBox, mousePosition: Vec2f) void {
-	if (self.state) {
-		if (self.pressed) {
-			textureCheckedPressed.bindTo(0);
-		} else if (GuiComponent.contains(self.pos, self.size, mousePosition) and self.hovered) {
-			textureCheckedHovered.bindTo(0);
+	const texture = blk: {
+		if (self.state) {
+			if (self.pressed) {
+				break :blk textureCheckedPressed;
+			} else if (GuiComponent.contains(self.pos, self.size, mousePosition) and self.hovered) {
+				break :blk textureCheckedHovered;
+			} else {
+				break :blk textureCheckedNormal;
+			}
 		} else {
-			textureCheckedNormal.bindTo(0);
+			if (self.pressed) {
+				break :blk textureEmptyPressed;
+			} else if (GuiComponent.contains(self.pos, self.size, mousePosition) and self.hovered) {
+				break :blk textureEmptyHovered;
+			} else {
+				break :blk textureEmptyNormal;
+			}
 		}
+	};
+	if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
+		graphics.vulkan.currentFrame.guiCommands.bindPipeline(Button.pipeline, graphics.draw.getScissor());
+		graphics.vulkan.currentFrame.guiCommands.bindDescriptors(Button.pipeline, .graphics, 0, &.{
+			.{ .image = .{
+				.binding = 0,
+				.imageView = texture.vulkanImage.?.view,
+				.sampler = texture.vulkanImage.?.sampler,
+			}},
+		});
+		draw.customShadedRect(@as(Button.ButtonUniforms, undefined), Button.pipeline, self.pos + Vec2f{0, self.size[1]/2 - boxSize/2}, @as(Vec2f, @splat(boxSize)));
 	} else {
-		if (self.pressed) {
-			textureEmptyPressed.bindTo(0);
-		} else if (GuiComponent.contains(self.pos, self.size, mousePosition) and self.hovered) {
-			textureEmptyHovered.bindTo(0);
-		} else {
-			textureEmptyNormal.bindTo(0);
-		}
+		Button.pipeline.bind(draw.getScissor());
+		texture.bindTo(0);
+		draw.customShadedRectOpenGl(Button.buttonUniforms, self.pos + Vec2f{0, self.size[1]/2 - boxSize/2}, @as(Vec2f, @splat(boxSize)));
 	}
-	Button.pipeline.bind(draw.getScissor());
 	self.hovered = false;
-	draw.customShadedRect(Button.buttonUniforms, self.pos + Vec2f{0, self.size[1]/2 - boxSize/2}, @as(Vec2f, @splat(boxSize)));
 	const textPos = self.pos + Vec2f{boxSize/2, 0} + self.size/@as(Vec2f, @splat(2.0)) - self.label.size/@as(Vec2f, @splat(2.0));
 	self.label.pos = textPos;
 	self.label.render(mousePosition - textPos);

--- a/src/gui/components/ContinuousSlider.zig
+++ b/src/gui/components/ContinuousSlider.zig
@@ -140,9 +140,21 @@ pub fn mainButtonReleased(self: *ContinuousSlider, _: Vec2f) void {
 }
 
 pub fn render(self: *ContinuousSlider, mousePosition: Vec2f) void {
-	texture.bindTo(0);
-	Button.pipeline.bind(draw.getScissor());
-	draw.customShadedRect(Button.buttonUniforms, self.pos, self.size);
+	if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
+		graphics.vulkan.currentFrame.guiCommands.bindPipeline(Button.pipeline, graphics.draw.getScissor());
+		graphics.vulkan.currentFrame.guiCommands.bindDescriptors(Button.pipeline, .graphics, 0, &.{
+			.{ .image = .{
+				.binding = 0,
+				.imageView = texture.vulkanImage.?.view,
+				.sampler = texture.vulkanImage.?.sampler,
+			}},
+		});
+		draw.customShadedRect(@as(Button.ButtonUniforms, undefined), Button.pipeline, self.pos, self.size);
+	} else {
+		Button.pipeline.bind(draw.getScissor());
+		texture.bindTo(0);
+		draw.customShadedRectOpenGl(Button.buttonUniforms, self.pos, self.size);
+	}
 
 	{
 		const oldColor = draw.setColor(0x80000000);

--- a/src/gui/components/ContinuousSlider.zig
+++ b/src/gui/components/ContinuousSlider.zig
@@ -143,11 +143,7 @@ pub fn render(self: *ContinuousSlider, mousePosition: Vec2f) void {
 	if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
 		graphics.vulkan.currentFrame.guiCommands.bindPipeline(Button.pipeline, graphics.draw.getScissor());
 		graphics.vulkan.currentFrame.guiCommands.bindDescriptors(Button.pipeline, .graphics, 0, &.{
-			.{ .image = .{
-				.binding = 0,
-				.imageView = texture.vulkanImage.?.view,
-				.sampler = texture.vulkanImage.?.sampler,
-			}},
+			.{.image = .{.binding = 0, .image = texture.vulkanImage.?}},
 		});
 		draw.customShadedRect(@as(Button.ButtonUniforms, undefined), Button.pipeline, self.pos, self.size);
 	} else {

--- a/src/gui/components/DiscreteSlider.zig
+++ b/src/gui/components/DiscreteSlider.zig
@@ -152,9 +152,21 @@ pub fn mainButtonReleased(self: *DiscreteSlider, _: Vec2f) void {
 }
 
 pub fn render(self: *DiscreteSlider, mousePosition: Vec2f) void {
-	texture.bindTo(0);
-	Button.pipeline.bind(draw.getScissor());
-	draw.customShadedRect(Button.buttonUniforms, self.pos, self.size);
+	if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
+		graphics.vulkan.currentFrame.guiCommands.bindPipeline(Button.pipeline, graphics.draw.getScissor());
+		graphics.vulkan.currentFrame.guiCommands.bindDescriptors(Button.pipeline, .graphics, 0, &.{
+			.{ .image = .{
+				.binding = 0,
+				.imageView = texture.vulkanImage.?.view,
+				.sampler = texture.vulkanImage.?.sampler,
+			}},
+		});
+		draw.customShadedRect(@as(Button.ButtonUniforms, undefined), Button.pipeline, self.pos, self.size);
+	} else {
+		Button.pipeline.bind(draw.getScissor());
+		texture.bindTo(0);
+		draw.customShadedRectOpenGl(Button.buttonUniforms, self.pos, self.size);
+	}
 
 	{
 		const oldColor = draw.setColor(0x80000000);

--- a/src/gui/components/DiscreteSlider.zig
+++ b/src/gui/components/DiscreteSlider.zig
@@ -155,11 +155,7 @@ pub fn render(self: *DiscreteSlider, mousePosition: Vec2f) void {
 	if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
 		graphics.vulkan.currentFrame.guiCommands.bindPipeline(Button.pipeline, graphics.draw.getScissor());
 		graphics.vulkan.currentFrame.guiCommands.bindDescriptors(Button.pipeline, .graphics, 0, &.{
-			.{ .image = .{
-				.binding = 0,
-				.imageView = texture.vulkanImage.?.view,
-				.sampler = texture.vulkanImage.?.sampler,
-			}},
+			.{.image = .{.binding = 0, .image = texture.vulkanImage.?}},
 		});
 		draw.customShadedRect(@as(Button.ButtonUniforms, undefined), Button.pipeline, self.pos, self.size);
 	} else {

--- a/src/gui/components/ItemSlot.zig
+++ b/src/gui/components/ItemSlot.zig
@@ -132,8 +132,7 @@ pub fn mainButtonReleased(self: *ItemSlot, _: Vec2f) void {
 pub fn render(self: *ItemSlot, _: Vec2f) void {
 	self.refreshText();
 	if (self.renderFrame and self.texture != null) {
-		self.texture.?.bindTo(0);
-		draw.boundImage(self.pos, self.size);
+		draw.image(self.texture.?, self.pos, self.size);
 	}
 	const item = self.inventory.getItem(self.itemSlot);
 	if (item != .null) {

--- a/src/gui/components/ScrollBar.zig
+++ b/src/gui/components/ScrollBar.zig
@@ -95,9 +95,21 @@ pub fn mainButtonReleased(self: *ScrollBar, mousePosition: Vec2f) void {
 }
 
 pub fn render(self: *ScrollBar, mousePosition: Vec2f) void {
-	texture.bindTo(0);
-	Button.pipeline.bind(draw.getScissor());
-	draw.customShadedRect(Button.buttonUniforms, self.pos, self.size);
+	if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
+		graphics.vulkan.currentFrame.guiCommands.bindPipeline(Button.pipeline, graphics.draw.getScissor());
+		graphics.vulkan.currentFrame.guiCommands.bindDescriptors(Button.pipeline, .graphics, 0, &.{
+			.{ .image = .{
+				.binding = 0,
+				.imageView = texture.vulkanImage.?.view,
+				.sampler = texture.vulkanImage.?.sampler,
+			}},
+		});
+		draw.customShadedRect(@as(Button.ButtonUniforms, undefined), Button.pipeline, self.pos, self.size);
+	} else {
+		Button.pipeline.bind(draw.getScissor());
+		texture.bindTo(0);
+		draw.customShadedRectOpenGl(Button.buttonUniforms, self.pos, self.size);
+	}
 
 	const range: f32 = self.size[1] - self.button.size[1];
 	self.setButtonPosFromValue();

--- a/src/gui/components/ScrollBar.zig
+++ b/src/gui/components/ScrollBar.zig
@@ -98,11 +98,7 @@ pub fn render(self: *ScrollBar, mousePosition: Vec2f) void {
 	if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
 		graphics.vulkan.currentFrame.guiCommands.bindPipeline(Button.pipeline, graphics.draw.getScissor());
 		graphics.vulkan.currentFrame.guiCommands.bindDescriptors(Button.pipeline, .graphics, 0, &.{
-			.{ .image = .{
-				.binding = 0,
-				.imageView = texture.vulkanImage.?.view,
-				.sampler = texture.vulkanImage.?.sampler,
-			}},
+			.{.image = .{.binding = 0, .image = texture.vulkanImage.?}},
 		});
 		draw.customShadedRect(@as(Button.ButtonUniforms, undefined), Button.pipeline, self.pos, self.size);
 	} else {

--- a/src/gui/components/TextInput.zig
+++ b/src/gui/components/TextInput.zig
@@ -522,11 +522,7 @@ pub fn render(self: *TextInput, mousePosition: Vec2f) void {
 	if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
 		graphics.vulkan.currentFrame.guiCommands.bindPipeline(Button.pipeline, graphics.draw.getScissor());
 		graphics.vulkan.currentFrame.guiCommands.bindDescriptors(Button.pipeline, .graphics, 0, &.{
-			.{ .image = .{
-				.binding = 0,
-				.imageView = texture.vulkanImage.?.view,
-				.sampler = texture.vulkanImage.?.sampler,
-			}},
+			.{.image = .{.binding = 0, .image = texture.vulkanImage.?}},
 		});
 		draw.customShadedRect(@as(Button.ButtonUniforms, undefined), Button.pipeline, self.pos, self.size);
 	} else {

--- a/src/gui/components/TextInput.zig
+++ b/src/gui/components/TextInput.zig
@@ -519,9 +519,21 @@ fn getRenderCursorPos(self: *const TextInput, pos: u32) u32 {
 }
 
 pub fn render(self: *TextInput, mousePosition: Vec2f) void {
-	texture.bindTo(0);
-	Button.pipeline.bind(draw.getScissor());
-	draw.customShadedRect(Button.buttonUniforms, self.pos, self.size);
+	if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
+		graphics.vulkan.currentFrame.guiCommands.bindPipeline(Button.pipeline, graphics.draw.getScissor());
+		graphics.vulkan.currentFrame.guiCommands.bindDescriptors(Button.pipeline, .graphics, 0, &.{
+			.{ .image = .{
+				.binding = 0,
+				.imageView = texture.vulkanImage.?.view,
+				.sampler = texture.vulkanImage.?.sampler,
+			}},
+		});
+		draw.customShadedRect(@as(Button.ButtonUniforms, undefined), Button.pipeline, self.pos, self.size);
+	} else {
+		Button.pipeline.bind(draw.getScissor());
+		texture.bindTo(0);
+		draw.customShadedRectOpenGl(Button.buttonUniforms, self.pos, self.size);
+	}
 	const oldTranslation = draw.setTranslation(self.pos);
 	defer draw.restoreTranslation(oldTranslation);
 	const oldClip = draw.setClip(self.size);

--- a/src/gui/gamepad_cursor.zig
+++ b/src/gui/gamepad_cursor.zig
@@ -21,7 +21,6 @@ pub fn deinit() void {
 
 pub fn render() void {
 	if (main.Window.lastUsedMouse or main.Window.grabbed) return;
-	texture.bindTo(0);
 	const mousePos = main.Window.getMousePosition();
-	graphics.draw.boundImage(@as(Vec2f, @splat(-size/2.0)) + (mousePos/@as(Vec2f, @splat(gui.scale))), .{size, size});
+	graphics.draw.image(texture, @as(Vec2f, @splat(-size/2.0)) + (mousePos/@as(Vec2f, @splat(gui.scale))), .{size, size});
 }

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -607,9 +607,16 @@ pub fn updateAndRenderGui() void {
 		if (!main.Window.grabbed) {
 			const oldColor = draw.setColor(0x80000000);
 			defer draw.restoreColor(oldColor);
-			GuiWindow.borderPipeline.bind(draw.getScissor());
-			c.glUniform2f(GuiWindow.borderUniforms.effectLength, main.Window.getWindowSize()[0]/6, main.Window.getWindowSize()[1]/6);
-			draw.customShadedRect(GuiWindow.borderUniforms, .{0, 0}, main.Window.getWindowSize());
+			if (main.settings.launchConfig.vulkanTestingMode) {
+				graphics.vulkan.currentFrame.guiCommands.bindPipeline(GuiWindow.borderPipeline, graphics.draw.getScissor());
+				var uniforms: GuiWindow.BorderUniforms = undefined;
+				uniforms.effectLength = .{main.Window.getWindowSize()[0]/6, main.Window.getWindowSize()[1]/6};
+				draw.customShadedRect(uniforms, GuiWindow.borderPipeline, .{0, 0}, main.Window.getWindowSize());
+			} else {
+				GuiWindow.borderPipeline.bind(draw.getScissor());
+				c.glUniform2f(GuiWindow.borderUniforms.effectLength, main.Window.getWindowSize()[0]/6, main.Window.getWindowSize()[1]/6);
+				draw.customShadedRectOpenGl(GuiWindow.borderUniforms, .{0, 0}, main.Window.getWindowSize());
+			}
 		}
 		const oldScale = draw.setScale(scale);
 		defer draw.restoreScale(oldScale);

--- a/src/gui/tooltip.zig
+++ b/src/gui/tooltip.zig
@@ -27,7 +27,6 @@ pub fn globalDeinit() void {
 
 pub fn render(guiComponent: *GuiComponent, pos: Vec2f) void {
 	const size = guiComponent.size() + Vec2f{cornerSize[0]*2, cornerSize[1]*2};
-	tooltipTexture.bindTo(0);
 
 	const windowSize = main.Window.getWindowSize()/@as(Vec2f, @splat(gui.scale));
 	var renderPos = pos + Vec2f{offsetFromMouse, 0};
@@ -39,7 +38,7 @@ pub fn render(guiComponent: *GuiComponent, pos: Vec2f) void {
 		renderPos[1] += windowSize[1] - (renderPos[1] + size[1]);
 	}
 
-	draw.bound9SliceImage(renderPos, size, @floatFromInt(tooltipTexture.size()), cornerSize, 1);
+	draw.nineSliceImage(tooltipTexture, renderPos, size, @floatFromInt(tooltipTexture.size()), cornerSize, 1);
 
 	const adjustment = renderPos - guiComponent.pos() + Vec2f{cornerSize[0], cornerSize[1]};
 	const oldTranslation = draw.setTranslation(adjustment);

--- a/src/gui/windows/crosshair.zig
+++ b/src/gui/windows/crosshair.zig
@@ -75,11 +75,7 @@ pub fn render() void {
 	if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
 		graphics.vulkan.currentFrame.guiCommands.bindPipeline(pipeline, graphics.draw.getScissor());
 		graphics.vulkan.currentFrame.guiCommands.bindDescriptors(pipeline, .graphics, 0, &.{
-			.{ .image = .{
-				.binding = 0,
-				.imageView = texture.vulkanImage.?.view,
-				.sampler = texture.vulkanImage.?.sampler,
-			}},
+			.{.image = .{.binding = 0, .image = texture.vulkanImage.?}},
 		});
 		graphics.draw.customShadedImage(@as(Uniforms, undefined), pipeline, .{0, 0}, .{size, size});
 	} else {

--- a/src/gui/windows/crosshair.zig
+++ b/src/gui/windows/crosshair.zig
@@ -31,6 +31,14 @@ var uniforms: struct {
 	uvOffset: c_int,
 	uvDim: c_int,
 } = undefined;
+const Uniforms = extern struct {
+	start: [2]f32 align(8),
+	size: [2]f32 align(8),
+	screen: [2]f32 align(8),
+	color: i32,
+	uvOffset: [2]f32 align(8),
+	uvDim: [2]f32 align(8),
+};
 
 pub fn init() void {
 	pipeline = graphics.Pipeline.init(
@@ -40,6 +48,7 @@ pub fn init() void {
 		&uniforms,
 		graphics.draw.SimpleVertex2D,
 		.{
+			.bindings = &.{.sampler(0, .{.fragment = true})},
 			.rasterState = .{.cullMode = .none},
 			.depthStencilState = .{.depthTest = false, .depthWrite = false},
 			.blendState = .{.attachments = &.{.{
@@ -50,6 +59,8 @@ pub fn init() void {
 				.dstAlphaBlendFactor = .one,
 				.alphaBlendOp = .subtract,
 			}}, .formats = &.{.swapChain}},
+			.inputAssemblyState = .{.topology = .triangleStrip},
+			.pushConstantSize = @sizeOf(Uniforms),
 		},
 	);
 	texture = Texture.initFromFile("assets/cubyz/ui/hud/crosshair.png");
@@ -61,7 +72,19 @@ pub fn deinit() void {
 }
 
 pub fn render() void {
-	texture.bindTo(0);
-	pipeline.bind(graphics.draw.getScissor());
-	graphics.draw.customShadedImage(&uniforms, .{0, 0}, .{size, size});
+	if (main.settings.launchConfig.vulkanTestingMode and texture.vulkanImage != null) {
+		graphics.vulkan.currentFrame.guiCommands.bindPipeline(pipeline, graphics.draw.getScissor());
+		graphics.vulkan.currentFrame.guiCommands.bindDescriptors(pipeline, .graphics, 0, &.{
+			.{ .image = .{
+				.binding = 0,
+				.imageView = texture.vulkanImage.?.view,
+				.sampler = texture.vulkanImage.?.sampler,
+			}},
+		});
+		graphics.draw.customShadedImage(@as(Uniforms, undefined), pipeline, .{0, 0}, .{size, size});
+	} else {
+		texture.bindTo(0);
+		pipeline.bind(graphics.draw.getScissor());
+		graphics.draw.customShadedImageOpenGl(&uniforms, .{0, 0}, .{size, size});
+	}
 }

--- a/src/gui/windows/energybar.zig
+++ b/src/gui/windows/energybar.zig
@@ -53,14 +53,16 @@ pub fn render() void {
 			x = 0;
 			y += 20;
 		}
-		if (energy + 1 <= main.game.Player.super.energy) {
-			energyTexture.bindTo(0);
-		} else if (energy + 0.5 <= main.game.Player.super.energy) {
-			halfEnergyTexture.bindTo(0);
-		} else {
-			noEnergyTexture.bindTo(0);
-		}
-		draw.boundImage(Vec2f{x, window.contentSize[1] - y - 20}, .{20, 20});
+		const texture = blk: {
+			if (energy + 1 <= main.game.Player.super.energy) {
+				break :blk energyTexture;
+			} else if (energy + 0.5 <= main.game.Player.super.energy) {
+				break :blk halfEnergyTexture;
+			} else {
+				break :blk noEnergyTexture;
+			}
+		};
+		draw.image(texture, Vec2f{x, window.contentSize[1] - y - 20}, .{20, 20});
 		x += 20;
 	}
 	y += 20;

--- a/src/gui/windows/healthbar.zig
+++ b/src/gui/windows/healthbar.zig
@@ -59,15 +59,17 @@ pub fn render() void {
 			y += 20;
 		}
 
-		if (i < wholeHearts) {
-			heartTexture.bindTo(0);
-		} else if (i < wholeHearts + halfHeart) {
-			halfHeartTexture.bindTo(0);
-		} else {
-			deadHeartTexture.bindTo(0);
-		}
+		const texture = blk: {
+			if (i < wholeHearts) {
+				break :blk heartTexture;
+			} else if (i < wholeHearts + halfHeart) {
+				break :blk halfHeartTexture;
+			} else {
+				break :blk deadHeartTexture;
+			}
+		};
 
-		draw.boundImage(Vec2f{x, window.contentSize[1] - y - 20}, .{20, 20});
+		draw.image(texture, Vec2f{x, window.contentSize[1] - y - 20}, .{20, 20});
 		x += 20;
 	}
 

--- a/src/items.zig
+++ b/src/items.zig
@@ -1234,8 +1234,7 @@ pub const Item = union(ItemType) { // MARK: Item
 
 	pub fn render(self: Item, pos: Vec2f, slotSize: Vec2f, border: f32) void {
 		const itemTexture = self.getTexture();
-		itemTexture.bindTo(0);
-		graphics.draw.boundImage(pos + @as(Vec2f, @splat(border)), slotSize - @as(Vec2f, @splat(2*border)));
+		graphics.draw.image(itemTexture, pos + @as(Vec2f, @splat(border)), slotSize - @as(Vec2f, @splat(2*border)));
 
 		if (self == .proceduralItem) {
 			const proceduralItem = self.proceduralItem;


### PR DESCRIPTION
For now I decided to put sampler and image view into the same image object, we probably won't have context dependent sampling methods for the same images any time soon.

Beyond this, this PR mainly just converts some basic functionality that uses images:

<img width="1903" height="741" alt="Screenshot at 2026-08-31 17-02-54" src="https://github.com/user-attachments/assets/2b597bb3-6540-4e28-9d51-a1ce280f813a" />

progress towards #102