### PR TITLE
Fix server restart freeze

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -298,18 +298,22 @@ pub const World = struct { // MARK: World
 			.milliTime = main.timestamp().toMilliseconds(),
 		};
 
-		errdefer self.conn.deinit();
-
-		self.itemDrops.init(main.globalAllocator);
-		errdefer self.itemDrops.deinit();
-
 		return try network.protocols.handShake.clientSide(self.conn, settings.playerName);
 	}
 
 	pub fn init(self: *World, ip: []const u8, manager: *ConnectionManager) !ZonElement {
 		self.conn = try Connection.init(manager, ip, null);
+		errdefer self.conn.deinit();
 		self.manager = manager;
-		return try self.connect();
+		while (true) {
+			return self.connect() catch |err| switch(err) {
+				error.RestartAgain => {
+					std.log.warn("Server restarted while joining", .{});
+					continue;
+				},
+				inline else => |e| return e,
+			};
+		}
 	}
 
 	pub fn @"continue"(self: *World) !void {
@@ -365,6 +369,7 @@ pub const World = struct { // MARK: World
 		main.game.world = self;
 		errdefer main.heap.allocators.destroyWorldArena();
 		errdefer self.conn.deinit();
+		self.itemDrops.init(main.globalAllocator);
 		errdefer self.itemDrops.deinit();
 
 		// TODO: Consider using a per-world allocator.
@@ -799,16 +804,26 @@ pub fn restart() void {
 	if (world) |_world| {
 		_world.pause();
 
-		network.protocols.reload.informServerOfRestart(_world.conn);
+		while (true) {
+			network.protocols.reload.informServerOfRestart(_world.conn);
 
-		_world.@"continue"() catch |err| {
-			std.log.err("Encountered error while opening world: {s}", .{@errorName(err)});
-			main.gui.windowlist.notification.raiseNotification("Encountered error while opening world: {s}", .{@errorName(err)});
-			world = null;
+			_world.@"continue"() catch |err| switch (err) {
+				error.RestartAgain => {
+					std.log.warn("Server restarted multiple times", .{});
+					continue;
+				},
+				else => {
+					std.log.err("Encountered error while opening world: {s}", .{@errorName(err)});
+					main.gui.windowlist.notification.raiseNotification("Encountered error while opening world: {s}", .{@errorName(err)});
+					world = null;
 
-			main.gui.openWindow("main");
-			return;
-		};
+					main.gui.openWindow("main");
+					return;
+				},
+			};
+
+			break;
+		}
 		main.gui.openHud();
 	}
 }

--- a/src/game.zig
+++ b/src/game.zig
@@ -306,7 +306,7 @@ pub const World = struct { // MARK: World
 		errdefer self.conn.deinit();
 		self.manager = manager;
 		while (true) {
-			return self.connect() catch |err| switch(err) {
+			return self.connect() catch |err| switch (err) {
 				error.RestartAgain => {
 					std.log.warn("Server restarted while joining", .{});
 					continue;

--- a/src/network.zig
+++ b/src/network.zig
@@ -1716,6 +1716,10 @@ pub const Connection = struct { // MARK: Connection
 				self.nextPacketTimestamp = timestamp;
 				self.hasRttEstimate = true;
 			}
+			if (self.rttEstimate/averageRtt > 10) { // Quickly recover from spikes in RTT, as e.g. caused by /server restart
+				self.rttEstimate = averageRtt;
+				self.nextPacketTimestamp = timestamp;
+			}
 		}
 	}
 

--- a/src/network.zig
+++ b/src/network.zig
@@ -1617,6 +1617,7 @@ pub const Connection = struct { // MARK: Connection
 					.connectedVerified, .awaitingReloadVerified => main.game.world.?.shouldReload = true,
 				}
 				main.game.world.?.shouldRestart.store(true, .release);
+				conn.handShakeWaiting.broadcast();
 			}
 		}
 		if (conn.restartChannelCounter[@intFromEnum(channelId)] < restartCounter) {

--- a/src/network/protocols.zig
+++ b/src/network/protocols.zig
@@ -270,9 +270,10 @@ pub const handShake = struct { // MARK: handShake
 			else => unreachable,
 		}
 
-		{
+		while (true) {
 			conn.mutex.lock();
 			defer conn.mutex.unlock();
+			const expectedRestartCounter = conn.restartCounter;
 			while (true) {
 				try main.io.checkCancel();
 				conn.handShakeWaiting.timedWait(&conn.mutex, .fromMilliseconds(16)) catch {
@@ -281,7 +282,10 @@ pub const handShake = struct { // MARK: handShake
 				};
 				break;
 			}
+			if (conn.restartCounter != expectedRestartCounter) return error.RestartAgain;
 			if (conn.connectionState.load(.monotonic) == .disconnected) return error.DisconnectedByServer;
+			if (conn.connectionState.load(.monotonic) != .connected) continue;
+			break;
 		}
 
 		return handshakeZon;


### PR DESCRIPTION
Basically when the client was half-way through the handshake, the restart signal wouldn't go through, so it would freeze.
This is now handled by broadcasting the condition and checking if the restart counter increased.

Along the way I also found a problem with the RTT estimate, which was (naturally) super high after a server restart, and then it took too long to get back down. I decided to detect this by checking if the estimate is 10× larger than the RTT of the last sent packets. Since the RTT cannot be smaller than the true physical round trip time, this should not cause any issues.

fixes #3384