### PR TITLE
Ecs Modify Component Pt 1

### DIFF
--- a/src/entity.zig
+++ b/src/entity.zig
@@ -5,6 +5,7 @@ const Mat4f = vec.Mat4f;
 const Vec3d = vec.Vec3d;
 const Vec3f = vec.Vec3f;
 const Vec4f = vec.Vec4f;
+const BinaryReader = main.utils.BinaryReader;
 
 pub const components = @import("entityComponent/_list.zig");
 
@@ -13,6 +14,13 @@ pub const EntityNetworkData = struct {
 	pos: Vec3d,
 	vel: Vec3d,
 	rot: Vec3f,
+};
+
+pub const ComponentActionType = enum(u8) {
+	unload = 0,
+	load = 1,
+	modifyServer = 2,
+	modifyClient = 3,
 };
 
 pub const EntityComponentLoadError = error{
@@ -29,10 +37,12 @@ pub const Entity = enum(u32) {
 };
 pub const EntityComponentId = u32;
 const EntityComponentVTable = struct {
-	serverLoad: *const fn (entity: Entity, reader: *main.utils.BinaryReader, version: u32) EntityComponentLoadError!void,
-	clientLoad: *const fn (entity: Entity, reader: *main.utils.BinaryReader, version: u32) EntityComponentLoadError!void,
+	serverLoad: *const fn (entity: Entity, reader: *BinaryReader, version: u32) EntityComponentLoadError!void,
+	clientLoad: *const fn (entity: Entity, reader: *BinaryReader, version: u32) EntityComponentLoadError!void,
 	serverUnload: *const fn (entity: Entity) void,
 	clientUnload: *const fn (entity: Entity) void,
+	serverModifyComponent: *const fn (entity: Entity, reader: *BinaryReader) void,
+	clientModifyComponent: *const fn (entity: Entity, reader: *BinaryReader) void,
 };
 var componentList: []?EntityComponentVTable = undefined;
 
@@ -51,6 +61,8 @@ pub fn initComponents() void {
 				.clientLoad = @field(components, decl.name).client.load,
 				.serverUnload = @field(components, decl.name).server.unload,
 				.clientUnload = @field(components, decl.name).client.unload,
+				.serverModifyComponent = @field(components, decl.name).server.modifyComponent,
+				.clientModifyComponent = @field(components, decl.name).client.modifyComponent,
 			};
 		} else {
 			std.log.err("entity components: Duplicate list id {}.", .{componentId});
@@ -90,6 +102,23 @@ pub fn unloadComponent(comptime side: main.sync.Side, componentId: EntityCompone
 		switch (side) {
 			.server => vtable.serverUnload(entity),
 			.client => vtable.clientUnload(entity),
+		}
+	} else {
+		std.log.err("unknown Component Id {} ", .{componentId});
+		return error.UnknownComponentId;
+	}
+}
+
+pub fn modifyComponent(comptime side: main.sync.Side, componentId: EntityComponentId, entity: Entity, componentData: []const u8) EntityComponentLoadError!void {
+	if (componentId >= componentList.len) {
+		std.log.err("unknown Component Id {} ", .{componentId});
+		return error.UnknownComponentId;
+	}
+	var componentReader = BinaryReader.init(componentData);
+	if (componentList[componentId]) |vtable| {
+		switch (side) {
+			.server => vtable.serverModifyComponent(entity, &componentReader),
+			.client => vtable.clientModifyComponent(entity, &componentReader),
 		}
 	} else {
 		std.log.err("unknown Component Id {} ", .{componentId});

--- a/src/entityComponent/_template.zig
+++ b/src/entityComponent/_template.zig
@@ -44,6 +44,11 @@ pub const client = struct {
 	pub fn init() void {}
 	pub fn deinit() void {}
 	pub fn clear() void {}
+
+	pub fn modifyComponent(entity: Entity, reader: *utils.BinaryReader) void {
+		_ = entity;
+		_ = reader;
+	}
 };
 // ############################# Server only stuff ################################
 pub const server = struct {
@@ -69,5 +74,9 @@ pub const server = struct {
 	}
 	pub fn unload(entity: Entity) void {
 		_ = entity;
+	}
+	pub fn modifyComponent(entity: Entity, reader: *utils.BinaryReader) void {
+		_ = entity;
+		_ = reader;
 	}
 };

--- a/src/entityComponent/_template.zig
+++ b/src/entityComponent/_template.zig
@@ -33,6 +33,15 @@ pub const entityComponentVersion = 0;
 
 // ############################# Client only stuff ################################
 pub const client = struct {
+	pub const ExampleComponent = struct {
+		pub fn save(self: ExampleComponent, writer: *utils.BinaryWriter, audience: main.entity.AudienceInfo) main.entity.ComponentSaveBehaviour {
+			_ = self;
+			_ = writer;
+			_ = audience;
+			// do i want to be saved?
+			return .save;
+		}
+	};
 	pub fn load(entity: Entity, reader: *utils.BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
 		_ = entity;
 		_ = reader;
@@ -44,6 +53,10 @@ pub const client = struct {
 	pub fn init() void {}
 	pub fn deinit() void {}
 	pub fn clear() void {}
+	pub fn get(entity: Entity) ?ExampleComponent {
+		_ = entity;
+		return null;
+	}
 
 	pub fn modifyComponent(entity: Entity, reader: *utils.BinaryReader) void {
 		_ = entity;

--- a/src/entityComponent/bag.zig
+++ b/src/entityComponent/bag.zig
@@ -62,6 +62,10 @@ pub const client = struct {
 		const bag = components.fetchRemove(entity) catch return;
 		bag.bag.deinit();
 	}
+	pub fn modifyComponent(entity: Entity, reader: *utils.BinaryReader) void {
+		_ = entity;
+		_ = reader;
+	}
 };
 
 // ############################# Server only stuff ################################
@@ -102,5 +106,9 @@ pub const server = struct {
 	pub fn unload(entity: Entity) void {
 		const bag = components.fetchRemove(entity) catch return;
 		bag.bag.deinit();
+	}
+	pub fn modifyComponent(entity: Entity, reader: *utils.BinaryReader) void {
+		_ = entity;
+		_ = reader;
 	}
 };

--- a/src/entityComponent/bag.zig
+++ b/src/entityComponent/bag.zig
@@ -37,6 +37,11 @@ const playerBagSizeLimit = 120;
 pub const client = struct {
 	const Component = struct {
 		bag: items.Inventory.BagInventory,
+		pub fn save(self: Component, writer: *utils.BinaryWriter, audience: main.entity.AudienceInfo) main.entity.ComponentSaveBehaviour {
+			if (audience != .disk and audience != .playerHimself) return .discard;
+			self.bag.toBytes(writer);
+			return .save;
+		}
 	};
 	pub var components: main.utils.SparseSet(Component, Entity) = .{};
 

--- a/src/entityComponent/bag.zig
+++ b/src/entityComponent/bag.zig
@@ -48,6 +48,9 @@ pub const client = struct {
 		components.clear();
 	}
 
+	pub fn get(entity: Entity) ?Component {
+		return (components.get(entity) orelse return null).*;
+	}
 	pub fn getBag(entity: Entity) ?*items.Inventory.BagInventory {
 		return &(components.get(entity) orelse return null).bag;
 	}

--- a/src/entityComponent/model.zig
+++ b/src/entityComponent/model.zig
@@ -75,6 +75,10 @@ pub const client = struct {
 	pub fn get(entity: Entity) ?*Component {
 		return components.get(entity);
 	}
+	pub fn modifyComponent(entity: Entity, reader: *utils.BinaryReader) void {
+		_ = entity;
+		_ = reader;
+	}
 };
 
 // ############################# Server only stuff ################################
@@ -113,5 +117,9 @@ pub const server = struct {
 	}
 	pub fn get(entity: Entity) ?*const Component {
 		return components.get(entity);
+	}
+	pub fn modifyComponent(entity: Entity, reader: *utils.BinaryReader) void {
+		_ = entity;
+		_ = reader;
 	}
 };

--- a/src/entityComponent/model.zig
+++ b/src/entityComponent/model.zig
@@ -38,6 +38,11 @@ pub const client = struct {
 
 			main.systems.systems.modelRenderer.client.nodeBuffer.free(self.bufferAllocation);
 		}
+		pub fn save(self: Component, writer: *utils.BinaryWriter, audience: main.entity.AudienceInfo) main.entity.ComponentSaveBehaviour {
+			_ = audience;
+			writer.writeVarInt(u32, self.entityModel.index);
+			return .save;
+		}
 	};
 	pub var components: main.utils.SparseSet(Component, Entity) = .{};
 

--- a/src/entityComponent/permissions.zig
+++ b/src/entityComponent/permissions.zig
@@ -23,6 +23,10 @@ pub const client = struct {
 	pub fn init() void {}
 	pub fn deinit() void {}
 	pub fn clear() void {}
+	pub fn get(entity: Entity) null {
+		_ = entity;
+		return null;
+	}
 
 	pub fn modifyComponent(entity: Entity, reader: *utils.BinaryReader) void {
 		_ = entity;

--- a/src/entityComponent/permissions.zig
+++ b/src/entityComponent/permissions.zig
@@ -23,22 +23,20 @@ pub const client = struct {
 	pub fn init() void {}
 	pub fn deinit() void {}
 	pub fn clear() void {}
+
+	pub fn modifyComponent(entity: Entity, reader: *utils.BinaryReader) void {
+		_ = entity;
+		_ = reader;
+	}
 };
 // ############################# Server only stuff ################################
-pub const server = struct {
+pub const server = struct { // MARK: server
 	pub const Component = struct {
 		permissions: main.server.permission.Permissions,
-		permissionGroups: std.AutoHashMapUnmanaged(main.server.permission.Group, void),
 
 		pub fn save(self: Component, writer: *BinaryWriter, audience: main.entity.AudienceInfo) main.entity.ComponentSaveBehaviour {
 			if (audience != .disk) return .discard;
 			self.permissions.toBytes(writer);
-
-			writer.writeVarInt(usize, self.permissionGroups.count());
-			var it = self.permissionGroups.keyIterator();
-			while (it.next()) |group| {
-				group.toBytes(writer);
-			}
 			return .save;
 		}
 	};
@@ -60,25 +58,11 @@ pub const server = struct {
 		return &(components.get(entity) orelse return null).permissions;
 	}
 
-	pub fn getPermissionGroups(entity: Entity) ?*std.AutoHashMapUnmanaged(main.server.permission.Group, void) {
-		return &(components.get(entity) orelse return null).permissionGroups;
-	}
-
 	pub fn hasPermission(entity: Entity, permissionPath: []const u8) bool {
-		switch ((getPermissions(entity) orelse return false).hasPermission(permissionPath)) {
-			.yes => return true,
-			.no => return false,
-			.neutral => {},
-		}
-		var groupIt = (getPermissionGroups(entity).?).keyIterator();
-		while (groupIt.next()) |group| {
-			const result = group.hasPermission(permissionPath) catch blk: {
-				std.debug.assert(removeFromGroup(entity, group.*) == true);
-				break :blk .no;
-			};
-			if (result == .yes) return true;
-		}
-		return false;
+		return switch ((getPermissions(entity) orelse return false).hasPermission(permissionPath)) {
+			.yes => true,
+			.no, .neutral => false,
+		};
 	}
 
 	pub fn addPermission(entity: Entity, listType: main.server.permission.Permissions.ListType, permissionPath: []const u8) void {
@@ -89,39 +73,25 @@ pub const server = struct {
 		return (getPermissions(entity) orelse return false).removePermission(listType, permissionPath);
 	}
 
-	pub fn addToGroup(entity: Entity, group: main.server.permission.Group) void {
-		(getPermissionGroups(entity) orelse return).put(main.globalAllocator.allocator, group, {}) catch unreachable;
-	}
-
-	pub fn removeFromGroup(entity: Entity, group: main.server.permission.Group) bool {
-		return getPermissionGroups(entity).?.remove(group);
-	}
-
 	pub fn loadFromData(entity: Entity, reader: *BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
 		if (version != entityComponentVersion) return error.InvalidComponentVersion;
-		const component = components.add(main.globalAllocator, entity);
-		component.permissions = .init(main.globalAllocator);
-		component.permissions.fromBytes(reader) catch return error.UnreadableComponentData;
-		component.permissionGroups = .empty;
-		const len = reader.readVarInt(usize) catch return;
-		for (0..len) |_| {
-			const group = main.server.permission.Group.fromBytes(reader) catch |err| {
-				if (err == error.GroupNotFound) continue; // if the group is not found we just skip it.
-				return error.UnreadableComponentData;
-			};
-			addToGroup(entity, group);
-		}
+		const permissions = &components.add(main.globalAllocator, entity).permissions;
+		permissions.* = .init(main.globalAllocator);
+		permissions.fromBytes(reader) catch return error.UnreadableComponentData;
 	}
 
 	pub fn loadEmpty(entity: Entity) void {
-		const component = components.add(main.globalAllocator, entity);
-		component.permissions = .init(main.globalAllocator);
-		component.permissionGroups = .empty;
+		const permissions = &components.add(main.globalAllocator, entity).permissions;
+		permissions.* = .init(main.globalAllocator);
 	}
 
 	pub fn unload(entity: Entity) void {
-		var component = components.fetchRemove(entity) catch return;
-		component.permissions.deinit();
-		component.permissionGroups.deinit(main.globalAllocator.allocator);
+		const permissions = components.fetchRemove(entity) catch return;
+		permissions.permissions.deinit();
+	}
+
+	pub fn modifyComponent(entity: Entity, reader: *utils.BinaryReader) void {
+		_ = entity;
+		_ = reader;
 	}
 };

--- a/src/entityComponent/permissions.zig
+++ b/src/entityComponent/permissions.zig
@@ -12,6 +12,15 @@ pub const entityComponentVersion = 0;
 
 // ############################# Client only stuff ################################
 pub const client = struct {
+	pub const Component = struct {
+		pub fn save(self: Component, writer: *utils.BinaryWriter, audience: main.entity.AudienceInfo) main.entity.ComponentSaveBehaviour {
+			_ = self;
+			_ = writer;
+			_ = audience;
+			// do i want to be saved?
+			return .save;
+		}
+	};
 	pub fn load(entity: Entity, reader: *BinaryReader, version: u32) main.entity.EntityComponentLoadError!void {
 		_ = entity;
 		_ = reader;
@@ -23,7 +32,7 @@ pub const client = struct {
 	pub fn init() void {}
 	pub fn deinit() void {}
 	pub fn clear() void {}
-	pub fn get(entity: Entity) null {
+	pub fn get(entity: Entity) ?*Component {
 		_ = entity;
 		return null;
 	}

--- a/src/entityComponent/player.zig
+++ b/src/entityComponent/player.zig
@@ -51,6 +51,11 @@ pub const client = struct {
 	pub fn get(entity: Entity) ?*Component {
 		return components.get(entity);
 	}
+
+	pub fn modifyComponent(entity: Entity, reader: *utils.BinaryReader) void {
+		_ = entity;
+		_ = reader;
+	}
 };
 
 // ############################# Server only stuff ################################
@@ -91,5 +96,10 @@ pub const server = struct {
 	}
 	pub fn get(entity: Entity) ?*Component {
 		return components.get(entity);
+	}
+
+	pub fn modifyComponent(entity: Entity, reader: *utils.BinaryReader) void {
+		_ = entity;
+		_ = reader;
 	}
 };

--- a/src/entityComponent/player.zig
+++ b/src/entityComponent/player.zig
@@ -26,6 +26,11 @@ pub const entityComponentVersion = 0;
 pub const client = struct {
 	const Component = struct {
 		playerIndex: u32,
+		pub fn save(self: Component, writer: *utils.BinaryWriter, audience: main.entity.AudienceInfo) main.entity.ComponentSaveBehaviour {
+			writer.writeVarInt(u32, self.playerIndex);
+			if (audience == .disk) return .discard;
+			return .save;
+		}
 	};
 	pub var components: main.utils.SparseSet(Component, Entity) = .{};
 


### PR DESCRIPTION
adds the basic functions required for the Modify Component Ecs pt 2

meant for sending signals from the server to the client or the client to the server
modifyComponent
is meant for smaller signals that dont overwrite a entire component. (eg: sending how much damage a player takes, or sending a inventory command)